### PR TITLE
Add Claude Fable 5 advisor routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.5.0 — 2026-07-10
+
+- Add Claude Fable 5 as an opt-in, root-only advisor inside Codex through a bundled local MCP bridge to the authenticated Claude Code CLI.
+- Keep all MCP launcher variants disabled by default; setup enables only the compatible Python 3.11+ variant and disable restores the prior plugin override values.
+- Pin `claude-fable-5`, sanitize API/provider override variables, disable tools, sessions, and prompt suggestions, and fail closed unless both the plan signal and runtime model metadata are valid.
+- Extend setup and status with no-spend login/capability checks and add unit, lifecycle, restoration, packaging, and protocol coverage.
+- Keep user-facing status on the exact `Claude Fable 5` name and omit account-plan metadata from MCP results.
+
 ## 0.4.0 — 2026-07-10
 
 - Make one-time, config-first routing the primary workflow: setup once, then use Codex normally.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Start a new Codex task after installation. In the desktop app, type `/` and choo
 
 Setup uses a small standard-library helper and requires Python 3.11 or newer. Codex uses `python3` on macOS/Linux or an available `py -3.11`/`python` launcher on Windows.
 
+Claude Fable 5 also requires the official Claude Code CLI, logged in with a first-party Pro or Max account. Codex remains the only UI: the plugin calls Claude headlessly when plan review is needed.
+
 The picker is the source of truth for the exact label. Depending on the client, it may appear as `/codex-orchestration`, `$codex-orchestration`, or `$codex-orchestration:codex-orchestration`.
 
 ## Set it up once
@@ -36,6 +38,14 @@ Add a second-opinion model when the extra review is worth it:
 ```text
 /codex-orchestration setup executor: GPT-5.6 Luna Extra High, advisor: GPT-5.6 Terra high
 ```
+
+Or use Claude Fable 5 as the root-only advisor:
+
+```text
+/codex-orchestration setup executor: GPT-5.6 Luna Extra High, advisor: Claude Fable 5 Extra High
+```
+
+That route uses the authenticated `claude` CLI through a bundled local MCP server. It does not need an Anthropic API key or a custom Codex provider.
 
 Codex resolves the display names against the active model catalog, previews the personal config change, checks the active binary plus the known PATH/Desktop clients, and applies the clean setup. Pass any other installation to the configurator with `--compat-bin`. It never changes the model selected for the current task.
 
@@ -169,7 +179,9 @@ Four details matter:
 3. `usage_hint_text` puts the chosen Luna or Terra route directly on Codex's spawn tool. This is what tells the root which model and effort to request for delegated execution.
 4. Codex-Orchestration deliberately uses `fork_turns = "none"` for every different child route. Full-history forks inherit the root and reject overrides; Codex can also accept a positive partial fork, but `none` avoids copied history and requires a deliberate self-contained packet.
 
-The installer writes those values through Codex App Server's own `config/read` and atomic `config/batchWrite` APIs. That preserves unrelated tables, comments, inline comments, and custom multi-agent limits; validates the complete config; and detects concurrent edits. The policy takes effect in new tasks. A small namespaced state file records its schema, config path, selected seats, the four managed values, and the exact pre-setup snapshots needed by `disable`; it uses restrictive file permissions where supported. A normal clean setup contains generated policy text, the namespace value, seat IDs, and that restoration metadata. If you explicitly replace your own hint text, its exact old value must be kept for restoration—so never put credentials in routing hints.
+The installer writes those values through Codex App Server's own `config/read` and atomic `config/batchWrite` APIs. That preserves unrelated tables, comments, inline comments, and custom multi-agent limits; validates the complete config; and detects concurrent edits. The policy takes effect in new tasks. A small namespaced state file records its schema, config path, selected seats, the managed values, and the exact pre-setup snapshots needed by `disable`; it uses restrictive file permissions where supported. A normal clean setup contains generated policy text, the namespace value, seat IDs, and that restoration metadata. If you explicitly replace your own hint text, its exact old value must be kept for restoration—so never put credentials in routing hints.
+
+The Claude Fable 5 MCP launchers are bundled but disabled by default. Selecting that advisor enables exactly one compatible Python launcher through the plugin's namespaced config. Setup and status check only the local Claude login and capabilities—they do not make a model call. `disable` restores the prior MCP override values as well as the routing fields. Codex may retain an inert empty TOML table header after deleting the last override; the plugin does not rewrite user TOML merely for cosmetic cleanup.
 
 The setup sets `tool_namespace = "agents"` because the currently validated Desktop route needs that namespace for expanded child-model controls. It changes the callable namespace; it does not name Luna, force a spawn, or replace Codex's delegation judgment.
 
@@ -202,7 +214,8 @@ One honest boundary remains: Codex has no global `executor_model = ...` engine s
 | Luna selected as the root | Luna currently declares multi-agent v1, so the v2 policy is not the right root route. Luna is best used here as a child of a Sol/Terra v2 root. |
 | Older Codex that rejects `multi_agent_mode_hint_text` | The installer refuses to break its shared config and keeps the per-task skill fallback available. Update that client before enabling the persistent preset. |
 | OpenAI root and OpenAI executor | Direct per-spawn model route; simplest setup. |
-| Different provider for advisor or executor | Use a loaded, namespaced custom agent with an already configured provider. |
+| Claude Fable 5 advisor | Bundled read-only MCP route through the authenticated Claude Code CLI; no custom provider. |
+| Any other different-provider advisor or executor | Use a loaded, namespaced custom agent with an already configured provider. |
 
 Desktop and CLI normally share `~/.codex/config.toml`. The setup asks the target binary, the `codex` on your PATH, and the Desktop binary when present to parse the complete four-field preset in an isolated home. That proves config compatibility, not a live child route. Report `route accepted` or `used and confirmed` only from the exact runtime evidence described above; the installer does not guess compatibility from a version number.
 
@@ -222,16 +235,37 @@ If a client cannot load the persistent policy, invoke the skill with the work in
 
 The skill uses the strongest child control that client exposes. On current v2 surfaces it passes the exact model and effort with `fork_turns = "none"`. If exact routing is unavailable, it says so. It never counts an inherited-root child as the requested executor.
 
-## Advisor or executor from another provider
+## Claude Fable 5 inside Codex
 
-A model name alone cannot create provider access. An Anthropic advisor, for example, needs an existing authenticated Codex-compatible provider plus a personal custom agent loaded before the task starts.
+Claude Fable 5 is a built-in advisor route, not a Codex child-model override. GPT-5.6 Sol remains the orchestrator and Luna or Terra remain normal Codex executors. When a non-trivial executor plan needs review, Sol calls the local `review_plan` MCP tool; the tool invokes Claude Code headlessly and returns the result to Sol.
+
+The bridge is intentionally narrow:
+
+- it accepts one self-contained review packet and exposes no implementation tool;
+- it removes API-key and Bedrock/Vertex/Foundry override variables before launching Claude;
+- it requires a first-party Pro or Max login from `claude auth status`;
+- it pins `claude-fable-5`, uses safe mode with tools disabled, and does not persist a Claude session;
+- it requires `PLAN_APPROVED` or `PLAN_REVISE` and verifies runtime metadata actually includes `claude-fable-5`;
+- any failure is reported as advisor unavailable, never silently treated as approval.
+
+The setup command is all that is needed:
+
+```text
+/codex-orchestration setup executor: GPT-5.6 Luna Extra High, advisor: Claude Fable 5 Extra High
+```
+
+Start a new Codex task afterward. The Fable call appears as an MCP tool call inside Codex, not as a Claude desktop window or a Codex subagent card.
+
+## Other providers
+
+A model name alone cannot create provider access. Outside the dedicated Claude Fable 5 route, an Anthropic advisor, for example, needs an existing authenticated Codex-compatible provider plus a personal custom agent loaded before the task starts.
 
 Codex custom providers use the Responses wire protocol. A raw Anthropic Messages endpoint and key are not interchangeable. A supported route such as Amazon Bedrock may also be appropriate.
 
 Once the provider is configured and tested, setup can save the namespaced roles:
 
 ```text
-/codex-orchestration setup executor: GPT-5.6 Luna Extra High, advisor: Fable 5 Extra High, advisor provider: <existing-provider-id>
+/codex-orchestration setup executor: GPT-5.6 Luna Extra High, advisor: <model> <effort>, advisor provider: <existing-provider-id>
 ```
 
 For this path, Codex-Orchestration creates only:
@@ -310,7 +344,7 @@ Uninstalling the plugin does not silently delete a policy or custom-agent file t
 python3 -m unittest discover -s tests -v
 ```
 
-The suite covers the native App Server protocol, capability detection, generated policy contract, setup/status/disable, exact restoration, custom agents, packaging, migration safety, model inspection, and an isolated real-CLI marketplace lifecycle.
+The suite covers the native App Server protocol, capability detection, generated policy contract, setup/status/disable, exact restoration, the Claude Fable 5 MCP bridge, custom agents, packaging, migration safety, model inspection, and an isolated real-CLI marketplace lifecycle.
 
 ## Design sources
 

--- a/plugins/codex-orchestration/.codex-plugin/plugin.json
+++ b/plugins/codex-orchestration/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-orchestration",
-  "version": "0.4.0",
+  "version": "0.5.0+codex.20260711022251",
   "description": "Configure Codex once so the selected task model leads while efficient models handle delegated execution.",
   "author": {
     "name": "CJ Zafir",
@@ -17,6 +17,7 @@
     "usage-limits"
   ],
   "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
   "interface": {
     "displayName": "Codex Orchestration",
     "shortDescription": "One-time efficient executor routing",

--- a/plugins/codex-orchestration/.mcp.json
+++ b/plugins/codex-orchestration/.mcp.json
@@ -1,0 +1,29 @@
+{
+  "mcpServers": {
+    "fable-advisor-python3": {
+      "command": "python3",
+      "args": [
+        "skills/codex-orchestration/scripts/fable_advisor_mcp.py"
+      ],
+      "cwd": ".",
+      "enabled": false
+    },
+    "fable-advisor-python": {
+      "command": "python",
+      "args": [
+        "skills/codex-orchestration/scripts/fable_advisor_mcp.py"
+      ],
+      "cwd": ".",
+      "enabled": false
+    },
+    "fable-advisor-py": {
+      "command": "py",
+      "args": [
+        "-3.11",
+        "skills/codex-orchestration/scripts/fable_advisor_mcp.py"
+      ],
+      "cwd": ".",
+      "enabled": false
+    }
+  }
+}

--- a/plugins/codex-orchestration/skills/codex-orchestration/SKILL.md
+++ b/plugins/codex-orchestration/skills/codex-orchestration/SKILL.md
@@ -11,10 +11,11 @@ This skill adds a model route to Codex's existing multi-agent flow. It does not 
 
 ## Understand the command
 
-Support four simple forms:
+Support these simple forms:
 
 ```text
 /codex-orchestration setup executor: GPT-5.6 Luna Extra High
+/codex-orchestration setup executor: GPT-5.6 Luna Extra High, advisor: Claude Fable 5 Extra High
 /codex-orchestration status
 /codex-orchestration disable
 /codex-orchestration remove custom roles personally
@@ -41,13 +42,13 @@ For a task-local request, append `— <original task>`. Keep every supplied modi
 
 If an old prompt contains `orchestrator:`, explain that the current task model already owns that role. Ignore that seat instead of switching or persisting it.
 
-Normalize `Extra High` to `xhigh`. Resolve display names to exact IDs only through the executing host's model catalog, picker, a loaded custom agent, or official provider documentation. Never invent an ID. For persistent direct routing, resolve `auto` to the catalog's concrete default.
+Normalize `Extra High` to `xhigh` for Codex models. `Claude Fable 5 Extra High` is the built-in advisor label; map it to `--advisor-fable --advisor-effort max`, not the Codex model catalog. Resolve every other display name to an exact ID only through the executing host's model catalog, picker, a loaded custom agent, or official provider documentation. Never invent an ID. For persistent direct routing, resolve `auto` to the catalog's concrete default.
 
 Read [providers-and-models.md](references/providers-and-models.md) before setup, when clients disagree, when a model is absent, when providers differ, or when custom agents or legacy migration are involved.
 
 ## One-time native setup
 
-Use this path for a current same-provider setup such as Sol root to Luna or Terra executors.
+Use this path for a current same-provider setup such as Sol root to Luna or Terra executors. Claude Fable 5 is the one built-in cross-provider advisor exception because it runs through the bundled read-only MCP bridge and the user's authenticated Claude Code CLI.
 
 1. Identify the Codex binary used by the active host. Do not assume the shell `codex` is the Desktop binary.
 2. Resolve the exact executor and optional advisor IDs and efforts from that host.
@@ -70,20 +71,22 @@ python3 <skill-dir>/scripts/configure_native_routing.py \
   --apply
 ```
 
-Add `--advisor-model` and `--advisor-effort` only when an advisor was supplied. Omission persists `advisor: none`.
+Add `--advisor-model` and `--advisor-effort` for a same-provider Codex advisor. For Claude Fable 5, use `--advisor-fable --advisor-effort max`. The configurator requires Claude Code to be logged in through a first-party Pro or Max account, chooses an available Python 3.11+ MCP launcher, and performs only an auth/capability check during setup. It never extracts a token, writes a credential, or makes a model call during setup or status. Omission persists `advisor: none`.
 
 The configurator capability-tests the complete four-field preset on the active target, `codex` on PATH when different, the known macOS Desktop binary when present, and every explicit `--compat-bin`. A successful isolated config probe means that client can parse the preset; it is not a live child-model confirmation. Report `route accepted` or `used and confirmed` only from the exact live spawn evidence defined below. Ask about other Codex/IDE installations that share this config only when the environment suggests they exist, and pass their binaries explicitly. If the request or active host indicates a named `--profile`, explain that normal setup manages the default user layer and is not verified for that profile; do not add a routine question for users with no profile signal. If a checked client rejects any managed field, stop before apply. Recommend updating it or using the task-local fallback. `--allow-incompatible-client` requires a separate explicit user decision because it can make the shared config unreadable to that client.
 
 For the current validated v2 direct route, set `tool_namespace = "agents"`. Live testing on Desktop `0.144.0-alpha.4` showed that the default reserved `collaboration.spawn_agent` schema rejected expanded model/effort metadata, while `agents` accepted the same request and spawned Luna at `xhigh`. Treat this as a required control-surface setting for that tested path, not as the executor selection. `usage_hint_text` carries the actual executor/advisor route.
 
-Do not add `enabled = true` for a Sol or Terra root. Their current model metadata selects v2. The configurator intentionally manages only:
+Do not add `enabled = true` for a Sol or Terra root. Their current model metadata selects v2. The configurator intentionally manages these routing fields:
 
 - `features.multi_agent_v2.hide_spawn_agent_metadata`;
 - `features.multi_agent_v2.tool_namespace`;
 - `features.multi_agent_v2.multi_agent_mode_hint_text`;
 - `features.multi_agent_v2.usage_hint_text`.
 
-It uses Codex App Server's `config/read` and `config/batchWrite` APIs, not a home-grown TOML rewrite. It preserves unrelated settings and comments, validates the whole effective config, and uses the user-layer version to detect races. Restore snapshots are limited to the four owned config fields; the namespaced state also records schema/version markers, config path, selected seats, and scalar-conversion metadata when needed. If the user explicitly replaces existing hint text, the exact prior text is stored for restoration; warn them never to place credentials in routing hints.
+When Claude Fable 5 is selected, it additionally manages only the plugin-scoped `enabled` override for the chosen bundled MCP launcher and any launcher variant already overridden by the user. All bundled variants are disabled by default. The original override values are stored and restored by `disable`. Codex's TOML editor may retain an inert empty table header after deleting the last override; never rewrite the file merely to remove that cosmetic header.
+
+It uses Codex App Server's `config/read` and `config/batchWrite` APIs, not a home-grown TOML rewrite. It preserves unrelated settings and comments, validates the whole effective config, and uses the user-layer version to detect races. Restore snapshots cover the four routing fields plus the narrowly scoped MCP overrides only when Fable is selected; the namespaced state also records schema/version markers, config path, selected seats, and scalar-conversion metadata when needed. If the user explicitly replaces existing hint text, the exact prior text is stored for restoration; warn them never to place credentials in routing hints.
 
 If a user-authored mode or usage hint already exists, do not replace it automatically. Show the conflict. Use `--replace-existing-policy` only after the user explicitly approves replacing and later restoring those exact values.
 
@@ -117,9 +120,25 @@ Disable must remain available even if an older client is incompatible with the a
 
 For personal v0.4 custom roles, preview and apply removal with `configure_orchestration.py --scope personal --personal-route-names --remove-saved-roles`. For older fixed-name personal roles, run a separate preview without `--personal-route-names`. Project removal uses `--scope project --root <trusted-project> --remove-saved-roles`. Delete only files that the configurator fully validates as managed; edited or user-owned files require manual review.
 
+## Claude Fable 5 advisor
+
+Use this built-in route when the user names Claude Fable 5. Do not create a custom provider or custom-agent file for it.
+
+In every user-facing status or result, use the exact name `Claude Fable 5`. Report authentication as `first-party login ready`; do not expose or restate Claude account-plan metadata.
+
+Prerequisites:
+
+- the official `claude` CLI is installed;
+- `claude auth status` reports a first-party Pro or Max login;
+- a Python 3.11+ launcher is available.
+
+The plugin packages three disabled MCP launcher variants for macOS, Linux, and Windows. Setup enables exactly the compatible variant through the plugin's namespaced config. At review time the MCP server removes API-key and Bedrock/Vertex/Foundry override variables, re-checks first-party login, and invokes `claude -p --model claude-fable-5` with `--safe-mode`, no tools, no session persistence, prompt suggestions disabled, and JSON output. The saved route pins the model and effort; the root cannot replace them through tool arguments.
+
+The bridge accepts only one self-contained `packet`. It requires `PLAN_APPROVED` or `PLAN_REVISE` as the first non-empty line and requires runtime `modelUsage` to confirm `claude-fable-5`. Any auth, transport, format, or model-confirmation failure is `advisor unavailable`, never approval. It returns no account identifier or credential.
+
 ## Durable or cross-provider custom agents
 
-Direct `model` routing is same-provider. A different provider needs an already authenticated Codex-compatible provider and a loaded custom agent that pins `model_provider`.
+Direct `model` routing is same-provider. Except for the built-in Claude Fable 5 MCP route above, a different provider needs an already authenticated Codex-compatible provider and a loaded custom agent that pins `model_provider`.
 
 Use the existing standalone-agent configurator for this extended path. Personal scope is required for machine-local provider IDs and affects all projects, so the user's explicit cross-provider `setup` request must name or confirm the existing provider ID. Never create provider definitions, collect keys in chat, or write credentials.
 
@@ -222,6 +241,8 @@ PLAN_REVISE
 
 The root adjudicates every suggestion and owns the revised plan. Allow at most one confirmation pass after a material revision. A configured advisor is a gate for a non-trivial executor plan by default. Transport failure, malformed output, inaccessible routing, or missing context means `advisor unavailable`, never approval; stop before executor work unless the user explicitly made the advisor best-effort.
 
+For Claude Fable 5, call the configured MCP server's `review_plan` tool instead of spawning an advisor child. It remains root-only and read-only; executors never receive the tool or direct it.
+
 ## Executor handoff
 
 Give each executor one bounded packet with:
@@ -273,6 +294,7 @@ Never call that 65% fewer raw tokens, a guaranteed five-hour or weekly-limit sav
 ## Resources
 
 - `scripts/configure_native_routing.py`: one-time native setup, status, update, and disable.
+- `scripts/fable_advisor_mcp.py`: fail-closed Claude Fable 5 plan-review bridge.
 - `scripts/configure_orchestration.py`: namespaced custom agents, provider pins, safe removal, and legacy migration.
 - `scripts/inspect_models.py`: fallible host-catalog diagnostics.
 - [providers-and-models.md](references/providers-and-models.md): detailed capability, provider, compatibility, persistence, and usage boundaries.

--- a/plugins/codex-orchestration/skills/codex-orchestration/references/providers-and-models.md
+++ b/plugins/codex-orchestration/skills/codex-orchestration/references/providers-and-models.md
@@ -26,6 +26,7 @@ These facts were source-checked and runtime-tested on July 10, 2026. Always capa
 | `tool_namespace = "agents"` | On live-tested Desktop `0.144.0-alpha.4`, the default `collaboration` namespace rejected expanded model/effort metadata; `agents` accepted it and spawned Luna at `xhigh`. | Required for this validated direct-routing path. It changes the callable namespace but does not select Luna. |
 | `usage_hint_text` | Appended to the spawn tool description | Carries the exact executor/advisor route where the root chooses children. |
 | `multi_agent_mode_hint_text` | Replaces the default proactive/explicit mode hint and is sent to root and child tasks | Must contain both root and child boundaries. |
+| Claude Fable 5 MCP route | Root-only `review_plan` tool invokes the authenticated Claude Code CLI headlessly | Built-in cross-provider advisor exception; no custom Codex provider or advisor child. |
 | `fork_turns` default | `all` | Different model/effort/role overrides are rejected unless the call uses `none` or a positive partial fork. |
 | v2 default concurrency | Four active threads including the root | Normally at most three children run concurrently. Codex chooses the useful count. |
 | Older CLI 0.142.5 | Rejects `multi_agent_mode_hint_text` as an unknown feature-table field | Never write the global native policy without checking every known shared-config client. |
@@ -76,6 +77,8 @@ For a durable custom-agent route it uses:
 agent_type="codex_orchestration_executor", fork_turns="none"
 agent_type="codex_orchestration_advisor", fork_turns="none"
 ```
+
+For Claude Fable 5 it names the enabled bundled MCP server and tells the root to call its `review_plan` tool. This is a root tool call, not `spawn_agent`, so `fork_turns` does not apply.
 
 The custom mode text is visible in spawned children too. That is why it says: if root, orchestrate; if child, stay within the packet and never spawn.
 
@@ -146,7 +149,7 @@ Restore state lives at:
 ~/.codex/.codex-orchestration-routing.json
 ```
 
-It contains the prior and managed values of the four owned fields, chosen seat IDs, schema/version markers, scalar-conversion metadata when needed, and config path. It never copies provider definitions, auth stores, or config outside those fields. A normal clean setup contains generated policy text, the namespace value, seat IDs, and restoration metadata. Explicit replacement must retain the user's exact old hint text so disable can restore it; routing hints must never contain credentials. State is written with a same-directory atomic replacement and restrictive file mode where supported. If persistence fails after config apply, the configurator rolls the config back using the returned version.
+It contains the prior and managed values of the four routing fields, chosen seat IDs, schema/version markers, scalar-conversion metadata when needed, and config path. When Claude Fable 5 is selected, it also records only the plugin-scoped MCP launcher overrides that setup touched. It never copies provider definitions, auth stores, account identifiers, or credentials. A normal clean setup contains generated policy text, the namespace value, seat IDs, and restoration metadata. Explicit replacement must retain the user's exact old hint text so disable can restore it; routing hints must never contain credentials. State is written with a same-directory atomic replacement and restrictive file mode where supported. If persistence fails after config apply, the configurator rolls the config back using the returned version.
 
 Disable compares every current managed value before restoration. If the user edited a managed field after setup, it stops instead of erasing that work. Without state, each surviving marker proves ownership only of that hint string. Disable may safely remove the marked string or strings, but it leaves metadata visibility and the tool namespace unchanged because their previous values are unknown.
 
@@ -204,6 +207,10 @@ The standalone-agent configurator remains dry-run first, rejects symlinks and ha
 
 Direct v2 `model` overrides retain the parent's provider. They are the simplest route for an OpenAI root and OpenAI Luna/Terra child.
 
+Claude Fable 5 is the explicit built-in exception. The plugin does not pretend it is a Codex model or translate Anthropic into the Responses protocol. Instead, a disabled-by-default local MCP server invokes the official `claude` CLI with the user's first-party Pro or Max login. Setup enables one Python 3.11+ launcher variant, and disable restores every prior plugin override value. Codex's TOML editor can retain an inert empty table header after its final key is deleted; the configurator does not risk a broad TOML rewrite for cosmetic cleanup.
+
+The bridge removes `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, and Bedrock/Vertex/Foundry selection variables from the child environment. It re-checks `claude auth status`, pins `claude-fable-5` and the saved effort, disables tools and session persistence, disables prompt suggestions, and requires JSON runtime metadata to confirm the model. Setup and status never make a model call.
+
 A cross-provider seat normally needs:
 
 1. a provider already defined and authenticated in the user's Codex config;
@@ -220,6 +227,8 @@ Codex custom providers currently use the Responses wire protocol. An Anthropic M
 A task-local advisor is review-only by instruction. Do not claim it is mechanically read-only unless the effective child sandbox confirms that.
 
 A saved advisor requests `sandbox_mode = "read-only"`, but live parent permission overrides may be reapplied to children. Keep the behavioral prohibition on edits and mutation even with the requested sandbox.
+
+The Claude Fable 5 advisor is mechanically narrower than a child: the MCP tool accepts only a review packet, launches Claude with safe mode and no tools, and exposes no edit or shell operation. It still has open-world model access, so the packet must be deliberate and self-contained.
 
 Advisor failure is never approval. A configured advisor is required for a non-trivial executor plan unless the user explicitly marks it best-effort. Transport failure, malformed output, missing context, or wrong route becomes `advisor unavailable`; stop before executor work by default, or disclose and continue under the root only in best-effort mode.
 

--- a/plugins/codex-orchestration/skills/codex-orchestration/scripts/configure_native_routing.py
+++ b/plugins/codex-orchestration/skills/codex-orchestration/scripts/configure_native_routing.py
@@ -30,12 +30,21 @@ except ModuleNotFoundError as exc:  # pragma: no cover - Python < 3.11
     raise SystemExit("Python 3.11 or newer is required (missing tomllib).") from exc
 
 
-POLICY_VERSION = 1
-STATE_SCHEMA = 1
+POLICY_VERSION = 2
+STATE_SCHEMA = 2
+SUPPORTED_STATE_SCHEMAS = {1, 2}
 MANAGED_MARKER = "[codex-orchestration managed-policy v1]"
 STATE_FILENAME = ".codex-orchestration-routing.json"
 PROBE_VALUE = "CODEX_ORCHESTRATION_CAPABILITY_PROBE"
 ROUTING_TOOL_NAMESPACE = "agents"
+PLUGIN_ID = "codex-orchestration@codex-orchestration"
+FABLE_MODEL = "claude-fable-5"
+FABLE_EFFORTS = {"low", "medium", "high", "max"}
+FABLE_SERVERS = {
+    "fable-advisor-python3": ("python3", []),
+    "fable-advisor-python": ("python", []),
+    "fable-advisor-py": ("py", ["-3.11"]),
+}
 RPC_TIMEOUT_SECONDS = 20
 PROBE_TIMEOUT_SECONDS = 15
 MODEL_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:+/@-]{0,199}$")
@@ -74,6 +83,11 @@ def parse_args() -> argparse.Namespace:
     advisor = parser.add_mutually_exclusive_group()
     advisor.add_argument("--advisor-model", help="Optional exact advisor model ID.")
     advisor.add_argument("--advisor-agent", help="Optional loaded advisor agent name.")
+    advisor.add_argument(
+        "--advisor-fable",
+        action="store_true",
+        help="Use the bundled Claude Fable 5 advisor through Claude Code.",
+    )
     parser.add_argument(
         "--advisor-effort",
         default="auto",
@@ -120,6 +134,7 @@ def _validate_args(args: argparse.Namespace) -> None:
             args.executor_agent,
             args.advisor_model,
             args.advisor_agent,
+            args.advisor_fable,
         )
     ):
         raise ConfigurationError("--status does not accept seat settings.")
@@ -129,6 +144,7 @@ def _validate_args(args: argparse.Namespace) -> None:
             args.executor_agent,
             args.advisor_model,
             args.advisor_agent,
+            args.advisor_fable,
         )
     ):
         raise ConfigurationError("--disable does not accept seat settings.")
@@ -146,6 +162,12 @@ def _validate_args(args: argparse.Namespace) -> None:
         raise ConfigurationError(
             "A custom advisor agent owns its effort; omit --advisor-effort."
         )
+    if args.advisor_fable:
+        effort = "max" if args.advisor_effort == "auto" else args.advisor_effort
+        if effort not in FABLE_EFFORTS:
+            raise ConfigurationError(
+                "Claude Fable 5 effort must be one of: low, medium, high, max."
+            )
     for label, value, pattern in (
         ("executor model", args.executor_model, MODEL_RE),
         ("advisor model", args.advisor_model, MODEL_RE),
@@ -296,7 +318,7 @@ class AppServer:
                     "clientInfo": {
                         "name": "codex_orchestration_installer",
                         "title": "Codex Orchestration Installer",
-                        "version": "0.4.0",
+                        "version": "0.5.0",
                     },
                     "capabilities": {"experimentalApi": True},
                 },
@@ -466,6 +488,25 @@ def snapshot_edit(key_path: str, saved: dict[str, Any]) -> dict[str, Any] | None
     }
 
 
+def fable_key_path(server: str) -> str:
+    return (
+        f"plugins.{json.dumps(PLUGIN_ID)}.mcp_servers."
+        f"{json.dumps(server)}.enabled"
+    )
+
+
+def _valid_snapshot(saved: Any, expected: type | tuple[type, ...]) -> bool:
+    if not (
+        isinstance(saved, dict)
+        and isinstance(saved.get("known"), bool)
+        and isinstance(saved.get("present"), bool)
+    ):
+        return False
+    if saved["known"] and saved["present"]:
+        return "value" in saved and isinstance(saved["value"], expected)
+    return True
+
+
 def _read_state(path: Path) -> dict[str, Any] | None:
     if not path.exists():
         return None
@@ -478,7 +519,7 @@ def _read_state(path: Path) -> dict[str, Any] | None:
         state = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise ConfigurationError(f"Could not read routing state {path}: {exc}") from exc
-    if not isinstance(state, dict) or state.get("schema") != STATE_SCHEMA:
+    if not isinstance(state, dict) or state.get("schema") not in SUPPORTED_STATE_SCHEMAS:
         raise ConfigurationError(f"Unknown routing state schema in {path}.")
     if state.get("managed_by") != "codex-orchestration":
         raise ConfigurationError(f"Routing state is not owned by this plugin: {path}")
@@ -510,6 +551,12 @@ def _read_state(path: Path) -> dict[str, Any] | None:
             kind == "agent"
             and isinstance(route.get("agent"), str)
             and AGENT_RE.fullmatch(route["agent"])
+        ) or (
+            label == "advisor"
+            and kind == "fable"
+            and route.get("model") == FABLE_MODEL
+            and route.get("effort") in FABLE_EFFORTS
+            and route.get("server") in FABLE_SERVERS
         )
         if not valid:
             raise ConfigurationError(f"Routing state has an invalid {label} route: {path}")
@@ -518,21 +565,22 @@ def _read_state(path: Path) -> dict[str, Any] | None:
         raise ConfigurationError(f"Routing state has no restore values: {path}")
     for key in ("mode", "usage", "metadata", "namespace"):
         saved = previous.get(key)
-        if not (
-            isinstance(saved, dict)
-            and isinstance(saved.get("known"), bool)
-            and isinstance(saved.get("present"), bool)
-        ):
+        expected = bool if key == "metadata" else str
+        if not _valid_snapshot(saved, expected):
             raise ConfigurationError(f"Routing state has invalid {key} restore data: {path}")
-        if saved["known"] and saved["present"] and "value" not in saved:
-            raise ConfigurationError(f"Routing state has incomplete {key} restore data: {path}")
-        if saved["known"] and saved["present"]:
-            value = saved["value"]
-            expected = bool if key == "metadata" else str
-            if not isinstance(value, expected):
-                raise ConfigurationError(
-                    f"Routing state has an invalid {key} restore value: {path}"
-                )
+    managed_mcp = managed.get("mcp")
+    previous_mcp = previous.get("mcp")
+    if managed_mcp is not None or previous_mcp is not None:
+        if not (
+            isinstance(managed_mcp, dict)
+            and bool(managed_mcp)
+            and set(managed_mcp).issubset(FABLE_SERVERS)
+            and all(isinstance(value, bool) for value in managed_mcp.values())
+            and isinstance(previous_mcp, dict)
+            and set(previous_mcp) == set(managed_mcp)
+            and all(_valid_snapshot(value, bool) for value in previous_mcp.values())
+        ):
+            raise ConfigurationError(f"Routing state has invalid MCP restore data: {path}")
     return state
 
 
@@ -723,9 +771,77 @@ def resolve_model_effort(
     return resolved
 
 
+def select_fable_server() -> str:
+    for server, (launcher, prefix) in FABLE_SERVERS.items():
+        executable = shutil.which(launcher)
+        if not executable:
+            continue
+        try:
+            result = subprocess.run(
+                [executable, *prefix, "--version"],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                timeout=PROBE_TIMEOUT_SECONDS,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            continue
+        match = re.search(r"Python\s+(\d+)\.(\d+)", result.stdout)
+        if result.returncode == 0 and match and tuple(map(int, match.groups())) >= (3, 11):
+            return server
+    raise ConfigurationError(
+        "Claude Fable 5 requires a Python 3.11+ launcher named python3, python, "
+        "or py. Install one and retry."
+    )
+
+
+def verify_fable_prerequisites() -> dict[str, str]:
+    try:
+        from fable_advisor_mcp import AdvisorError, check_claude_auth, resolve_claude
+    except ImportError as exc:  # pragma: no cover - corrupt package
+        raise ConfigurationError("The bundled Claude Fable 5 bridge is missing.") from exc
+    try:
+        claude = resolve_claude()
+        auth = check_claude_auth(claude)
+        help_result = subprocess.run(
+            [str(claude), "--help"],
+            env={
+                key: value
+                for key, value in os.environ.items()
+                if key
+                not in {
+                    "ANTHROPIC_API_KEY",
+                    "ANTHROPIC_AUTH_TOKEN",
+                    "CLAUDE_CODE_USE_BEDROCK",
+                    "CLAUDE_CODE_USE_VERTEX",
+                    "CLAUDE_CODE_USE_FOUNDRY",
+                }
+            },
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            timeout=PROBE_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (AdvisorError, OSError, subprocess.TimeoutExpired) as exc:
+        raise ConfigurationError(str(exc)) from exc
+    required = ("--model", "--effort", "--safe-mode", "--prompt-suggestions")
+    missing = [flag for flag in required if flag not in help_result.stdout]
+    if help_result.returncode != 0 or missing:
+        detail = ", ".join(missing) if missing else f"exit {help_result.returncode}"
+        raise ConfigurationError(
+            f"Claude Code is too old for the Fable advisor bridge ({detail}); update it."
+        )
+    return {"claude": str(claude), **auth}
+
+
 def _route_summary(route: dict[str, Any]) -> str:
     if route["kind"] == "agent":
         return f"custom agent {route['agent']}"
+    if route["kind"] == "fable":
+        effort = "Extra High" if route["effort"] == "max" else route["effort"]
+        return f"Claude Fable 5 {effort}"
     return f"{route['model']}@{route['effort']}"
 
 
@@ -775,13 +891,21 @@ Explicit user instructions win, including no-subagents and task-local seat overr
 
 If you are a spawned child, stay inside the supplied packet, report only to the root, and never spawn descendants. An advisor reviews only the root's packet and never contacts executors. An executor never redesigns the root plan or contacts the advisor.
 """
-    advisor_hint = (
-        "For an advisor review, call this tool with "
-        f"{_spawn_route(advisor)}, fork_turns = \"none\". Send the complete "
-        "review packet and require PLAN_APPROVED or PLAN_REVISE."
-        if advisor is not None
-        else "No advisor route is configured."
-    )
+    if advisor is not None and advisor["kind"] == "fable":
+        advisor_hint = (
+            "For an advisor review, call `review_plan` from MCP server "
+            f"{json.dumps(advisor['server'])} with one complete packet. This is a "
+            "read-only root tool call, not a spawned child. Require PLAN_APPROVED or "
+            "PLAN_REVISE and fail closed if the tool is unavailable."
+        )
+    elif advisor is not None:
+        advisor_hint = (
+            "For an advisor review, call this tool with "
+            f"{_spawn_route(advisor)}, fork_turns = \"none\". Send the complete "
+            "review packet and require PLAN_APPROVED or PLAN_REVISE."
+        )
+    else:
+        advisor_hint = "No advisor route is configured."
     usage = f"""{MANAGED_MARKER}
 If you are the root task model, you are the orchestrator. Apply these routes only to children you decide to create.
 
@@ -843,6 +967,17 @@ def _current_values(config: dict[str, Any]) -> dict[str, Any]:
         "namespace": nested_get(
             config, "features", "multi_agent_v2", "tool_namespace"
         ),
+        "mcp": {
+            server: nested_get(
+                config,
+                "plugins",
+                PLUGIN_ID,
+                "mcp_servers",
+                server,
+                "enabled",
+            )
+            for server in FABLE_SERVERS
+        },
     }
 
 
@@ -852,13 +987,20 @@ def _is_managed(value: Any) -> bool:
 
 def _managed_matches(state: dict[str, Any], current: dict[str, Any]) -> bool:
     managed = state.get("managed")
-    return (
+    base_matches = (
         isinstance(managed, dict)
         and current["mode"] == managed.get("mode")
         and current["usage"] == managed.get("usage")
         and current["metadata"] is False
         and managed.get("namespace") == ROUTING_TOOL_NAMESPACE
         and current["namespace"] == ROUTING_TOOL_NAMESPACE
+    )
+    if not base_matches:
+        return False
+    managed_mcp = managed.get("mcp")
+    return managed_mcp is None or all(
+        current["mcp"].get(server, MISSING) == enabled
+        for server, enabled in managed_mcp.items()
     )
 
 
@@ -939,6 +1081,15 @@ def _status(
             print(f"Executor: {_route_summary(state['executor'])}")
             advisor = state.get("advisor")
             print(f"Advisor: {_route_summary(advisor) if advisor else 'none'}")
+            if isinstance(advisor, dict) and advisor.get("kind") == "fable":
+                try:
+                    auth = verify_fable_prerequisites()
+                except ConfigurationError as exc:
+                    print(f"Claude Fable 5: unavailable — {exc}")
+                else:
+                    print(
+                        "Claude Fable 5: ready — first-party login; no model call made"
+                    )
             try:
                 verified = verify_agent_routes(
                     app.codex_home,
@@ -992,6 +1143,7 @@ def _prepare_setup_state(
         previous = existing_state.get("previous")
         if not isinstance(previous, dict):
             raise ConfigurationError("Managed routing state is missing its restore data.")
+        previous = dict(previous)
         scalar_origin = existing_state.get("scalar_origin")
         if isinstance(scalar_origin, bool):
             managed_feature = existing_state.get("managed_feature")
@@ -1132,6 +1284,59 @@ def _prepare_setup_state(
         ]
         managed_feature = None
 
+    existing_managed = existing_state.get("managed", {}) if existing_state else {}
+    manage_mcp = (
+        isinstance(advisor, dict)
+        and advisor.get("kind") == "fable"
+        or isinstance(existing_managed, dict)
+        and isinstance(existing_managed.get("mcp"), dict)
+    )
+    managed_mcp: dict[str, bool] | None = None
+    if manage_mcp:
+        previous_mcp = previous.get("mcp")
+        if not isinstance(previous_mcp, dict):
+            previous_mcp = {}
+        selected = advisor.get("server") if isinstance(advisor, dict) else None
+        existing_mcp = (
+            existing_managed.get("mcp")
+            if isinstance(existing_managed, dict)
+            and isinstance(existing_managed.get("mcp"), dict)
+            else {}
+        )
+        touched = set(existing_mcp)
+        touched.update(
+            server for server, value in current["mcp"].items() if value is not MISSING
+        )
+        if isinstance(selected, str):
+            touched.add(selected)
+        for server in touched:
+            if server not in previous_mcp:
+                previous_mcp[server] = snapshot(current["mcp"][server])
+        previous["mcp"] = previous_mcp
+        managed_mcp = {server: server == selected for server in FABLE_SERVERS if server in touched}
+        for server, enabled in managed_mcp.items():
+            edits.append(
+                {
+                    "keyPath": fable_key_path(server),
+                    "value": enabled,
+                    "mergeStrategy": "replace",
+                }
+            )
+            rollback_edit = snapshot_edit(
+                fable_key_path(server), snapshot(current["mcp"][server])
+            )
+            if rollback_edit is not None:
+                rollback.append(rollback_edit)
+
+    managed = {
+        "mode": mode,
+        "usage": usage,
+        "metadata": False,
+        "namespace": ROUTING_TOOL_NAMESPACE,
+    }
+    if managed_mcp is not None:
+        managed["mcp"] = managed_mcp
+
     state = {
         "schema": STATE_SCHEMA,
         "policy_version": POLICY_VERSION,
@@ -1139,12 +1344,7 @@ def _prepare_setup_state(
         "config_file": str(config_path),
         "executor": executor,
         "advisor": advisor,
-        "managed": {
-            "mode": mode,
-            "usage": usage,
-            "metadata": False,
-            "namespace": ROUTING_TOOL_NAMESPACE,
-        },
+        "managed": managed,
         "previous": previous,
         "scalar_origin": scalar_origin,
         "managed_feature": managed_feature,
@@ -1196,6 +1396,9 @@ def _disable(
                 "Managed routing fields were edited after setup. Refusing to erase "
                 "those changes; restore the managed values or remove them manually."
             )
+        previous = state.get("previous")
+        if not isinstance(previous, dict):
+            raise ConfigurationError("Routing state has no restore data.")
         scalar_origin = state.get("scalar_origin")
         if isinstance(scalar_origin, bool):
             if current["feature"] != state.get("managed_feature"):
@@ -1211,9 +1414,6 @@ def _disable(
                 }
             ]
         else:
-            previous = state.get("previous")
-            if not isinstance(previous, dict):
-                raise ConfigurationError("Routing state has no restore data.")
             edits = [
                 edit
                 for edit in (
@@ -1236,6 +1436,16 @@ def _disable(
                 )
                 if edit is not None
             ]
+        previous_mcp = previous.get("mcp")
+        if isinstance(previous_mcp, dict):
+            edits.extend(
+                edit
+                for edit in (
+                    snapshot_edit(fable_key_path(server), previous_mcp[server])
+                    for server in previous_mcp
+                )
+                if edit is not None
+            )
         print("Will restore the pre-setup values of every owned routing field.")
     if not apply:
         print("Dry run only. Re-run with --disable --apply after reviewing this preview.")
@@ -1305,6 +1515,7 @@ def main() -> int:
                 executor = {"kind": "agent", "agent": args.executor_agent}
 
             advisor: dict[str, Any] | None = None
+            fable_auth: dict[str, str] | None = None
             if args.advisor_model:
                 advisor_effort = resolve_model_effort(
                     "Advisor",
@@ -1320,6 +1531,17 @@ def main() -> int:
                 }
             elif args.advisor_agent:
                 advisor = {"kind": "agent", "agent": args.advisor_agent}
+            elif args.advisor_fable:
+                server = select_fable_server()
+                fable_auth = verify_fable_prerequisites()
+                advisor = {
+                    "kind": "fable",
+                    "model": FABLE_MODEL,
+                    "effort": (
+                        "max" if args.advisor_effort == "auto" else args.advisor_effort
+                    ),
+                    "server": server,
+                }
 
             verified_agents = verify_agent_routes(
                 app.codex_home,
@@ -1342,6 +1564,11 @@ def main() -> int:
             print(f"Orchestrator: model selected when each Codex task starts")
             print(f"Executor: {_route_summary(executor)}")
             print(f"Advisor: {_route_summary(advisor) if advisor else 'none'}")
+            if fable_auth is not None:
+                print(
+                    "Claude Fable 5 login: ready — first-party; "
+                    "setup makes no model call"
+                )
             if verified_agents:
                 print(
                     "Custom-agent files: "

--- a/plugins/codex-orchestration/skills/codex-orchestration/scripts/fable_advisor_mcp.py
+++ b/plugins/codex-orchestration/skills/codex-orchestration/scripts/fable_advisor_mcp.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Read-only MCP bridge from Codex to Claude Fable 5 through Claude Code."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+from typing import Any
+
+
+STATE_FILENAME = ".codex-orchestration-routing.json"
+FABLE_MODEL = "claude-fable-5"
+SUPPORTED_EFFORTS = {"low", "medium", "high", "max"}
+CLAUDE_TIMEOUT_SECONDS = 600
+AUTH_TIMEOUT_SECONDS = 20
+SENSITIVE_ENV = {
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_AUTH_TOKEN",
+    "CLAUDE_CODE_USE_BEDROCK",
+    "CLAUDE_CODE_USE_VERTEX",
+    "CLAUDE_CODE_USE_FOUNDRY",
+}
+SYSTEM_PROMPT = """You are Claude Fable 5 acting only as a plan advisor to Codex's root orchestrator.
+Review the supplied self-contained packet for material correctness, missing constraints, unsafe sequencing, ownership conflicts, and verification gaps. Do not edit files, call tools, spawn agents, contact executors, or attempt implementation.
+
+Your first non-empty line must be exactly PLAN_APPROVED or PLAN_REVISE.
+Use PLAN_APPROVED only when no material gap is present. Use PLAN_REVISE when correction is needed, followed by a concise prioritized list in which every gap has a concrete correction. Ignore style preferences. Report only to the root orchestrator."""
+
+
+class AdvisorError(RuntimeError):
+    pass
+
+
+def codex_home() -> Path:
+    value = os.environ.get("CODEX_HOME")
+    return Path(value).expanduser() if value else Path.home() / ".codex"
+
+
+def sanitized_environment() -> dict[str, str]:
+    env = os.environ.copy()
+    for name in SENSITIVE_ENV:
+        env.pop(name, None)
+    return env
+
+
+def resolve_claude() -> Path:
+    found = shutil.which("claude")
+    if found:
+        return Path(found).resolve()
+    candidates = (
+        Path.home() / ".local" / "bin" / "claude",
+        Path("/usr/local/bin/claude"),
+        Path("/opt/homebrew/bin/claude"),
+    )
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate.resolve()
+    raise AdvisorError("Claude Code is not installed or `claude` is not on PATH.")
+
+
+def _run_json(command: list[str], *, timeout: int) -> dict[str, Any]:
+    try:
+        result = subprocess.run(
+            command,
+            env=sanitized_environment(),
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise AdvisorError(f"Could not run Claude Code: {exc}") from exc
+    if result.returncode != 0:
+        raise AdvisorError(f"Claude Code exited with {result.returncode}.")
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise AdvisorError("Claude Code returned malformed JSON.") from exc
+    if not isinstance(payload, dict):
+        raise AdvisorError("Claude Code returned an unexpected JSON value.")
+    return payload
+
+
+def check_claude_auth(claude: Path | None = None) -> dict[str, str]:
+    executable = claude or resolve_claude()
+    payload = _run_json([str(executable), "auth", "status"], timeout=AUTH_TIMEOUT_SECONDS)
+    subscription = payload.get("subscriptionType")
+    if not (
+        payload.get("loggedIn") is True
+        and payload.get("authMethod") == "claude.ai"
+        and payload.get("apiProvider") == "firstParty"
+        and subscription in {"pro", "max"}
+    ):
+        raise AdvisorError(
+            "Claude Code must be logged in through a first-party Pro or Max account; "
+            "run `claude auth login` and try again."
+        )
+    return {
+        "auth_method": "claude.ai",
+        "api_provider": "firstParty",
+    }
+
+
+def load_fable_route(home: Path | None = None) -> dict[str, str]:
+    path = (home or codex_home()) / STATE_FILENAME
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise AdvisorError("Claude Fable 5 is not configured; run setup first.") from exc
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise AdvisorError(f"Could not read the routing state: {exc}") from exc
+    route = payload.get("advisor") if isinstance(payload, dict) else None
+    if not isinstance(route, dict) or route.get("kind") != "fable":
+        raise AdvisorError("Claude Fable 5 is not the configured advisor.")
+    model = route.get("model")
+    effort = route.get("effort")
+    if model != FABLE_MODEL or effort not in SUPPORTED_EFFORTS:
+        raise AdvisorError("The saved Claude Fable 5 route is invalid.")
+    return {"model": model, "effort": effort}
+
+
+def review_plan(packet: str) -> dict[str, Any]:
+    if not isinstance(packet, str) or not packet.strip():
+        raise AdvisorError("`packet` must be a non-empty self-contained review packet.")
+    route = load_fable_route()
+    claude = resolve_claude()
+    auth = check_claude_auth(claude)
+    command = [
+        str(claude),
+        "-p",
+        "--model",
+        route["model"],
+        "--effort",
+        route["effort"],
+        "--safe-mode",
+        "--tools",
+        "",
+        "--permission-mode",
+        "dontAsk",
+        "--no-session-persistence",
+        "--prompt-suggestions",
+        "false",
+        "--output-format",
+        "json",
+        "--system-prompt",
+        SYSTEM_PROMPT,
+    ]
+    try:
+        result = subprocess.run(
+            command,
+            input=packet,
+            env=sanitized_environment(),
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=CLAUDE_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise AdvisorError(f"Claude Fable 5 review failed: {exc}") from exc
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "no diagnostic"
+        raise AdvisorError(f"Claude Fable 5 exited with {result.returncode}: {detail}")
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise AdvisorError("Claude Fable 5 returned malformed JSON.") from exc
+    if not isinstance(payload, dict) or not isinstance(payload.get("result"), str):
+        raise AdvisorError("Claude Fable 5 returned an unexpected response.")
+    review = payload["result"].strip()
+    first = next((line.strip() for line in review.splitlines() if line.strip()), "")
+    if first not in {"PLAN_APPROVED", "PLAN_REVISE"}:
+        raise AdvisorError("Claude Fable 5 omitted the required plan decision.")
+    usage = payload.get("modelUsage")
+    used_models = sorted(usage) if isinstance(usage, dict) else []
+    if FABLE_MODEL not in used_models:
+        raise AdvisorError("Runtime metadata did not confirm Claude Fable 5.")
+    return {
+        "decision": first,
+        "review": review,
+        "model": FABLE_MODEL,
+        "effort": route["effort"],
+        "auth_method": auth["auth_method"],
+        "used_models": used_models,
+    }
+
+
+def tool_definitions() -> list[dict[str, Any]]:
+    annotations = {
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    }
+    return [
+        {
+            "name": "review_plan",
+            "title": "Review a plan with Claude Fable 5",
+            "description": (
+                "Send one self-contained, read-only plan-review packet to the configured "
+                "Claude Fable 5 advisor."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "packet": {
+                        "type": "string",
+                        "description": "Complete context, plan, risks, slices, and checks.",
+                    }
+                },
+                "required": ["packet"],
+                "additionalProperties": False,
+            },
+            "annotations": annotations,
+        },
+        {
+            "name": "status",
+            "title": "Check Claude Fable 5 advisor status",
+            "description": "Check the saved route and Claude Code login without a model call.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": False,
+            },
+            "annotations": annotations,
+        },
+    ]
+
+
+def _tool_result(payload: dict[str, Any], *, is_error: bool = False) -> dict[str, Any]:
+    return {
+        "content": [{"type": "text", "text": json.dumps(payload, sort_keys=True)}],
+        "isError": is_error,
+    }
+
+
+def handle_request(request: dict[str, Any]) -> dict[str, Any] | None:
+    method = request.get("method")
+    request_id = request.get("id")
+    if request_id is None:
+        return None
+    if method == "initialize":
+        result = {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {"tools": {"listChanged": False}},
+            "serverInfo": {"name": "codex-orchestration-fable-advisor", "version": "1.0.0"},
+        }
+    elif method == "ping":
+        result = {}
+    elif method == "tools/list":
+        result = {"tools": tool_definitions()}
+    elif method == "tools/call":
+        params = request.get("params")
+        name = params.get("name") if isinstance(params, dict) else None
+        arguments = params.get("arguments", {}) if isinstance(params, dict) else {}
+        try:
+            if name == "review_plan":
+                packet = arguments.get("packet") if isinstance(arguments, dict) else None
+                result = _tool_result(review_plan(packet))
+            elif name == "status":
+                route = load_fable_route()
+                auth = check_claude_auth()
+                result = _tool_result({"available": True, **route, **auth})
+            else:
+                raise AdvisorError(f"Unknown tool: {name!r}.")
+        except AdvisorError as exc:
+            result = _tool_result({"available": False, "error": str(exc)}, is_error=True)
+    else:
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": {"code": -32601, "message": f"Method not found: {method}"},
+        }
+    return {"jsonrpc": "2.0", "id": request_id, "result": result}
+
+
+def main() -> int:
+    for line in sys.stdin:
+        try:
+            request = json.loads(line)
+            if not isinstance(request, dict):
+                raise ValueError("request must be an object")
+            response = handle_request(request)
+        except (json.JSONDecodeError, ValueError) as exc:
+            response = {
+                "jsonrpc": "2.0",
+                "id": None,
+                "error": {"code": -32700, "message": str(exc)},
+            }
+        if response is not None:
+            print(json.dumps(response, separators=(",", ":")), flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/plugin_lifecycle_smoke.py
+++ b/tests/plugin_lifecycle_smoke.py
@@ -2,7 +2,7 @@
 """Exercise a real Codex plugin install, Git upgrade, and both setup routes.
 
 A disposable bare Git marketplace is served over loopback HTTP. The real Codex
-CLI installs 0.3.0, runs its documented marketplace-upgrade command after 0.4.0
+CLI installs 0.3.0, runs its documented marketplace-upgrade command after 0.5.0
 is pushed to that Git remote, installs the refreshed package, verifies its cache,
 and runs native-policy plus custom-agent setup/status/cleanup in isolation.
 """
@@ -30,7 +30,7 @@ PLUGIN_ID = "codex-orchestration@codex-orchestration"
 MARKETPLACE_NAME = "codex-orchestration"
 OLD_RELEASE = "d93b86e735a12a9fefcfd35b0b35199ce3e9a2a7"
 OLD_VERSION = "0.3.0"
-NEW_VERSION = "0.4.0"
+NEW_VERSION = "0.5.0"
 COMMAND_TIMEOUT_SECONDS = 60
 
 
@@ -199,7 +199,11 @@ def main() -> int:
         )
     )
     current_version = manifest.get("version")
-    assert_equal(current_version, NEW_VERSION, "checkout release version")
+    if not isinstance(current_version, str):
+        raise SmokeFailure("checkout release version is not a string")
+    assert_equal(
+        current_version.split("+", 1)[0], NEW_VERSION, "checkout release base version"
+    )
 
     with tempfile.TemporaryDirectory(prefix="codex-orchestration-lifecycle-") as raw:
         temp = Path(raw)

--- a/tests/test_fable_advisor_mcp.py
+++ b/tests/test_fable_advisor_mcp.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+from unittest import mock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = (
+    REPO_ROOT
+    / "plugins"
+    / "codex-orchestration"
+    / "skills"
+    / "codex-orchestration"
+    / "scripts"
+    / "fable_advisor_mcp.py"
+)
+SPEC = importlib.util.spec_from_file_location("fable_advisor_mcp", SCRIPT)
+assert SPEC and SPEC.loader
+FABLE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(FABLE)
+
+
+class FableAdvisorMcpTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.home = Path(self.temp.name)
+        (self.home / FABLE.STATE_FILENAME).write_text(
+            json.dumps(
+                {
+                    "advisor": {
+                        "kind": "fable",
+                        "model": "claude-fable-5",
+                        "effort": "max",
+                        "server": "fable-advisor-python3",
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    @staticmethod
+    def completed(command: list[str], stdout: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(command, 0, stdout, "")
+
+    def test_review_is_pinned_sanitized_read_only_and_runtime_confirmed(self) -> None:
+        calls: list[tuple[list[str], dict[str, object]]] = []
+
+        def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+            calls.append((command, kwargs))
+            if command[-2:] == ["auth", "status"]:
+                return self.completed(
+                    command,
+                    json.dumps(
+                        {
+                            "loggedIn": True,
+                            "authMethod": "claude.ai",
+                            "apiProvider": "firstParty",
+                            "subscriptionType": "max",
+                        }
+                    ),
+                )
+            return self.completed(
+                command,
+                json.dumps(
+                    {
+                        "result": "PLAN_APPROVED\nNo material gap found.",
+                        "modelUsage": {"claude-fable-5": {"outputTokens": 12}},
+                    }
+                ),
+            )
+
+        env = {
+            "CODEX_HOME": str(self.home),
+            "ANTHROPIC_API_KEY": "must-not-leak",
+            "ANTHROPIC_AUTH_TOKEN": "must-not-leak",
+            "CLAUDE_CODE_USE_BEDROCK": "1",
+        }
+        with (
+            mock.patch.dict(os.environ, env, clear=False),
+            mock.patch.object(FABLE, "resolve_claude", return_value=Path("/fake/claude")),
+            mock.patch.object(FABLE.subprocess, "run", side_effect=fake_run),
+        ):
+            result = FABLE.review_plan("Review this complete plan.")
+
+        self.assertEqual(result["decision"], "PLAN_APPROVED")
+        self.assertEqual(result["model"], "claude-fable-5")
+        self.assertEqual(result["used_models"], ["claude-fable-5"])
+        self.assertNotIn("subscription_type", result)
+        review_command, review_kwargs = calls[1]
+        self.assertIn("--safe-mode", review_command)
+        self.assertNotIn("--bare", review_command)
+        self.assertEqual(review_command[review_command.index("--model") + 1], "claude-fable-5")
+        self.assertEqual(review_command[review_command.index("--effort") + 1], "max")
+        self.assertEqual(
+            review_command[review_command.index("--prompt-suggestions") + 1], "false"
+        )
+        self.assertEqual(review_kwargs["input"], "Review this complete plan.")
+        sanitized = review_kwargs["env"]
+        self.assertIsInstance(sanitized, dict)
+        for name in FABLE.SENSITIVE_ENV:
+            self.assertNotIn(name, sanitized)
+
+    def test_invalid_decision_or_unconfirmed_model_fails_closed(self) -> None:
+        auth = self.completed(
+            ["claude", "auth", "status"],
+            json.dumps(
+                {
+                    "loggedIn": True,
+                    "authMethod": "claude.ai",
+                    "apiProvider": "firstParty",
+                    "subscriptionType": "pro",
+                }
+            ),
+        )
+        malformed = self.completed(
+            ["claude"],
+            json.dumps(
+                {
+                    "result": "Looks good.",
+                    "modelUsage": {"claude-fable-5": {}},
+                }
+            ),
+        )
+        with (
+            mock.patch.dict(os.environ, {"CODEX_HOME": str(self.home)}),
+            mock.patch.object(FABLE, "resolve_claude", return_value=Path("/fake/claude")),
+            mock.patch.object(FABLE.subprocess, "run", side_effect=[auth, malformed]),
+        ):
+            with self.assertRaisesRegex(FABLE.AdvisorError, "required plan decision"):
+                FABLE.review_plan("packet")
+
+        unconfirmed = self.completed(
+            ["claude"],
+            json.dumps(
+                {
+                    "result": "PLAN_REVISE\nFix the verification step.",
+                    "modelUsage": {"claude-haiku-4-5": {}},
+                }
+            ),
+        )
+        with (
+            mock.patch.dict(os.environ, {"CODEX_HOME": str(self.home)}),
+            mock.patch.object(FABLE, "resolve_claude", return_value=Path("/fake/claude")),
+            mock.patch.object(FABLE.subprocess, "run", side_effect=[auth, unconfirmed]),
+        ):
+            with self.assertRaisesRegex(FABLE.AdvisorError, "did not confirm"):
+                FABLE.review_plan("packet")
+
+    def test_mcp_surface_exposes_only_bounded_tools(self) -> None:
+        initialized = FABLE.handle_request(
+            {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}
+        )
+        self.assertEqual(initialized["result"]["serverInfo"]["name"], "codex-orchestration-fable-advisor")
+        listed = FABLE.handle_request(
+            {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}}
+        )
+        tools = listed["result"]["tools"]
+        self.assertEqual([tool["name"] for tool in tools], ["review_plan", "status"])
+        for tool in tools:
+            self.assertTrue(tool["annotations"]["readOnlyHint"])
+            self.assertFalse(tool["annotations"]["destructiveHint"])
+        review_schema = tools[0]["inputSchema"]
+        self.assertEqual(review_schema["required"], ["packet"])
+        self.assertFalse(review_schema["additionalProperties"])
+
+    def test_status_does_not_expose_account_plan_metadata(self) -> None:
+        with (
+            mock.patch.object(FABLE, "load_fable_route", return_value={"model": "claude-fable-5", "effort": "max"}),
+            mock.patch.object(
+                FABLE,
+                "check_claude_auth",
+                return_value={"auth_method": "claude.ai", "api_provider": "firstParty"},
+            ),
+        ):
+            response = FABLE.handle_request(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 3,
+                    "method": "tools/call",
+                    "params": {"name": "status", "arguments": {}},
+                }
+            )
+        text = response["result"]["content"][0]["text"]
+        self.assertNotIn("subscription", text.lower())
+        self.assertNotIn("account_plan", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_native_routing.py
+++ b/tests/test_native_routing.py
@@ -75,7 +75,24 @@ def version():
     return int(version_file.read_text()) if version_file.exists() else 0
 
 def set_path(root, path, value):
-    parts = path.split(".")
+    parts = []
+    current_part = []
+    quoted = False
+    escaped = False
+    for character in path:
+        if escaped:
+            current_part.append(character)
+            escaped = False
+        elif character == "\\" and quoted:
+            escaped = True
+        elif character == '"':
+            quoted = not quoted
+        elif character == "." and not quoted:
+            parts.append("".join(current_part))
+            current_part = []
+        else:
+            current_part.append(character)
+    parts.append("".join(current_part))
     current = root
     for part in parts[:-1]:
         if not isinstance(current.get(part), dict):
@@ -227,6 +244,32 @@ class NativeRoutingTests(unittest.TestCase):
         self.codex = self.root / "fake-codex"
         self.codex.write_text(textwrap.dedent(FAKE_CODEX), encoding="utf-8")
         self.codex.chmod(0o755)
+        self.bin = self.root / "bin"
+        self.bin.mkdir()
+        self.claude = self.bin / "claude"
+        self.claude.write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env python3
+                import json
+                import sys
+                if sys.argv[1:] == ["auth", "status"]:
+                    print(json.dumps({
+                        "loggedIn": True,
+                        "authMethod": "claude.ai",
+                        "apiProvider": "firstParty",
+                        "subscriptionType": "max",
+                    }))
+                    raise SystemExit(0)
+                if sys.argv[1:] == ["--help"]:
+                    print("--model --effort --safe-mode --prompt-suggestions")
+                    raise SystemExit(0)
+                raise SystemExit(2)
+                """
+            ),
+            encoding="utf-8",
+        )
+        self.claude.chmod(0o755)
 
     def tearDown(self) -> None:
         self.temp.cleanup()
@@ -238,6 +281,8 @@ class NativeRoutingTests(unittest.TestCase):
         allow_incompatible: bool = True,
     ) -> subprocess.CompletedProcess[str]:
         compatibility = ["--allow-incompatible-client"] if allow_incompatible else []
+        env = os.environ.copy()
+        env["PATH"] = f"{self.bin}{os.pathsep}{env.get('PATH', '')}"
         result = subprocess.run(
             [
                 sys.executable,
@@ -254,6 +299,7 @@ class NativeRoutingTests(unittest.TestCase):
             stderr=subprocess.PIPE,
             timeout=20,
             check=False,
+            env=env,
         )
         if check and result.returncode != 0:
             self.fail(f"command failed\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}")
@@ -741,6 +787,65 @@ class NativeRoutingTests(unittest.TestCase):
         usage = feature["usage_hint_text"]
         self.assertIn('agent_type = "codex_orchestration_executor"', usage)
         self.assertIn('agent_type = "codex_orchestration_advisor"', usage)
+
+    def test_fable_setup_status_update_and_disable_restore_mcp_policy(self) -> None:
+        initial = {
+            "features": {
+                "multi_agent_v2": {"max_concurrent_threads_per_session": 5}
+            },
+            "plugins": {
+                NATIVE.PLUGIN_ID: {
+                    "mcp_servers": {
+                        "fable-advisor-python3": {"enabled": False},
+                        "fable-advisor-python": {"enabled": True},
+                    }
+                }
+            },
+            "unrelated": {"keep": True},
+        }
+        (self.home / ".fake-user-config.json").write_text(
+            json.dumps(initial), encoding="utf-8"
+        )
+        setup = self.run_script(
+            "--executor-model",
+            "gpt-5.6-luna",
+            "--executor-effort",
+            "xhigh",
+            "--advisor-fable",
+            "--advisor-effort",
+            "max",
+            "--apply",
+        )
+        self.assertIn("Claude Fable 5 Extra High", setup.stdout)
+        config = self.read_fake_config()
+        servers = config["plugins"][NATIVE.PLUGIN_ID]["mcp_servers"]
+        self.assertTrue(servers["fable-advisor-python3"]["enabled"])
+        self.assertFalse(servers["fable-advisor-python"]["enabled"])
+        self.assertNotIn("fable-advisor-py", servers)
+        state = json.loads(
+            (self.home / NATIVE.STATE_FILENAME).read_text(encoding="utf-8")
+        )
+        self.assertEqual(state["advisor"]["kind"], "fable")
+        self.assertEqual(state["advisor"]["model"], "claude-fable-5")
+        self.assertIn("mcp", state["previous"])
+
+        status = self.run_script("--status")
+        self.assertIn("Claude Fable 5: ready", status.stdout)
+        self.assertIn("no model call made", status.stdout)
+
+        update = self.run_script(
+            "--executor-model",
+            "gpt-5.6-terra",
+            "--executor-effort",
+            "high",
+            "--apply",
+        )
+        self.assertIn("Advisor: none", update.stdout)
+        servers = self.read_fake_config()["plugins"][NATIVE.PLUGIN_ID]["mcp_servers"]
+        self.assertTrue(all(not entry["enabled"] for entry in servers.values()))
+
+        self.run_script("--disable", "--apply")
+        self.assertEqual(self.read_fake_config(), initial)
 
     def test_missing_or_project_shadowed_custom_agent_is_refused(self) -> None:
         missing = self.run_script(

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -24,7 +24,8 @@ class PackagingTests(unittest.TestCase):
 
         self.assertEqual(manifest["name"], "codex-orchestration")
         self.assertEqual(manifest["skills"], "./skills/")
-        self.assertEqual(manifest["version"], "0.4.0")
+        self.assertEqual(manifest["mcpServers"], "./.mcp.json")
+        self.assertRegex(manifest["version"], r"^0\.5\.0(?:\+codex\.\d+)?$")
         self.assertRegex(
             manifest["version"],
             r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$",
@@ -43,6 +44,23 @@ class PackagingTests(unittest.TestCase):
         self.assertTrue(custom.is_file())
         self.assertIn("config/batchWrite", native.read_text(encoding="utf-8"))
         self.assertIn("Standalone custom agent", custom.read_text(encoding="utf-8"))
+
+    def test_fable_mcp_is_packaged_and_disabled_until_selected(self) -> None:
+        mcp = json.loads((PLUGIN_ROOT / ".mcp.json").read_text(encoding="utf-8"))
+        servers = mcp["mcpServers"]
+        self.assertEqual(
+            set(servers),
+            {
+                "fable-advisor-python3",
+                "fable-advisor-python",
+                "fable-advisor-py",
+            },
+        )
+        for server in servers.values():
+            self.assertFalse(server["enabled"])
+            self.assertEqual(server["cwd"], ".")
+            self.assertIn("fable_advisor_mcp.py", server["args"][-1])
+        self.assertTrue((SKILL_ROOT / "scripts" / "fable_advisor_mcp.py").is_file())
 
     def test_explicit_invocation_metadata_is_consistent(self) -> None:
         metadata = (SKILL_ROOT / "agents" / "openai.yaml").read_text(encoding="utf-8")
@@ -89,7 +107,7 @@ class PackagingTests(unittest.TestCase):
         self.assertIn("@openai/codex@0.144.1", workflow)
         smoke_text = smoke.read_text(encoding="utf-8")
         self.assertIn('OLD_VERSION = "0.3.0"', smoke_text)
-        self.assertIn('NEW_VERSION = "0.4.0"', smoke_text)
+        self.assertIn('NEW_VERSION = "0.5.0"', smoke_text)
         self.assertIn("configure_native_routing.py", smoke_text)
         self.assertIn("configure_orchestration.py", smoke_text)
         self.assertIn('"marketplace",\n                    "upgrade"', smoke_text)

--- a/tests/test_skill_contract.py
+++ b/tests/test_skill_contract.py
@@ -111,6 +111,19 @@ class SkillContractTests(unittest.TestCase):
         self.assertIn("verify_agent_routes", NATIVE_SCRIPT)
         self.assertIn("same-name project role", SKILL)
 
+    def test_fable_is_a_bundled_root_only_mcp_advisor(self) -> None:
+        self.assertIn("Claude Fable 5 Extra High", SKILL)
+        self.assertIn("--advisor-fable --advisor-effort max", SKILL)
+        self.assertIn("built-in cross-provider advisor exception", SKILL)
+        self.assertIn("All bundled variants are disabled by default", SKILL)
+        self.assertIn("first-party Pro or Max account", SKILL)
+        self.assertIn("never extracts a token", SKILL)
+        self.assertIn("runtime `modelUsage` to confirm `claude-fable-5`", SKILL)
+        self.assertIn("call the configured MCP server's `review_plan` tool", SKILL)
+        self.assertIn("instead of spawning an advisor child", SKILL)
+        self.assertIn("use the exact name `Claude Fable 5`", SKILL)
+        self.assertIn("do not expose or restate Claude account-plan metadata", SKILL)
+
     def test_direct_routes_are_guarded_to_the_root_provider(self) -> None:
         self.assertIn("Direct model overrides keep the root's provider", SKILL)
         self.assertIn("target model is on the same provider", NATIVE_SCRIPT)


### PR DESCRIPTION
## What changed

- Add an opt-in, bundled MCP bridge that invokes Claude Fable 5 through the authenticated Claude Code CLI.
- Integrate Claude Fable 5 with native setup, status, update, rollback, and disable behavior.
- Keep launcher variants disabled by default and enable only the compatible Python 3.11+ route.
- Pin model and effort, sanitize provider/API override variables, require valid plan decisions, and verify runtime model metadata.
- Update documentation, packaging, compatibility behavior, and user-facing status wording.
- Add protocol, security, lifecycle, restoration, packaging, and skill-contract tests.

## Why

Codex-Orchestration needed a root-only Claude Fable 5 advisor inside Codex without using an Anthropic API-key-backed custom provider. The initial test also exposed a shared-config compatibility failure caused by an outdated npm Codex CLI; the guard worked correctly, and the supported path is now documented and verified.

## Impact

Users can configure Claude Fable 5 as a read-only plan advisor while keeping the selected Codex model as orchestrator and using native Codex executors. Setup and status do not make model calls, failures are never treated as approval, and account-plan metadata is not exposed in user-facing tool results.

## Validation

- `python3 -m unittest discover -s tests -q` — 139 tests passed
- Plugin validator — passed
- Skill validator — passed
- Real marketplace lifecycle smoke — passed install, upgrade, cache verification, setup/status, and cleanup
- Live end-to-end smoke — Claude Fable 5 returned `PLAN_APPROVED`; configured GPT-5.6 Sol High executor returned `END_TO_END_OK`; no files changed
