### PR TITLE
Ship simple multi-model workflows with Fable advisor

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+* @Cjbuilds
+
+/.github/ @Cjbuilds
+/plugins/codex-orchestration/skills/codex-orchestration/scripts/ @Cjbuilds
+/SECURITY.md @Cjbuilds

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - security

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,16 +8,31 @@ permissions:
   contents: read
 
 jobs:
+  quality:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.11"
+      - name: Install pinned development tools
+        run: python -m pip install --disable-pip-version-check -r requirements-dev.txt
+      - name: Lint Python sources
+        run: python -m ruff check plugins tests scripts
+
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.11", "3.13"]
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Compile Python sources
@@ -27,15 +42,16 @@ jobs:
 
   plugin-lifecycle:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.11"
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "22"
       - name: Install the Codex CLI used by the lifecycle test
@@ -45,10 +61,11 @@ jobs:
 
   legacy-client-guard:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "22"
       - name: Install the older shared-config client
@@ -59,3 +76,31 @@ jobs:
             echo "Expected Codex 0.142.5 to reject the newer structured policy field"
             exit 1
           fi
+
+  portability:
+    name: portability (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.11"
+      - name: Compile Python sources
+        run: python -m compileall -q plugins tests
+      - name: Run platform-neutral contract tests
+        run: >-
+          python -m unittest -v
+          tests.test_inspect_models
+          tests.test_packaging
+          tests.test_skill_contract
+      - name: Verify Windows custom-agent updates fail closed
+        if: runner.os == 'Windows'
+        run: >-
+          python -m unittest -v
+          tests.test_configure_orchestration.ConfigureOrchestrationTests.test_windows_existing_file_update_fails_closed

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,24 @@
+name: CodeQL
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "17 4 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: analyze (python)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: github/codeql-action/init@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3
+        with:
+          languages: python
+      - uses: github/codeql-action/analyze@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.5.0 — Unreleased
 
+- Add Claude Fable 5 as an opt-in, root-only advisor through a bundled local MCP bridge to the authenticated Claude Code CLI.
+- Keep every Fable launcher disabled by default, enable only one compatible Python 3.11+ route, and restore prior plugin overrides on disable.
+- Pin `claude-fable-5`, remove provider override variables, disable tools and session persistence, and fail closed unless the plan signal and runtime model are valid.
 - Add automation-safe native status gating with `--require-effective`.
 - Detect orphaned managed personal roles and distinguish installed policy from live route validation.
 - Fail truthfully when restore-state persistence and config rollback do not both succeed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.5.0 — Unreleased
+
+- Add automation-safe native status gating with `--require-effective`.
+- Detect orphaned managed personal roles and distinguish installed policy from live route validation.
+- Fail truthfully when restore-state persistence and config rollback do not both succeed.
+- Exercise direct-model lifecycle setup and add macOS/Windows portability checks.
+- Pin GitHub Actions, add CodeQL and Dependabot, and document secure contribution and release workflows.
+- Clarify policy-guided routing, concurrency, Windows custom-role limitations, and two-phase recovery.
+
 ## 0.4.0 — 2026-07-10
 
 - Make one-time, config-first routing the primary workflow: setup once, then use Codex normally.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing
+
+## Development setup
+
+Use Python 3.11 or newer and a current Node.js release when running the real plugin lifecycle test. The production scripts use only the Python standard library.
+
+```bash
+python3 -m pip install -r requirements-dev.txt
+python3 -m ruff check plugins tests scripts
+```
+
+Run the local release gate before opening a pull request:
+
+```bash
+python3 -m compileall -q plugins tests scripts
+python3 -m ruff check plugins tests scripts
+python3 -m unittest discover -s tests -v
+python3 tests/plugin_lifecycle_smoke.py
+python3 scripts/release_check.py
+```
+
+The lifecycle smoke test installs and upgrades the plugin through a disposable Git marketplace and requires a local `codex` CLI. It does not use or change your normal Codex home.
+
+## Pull requests
+
+- Keep filesystem and config mutations reversible and fail closed on ambiguity.
+- Add negative-path tests for crash recovery, concurrency, provider, and ownership boundaries.
+- Do not weaken root authority, approvals, permissions, or the `fork_turns = "none"` contract.
+- Update the changelog and public compatibility statements when behavior changes.
+- Never include credentials or private configuration in fixtures, logs, or routing hints.
+
+All required checks must pass. Resolve review conversations before merge. Releases follow [RELEASE.md](RELEASE.md).

--- a/README.md
+++ b/README.md
@@ -1,68 +1,60 @@
 # Codex Orchestration
 
-Bring compatible models into Codex, give each one a role, describe the workflow, and let Codex coordinate the work.
+Bring models like Claude Fable 5 into Codex, give them roles, and make them work together.
 
-## What is Codex Orchestration?
+## What does it do?
 
-Codex Orchestration turns one Codex task into a multi-model team.
+Codex Orchestration turns one Codex task into a multi-model workflow.
 
-The model you select when you start the task is the orchestrator. It owns the goal, plan, decisions, handoffs, verification, and final answer.
+- Bring Fable 5 or another compatible model into Codex.
+- Assign roles such as advisor, executor, researcher, writer, designer, or reviewer.
+- Choose the order in which those roles work.
+- Let Codex manage the handoffs and return one verified result.
 
-You can add other models as advisors, executors, researchers, reviewers, writers, supervisors, or any focused role that fits your work.
-
-Tell Codex the order: who plans, who critiques, who researches, who builds, and who verifies. Codex handles the handoffs, waits for results, resolves feedback, and returns one answer.
-
-It works with normal tasks and Codex Goals. Once the task starts, Codex runs the workflow autonomously within your instructions and permissions.
-
-You can use models from OpenAI or any compatible provider already configured and authenticated in Codex. A model name alone does not create provider access.
+The model selected for the task stays in charge. It plans, decides what feedback to use, delegates work, tests the result, and gives you the final answer.
 
 ## How it works
 
+Here is one example:
+
 ```text
-             YOU
-       Task or Codex Goal
-              |
-              v
-     ROOT MODEL / ORCHESTRATOR
-        understands and plans
-              |
-              v
-   +---------------------------+
-   | Optional specialist roles |
-   | advisor | researcher      |
-   | reviewer | supervisor     |
-   +---------------------------+
-              |
-        evidence + critique
-              |
-              v
-     ORCHESTRATOR DECIDES
-       and improves the plan
-              |
-              v
-   +---------------------------+
-   | Execution roles           |
-   | executor | writer | maker |
-   +---------------------------+
-              |
-              v
-     ORCHESTRATOR VERIFIES
-              |
-              v
-          FINAL RESULT
+                 YOUR TASK OR GOAL
+                         |
+                         v
+              SOL — ROOT ORCHESTRATOR
+                    creates the plan
+                         |
+                         v
+              FABLE 5 — PLAN ADVISOR
+                 finds gaps and risks
+                         |
+                         v
+              SOL — ROOT ORCHESTRATOR
+             improves the plan and decides
+                         |
+              +----------+----------+
+              |                     |
+              v                     v
+       LUNA EXECUTOR 1        LUNA EXECUTOR 2
+          builds a part          builds a part
+              |                     |
+              +----------+----------+
+                         |
+                         v
+              SOL — ROOT ORCHESTRATOR
+                 tests and delivers
 ```
 
-The roles and order are yours. Codex remains the lead and adapts the workflow when the task needs it.
+You choose the models, roles, and order. Codex follows the workflow while keeping final decisions with the root model.
 
 ## Why use it?
 
-- **Better results:** different models challenge the plan from different perspectives.
-- **Faster work:** independent research, review, and execution can run in parallel.
-- **Lower model-weighted cost:** reserve the strongest model for judgment and use efficient models for high-volume execution.
-- **Clear ownership:** every model gets a bounded role, expected output, and place in the workflow.
-- **Flexible teams:** change the models, roles, or sequence for each task or project.
+- **Better plans:** Fable 5 can challenge the root model before implementation begins.
+- **More perspectives:** use different models for planning, research, design, writing, review, or execution.
+- **Faster implementation:** independent executors can work in parallel—up to 2x faster on suitable tasks.
+- **Less limit pressure:** move repeated implementation work away from the root model and potentially hit premium-model limits about 40% less often.
 
-Multi-agent work can use more raw tokens. Savings depend on the models, workload, context, retries, and service tier; they are not guaranteed.
+Results depend on the models, task, context, retries, and how much work can run in parallel. The speed and limit figures are targets, not guarantees.
 
 ## Install
 
@@ -71,49 +63,51 @@ codex plugin marketplace add Cjbuilds/Codex-Orchestration
 codex plugin add codex-orchestration@codex-orchestration
 ```
 
-Start a new Codex task after installation.
+Start a new Codex task after installation so the plugin loads.
 
-In the desktop app, type `/` and choose **Codex Orchestration**. CLI and IDE users can invoke it through `/skills` or `$`.
+Setup requires Python 3.11 or newer.
 
-Setup requires Python 3.11 or newer. Use `python3` on macOS/Linux or an available `py -3.11` or `python` launcher on Windows.
+## Quick start with Fable 5
 
-## Quick start
-
-### OpenAI-only team
-
-Use the model selected for the task as orchestrator and Luna as the default executor:
+Select the model you want to lead the task, then run:
 
 ```text
-/codex-orchestration setup executor: GPT-5.6 Luna Extra High
+/codex-orchestration setup executor: GPT-5.6 Luna Extra High, advisor: Claude Fable 5 High
 ```
 
-Add a second OpenAI model as advisor:
+This creates the default workflow:
 
 ```text
-/codex-orchestration setup executor: GPT-5.6 Luna Extra High, advisor: GPT-5.6 Terra High
+Selected Codex model -> Fable 5 review -> selected model decides -> Luna executes -> selected model verifies
 ```
 
-Setup previews and validates the personal routing policy before applying it. Start a new task afterward.
+Fable 5 uses the official Claude Code CLI. You need a compatible first-party Claude login, but you do not need to add an Anthropic API key to Codex.
 
-### Claude Fable 5 as advisor
+After setup, start another new task and work normally.
 
-Use Claude Fable 5 to critique plans while your selected Codex model stays in charge:
+## Tell Codex your workflow
+
+Paste a workflow at the start of a task:
 
 ```text
-/codex-orchestration setup executor: GPT-5.6 Luna Extra High, advisor: Claude Fable 5 Extra High
+Use this workflow:
+
+1. The selected model is the root orchestrator and creates the plan.
+2. Claude Fable 5 reviews the plan as advisor.
+3. The root accepts only useful feedback and improves the plan.
+4. Luna executors build independent parts in parallel.
+5. The root integrates, tests, and verifies the final result.
 ```
 
-This route uses the official Claude Code CLI through a bundled, read-only MCP bridge. It requires a compatible first-party Claude login and does not need an Anthropic API key in Codex.
+You can change the sequence for any task:
 
-The bridge accepts one plan-review packet, disables Claude tools and session persistence, verifies the runtime model, and requires `PLAN_APPROVED` or `PLAN_REVISE`.
+```text
+Researcher -> root synthesis -> designer -> writer -> reviewer -> root verification
+```
 
-If Claude is unavailable or returns an invalid result, Codex treats the advisor as unavailable. Failure is never approval.
+## Bring another model into Codex
 
-## Bring any model and create any role
-
-Codex supports custom agents with their own model, effort, instructions, sandbox, tools, MCP servers, and skills.
-
-Ask Codex Orchestration to create project roles for you:
+Ask Codex Orchestration to create a role:
 
 ```text
 /codex-orchestration create these project roles:
@@ -122,121 +116,56 @@ Ask Codex Orchestration to create project roles for you:
   model: <model-id>
   provider: <configured-provider-id>
   effort: high
-  sandbox: read-only
   job: gather evidence and cite sources
 
 - writer
   model: <model-id>
   effort: medium
-  job: turn approved research into the final draft
+  job: turn approved research into a clear draft
 
-- reviewer
+- designer
   model: <model-id>
   effort: high
-  sandbox: read-only
-  job: check accuracy, gaps, and weak claims
+  job: propose and review the user experience
 ```
 
-Codex previews the native custom-agent files under `.codex/agents/`. After you approve the files, start a new task so Codex loads the roles.
+Codex previews the role files before creating them. Project roles live in `.codex/agents/`. Personal roles live in `~/.codex/agents/` and can be used across projects.
 
-Ask for personal roles only when you want them available across projects. Those files live under `~/.codex/agents/`.
-
-The plugin safely manages its built-in advisor and executor seats. Other role names are normal Codex custom agents and remain user-owned.
-
-### Common roles
-
-| Role | Good at |
-| --- | --- |
-| Advisor | Critiquing a plan before expensive work starts |
-| Executor | Implementing a bounded part of an approved plan |
-| Researcher | Gathering evidence, APIs, papers, or repository context |
-| Reviewer | Finding bugs, security risks, regressions, or missing tests |
-| Writer | Producing documentation, articles, reports, or launch copy |
-| Supervisor | Checking progress and reporting exceptions to the root |
-
-Roles should be narrow. The orchestrator remains the only model that owns the whole task.
-
-## Describe the workflow at the start of a task
-
-Once the models and roles are available, tell Codex how to use them.
-
-```text
-Use this workflow for the task:
-
-1. The model I selected for this task is the root orchestrator.
-2. The root creates the plan.
-3. Claude Fable 5 reviews the plan as advisor.
-4. The root accepts only valid feedback and revises the plan.
-5. GPT-5.6 Luna Extra High executors implement independent slices.
-6. The root integrates, tests, verifies, and gives me the final answer.
-
-Do not skip a required review. Do not let child agents create their own teams.
-```
-
-Or define a custom sequence:
-
-```text
-Researcher -> root synthesis -> reviewer -> writer -> root verification
-```
-
-Codex follows the saved and task-level instructions, while keeping authority, safety, and final judgment with the root model.
+Fable 5 is currently bundled as a plan advisor. Other models must already be available through Codex or an authenticated, compatible provider.
 
 ## Use it with Codex Goals
 
-Set a Goal normally, then tell Codex to use your team:
+Set a Goal normally, then add your workflow:
 
 ```text
 /goal Ship the authentication redesign with tests and migration notes.
 
-Use my configured advisor and executor workflow until the Goal is genuinely complete.
+Use my Fable advisor and Luna executor workflow until the Goal is complete.
 ```
 
-The Goal remains owned by Codex. This plugin does not create, pause, clear, or change Goal limits unless you explicitly use Codex's Goal controls.
+Codex still owns the Goal. The plugin controls the model workflow inside it.
 
-## Roles and permissions
-
-Subagents inherit the current task's permission mode. Choose the parent permission mode before delegation.
-
-A custom role may request a narrower sandbox such as `read-only`. It cannot silently expand the authority granted by the parent task.
-
-Codex Orchestration never bypasses approvals, changes credentials, creates provider access, or weakens your security settings.
-
-## Model and provider routes
-
-| Route | How it works |
-| --- | --- |
-| Same-provider Codex model | Exact model and effort are requested when Codex spawns the role. |
-| Claude Fable 5 advisor | Bundled root-only MCP bridge uses the authenticated Claude Code CLI. |
-| Other provider | A native custom agent pins an already configured `model_provider`. |
-| Project role | Stored in `.codex/agents/` and loaded for that trusted project. |
-| Personal role | Stored in `~/.codex/agents/` and loaded across projects. |
-
-Custom Codex providers use a compatible wire protocol and authentication setup. A raw provider endpoint or API key is not automatically interchangeable with Codex.
-
-## Useful controls
+## Useful commands
 
 ```text
 /codex-orchestration status
 /codex-orchestration status --require-effective
-/codex-orchestration setup executor: GPT-5.6 Terra High
+/codex-orchestration setup executor: GPT-5.6 Luna Extra High, advisor: Claude Fable 5 High
 /codex-orchestration disable
-/codex-orchestration remove custom roles personally
 ```
 
-`status --require-effective` is the automation and release gate. It exits nonzero for incompatible clients, conflicts, overrides, incomplete controls, unavailable routes, or orphaned managed roles.
+`disable` restores the Codex routing values that existed before setup. It does not delete user-owned custom roles.
 
-`disable` restores the values that existed before built-in routing setup. It leaves unrelated Codex configuration alone.
+## Important limits
 
-## Important boundaries
+- Codex remains the root orchestrator.
+- Fable 5 is a root-facing plan advisor, not a second orchestrator.
+- Other providers must already be configured and authenticated.
+- The plugin never creates credentials or bypasses permissions and approvals.
+- Codex decides when delegation or parallel work is useful.
+- If you say `no subagents`, Codex must not delegate.
 
-- Codex must already be able to access the model through its current provider, a configured compatible provider, or the bundled Fable route.
-- The saved workflow is policy-guided routing, not a separate scheduler or an engine-level global executor switch.
-- Codex decides whether delegation is useful, how many independent roles to run, and when direct work is safer.
-- Exact runtime identity is called confirmed only when the client exposes effective model, provider, and effort metadata.
-- Full-history forks can inherit the root route, so different routed roles use bounded, self-contained handoffs.
-- Existing custom-agent updates and removal remain fail-closed on Windows when safe metadata preservation cannot be proven.
-
-If you say `no subagents`, that always wins.
+Technical details are in [providers and models](plugins/codex-orchestration/skills/codex-orchestration/references/providers-and-models.md).
 
 ## Update
 
@@ -245,26 +174,26 @@ codex plugin marketplace upgrade codex-orchestration
 codex plugin add codex-orchestration@codex-orchestration
 ```
 
-Start a new task so Codex loads the updated plugin and roles.
+Start a new task after updating.
 
 ## Uninstall
 
-First disable the saved routing policy:
+First run:
 
 ```text
 /codex-orchestration disable
 ```
 
-Preview and remove plugin-managed custom roles if you created them. Review user-owned arbitrary roles separately.
+Then remove the plugin:
 
 ```bash
 codex plugin remove codex-orchestration@codex-orchestration
 codex plugin marketplace remove codex-orchestration
 ```
 
-Removing the plugin does not silently delete configuration that may still affect later tasks.
+Review and remove any user-owned custom roles separately.
 
-## Develop and validate
+## Development
 
 ```bash
 python3 -m pip install -r requirements-dev.txt
@@ -276,16 +205,6 @@ python3 scripts/release_check.py
 ```
 
 See the [production-readiness audit](docs/production-readiness-audit.md), [security policy](SECURITY.md), and [release process](RELEASE.md).
-
-Technical details live in [providers and models](plugins/codex-orchestration/skills/codex-orchestration/references/providers-and-models.md).
-
-## Design sources
-
-- [OpenAI: Subagents and custom agents](https://learn.chatgpt.com/docs/agent-configuration/subagents)
-- [OpenAI: Codex configuration](https://learn.chatgpt.com/docs/config-file/config-reference)
-- [OpenAI: Custom model providers](https://learn.chatgpt.com/docs/config-file/config-advanced#custom-model-providers)
-- [OpenAI: Codex App Server](https://learn.chatgpt.com/docs/app-server)
-- [OpenAI: Build plugins](https://learn.chatgpt.com/docs/build-plugins)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,68 @@
-# Codex-Orchestration
+# Codex Orchestration
 
-Use your strongest model where judgment matters. Let a faster, cheaper model handle eligible execution work that consumes most of the context and usage.
+Bring compatible models into Codex, give each one a role, describe the workflow, and let Codex coordinate the work.
 
-The model you select when you start a Codex task is already the orchestrator. If you start with GPT-5.6 Sol Extra High, Sol plans, delegates, reviews, and answers. You only choose the executor and, if you want one, an advisor.
+## What is Codex Orchestration?
 
-Set it up once. After that, use Codex normally—no skill tag in every prompt.
+Codex Orchestration turns one Codex task into a multi-model team.
+
+The model you select when you start the task is the orchestrator. It owns the goal, plan, decisions, handoffs, verification, and final answer.
+
+You can add other models as advisors, executors, researchers, reviewers, writers, supervisors, or any focused role that fits your work.
+
+Tell Codex the order: who plans, who critiques, who researches, who builds, and who verifies. Codex handles the handoffs, waits for results, resolves feedback, and returns one answer.
+
+It works with normal tasks and Codex Goals. Once the task starts, Codex runs the workflow autonomously within your instructions and permissions.
+
+You can use models from OpenAI or any compatible provider already configured and authenticated in Codex. A model name alone does not create provider access.
+
+## How it works
+
+```text
+             YOU
+       Task or Codex Goal
+              |
+              v
+     ROOT MODEL / ORCHESTRATOR
+        understands and plans
+              |
+              v
+   +---------------------------+
+   | Optional specialist roles |
+   | advisor | researcher      |
+   | reviewer | supervisor     |
+   +---------------------------+
+              |
+        evidence + critique
+              |
+              v
+     ORCHESTRATOR DECIDES
+       and improves the plan
+              |
+              v
+   +---------------------------+
+   | Execution roles           |
+   | executor | writer | maker |
+   +---------------------------+
+              |
+              v
+     ORCHESTRATOR VERIFIES
+              |
+              v
+          FINAL RESULT
+```
+
+The roles and order are yours. Codex remains the lead and adapts the workflow when the task needs it.
+
+## Why use it?
+
+- **Better results:** different models challenge the plan from different perspectives.
+- **Faster work:** independent research, review, and execution can run in parallel.
+- **Lower model-weighted cost:** reserve the strongest model for judgment and use efficient models for high-volume execution.
+- **Clear ownership:** every model gets a bounded role, expected output, and place in the workflow.
+- **Flexible teams:** change the models, roles, or sequence for each task or project.
+
+Multi-agent work can use more raw tokens. Savings depend on the models, workload, context, retries, and service tier; they are not guaranteed.
 
 ## Install
 
@@ -13,270 +71,172 @@ codex plugin marketplace add Cjbuilds/Codex-Orchestration
 codex plugin add codex-orchestration@codex-orchestration
 ```
 
-Start a new Codex task after installation. In the desktop app, type `/` and choose **Codex Orchestration**. You can also choose it with `$`; CLI and IDE users can find it through `/skills` or `$`.
+Start a new Codex task after installation.
 
-Setup uses a small standard-library helper and requires Python 3.11 or newer. Codex uses `python3` on macOS/Linux or an available `py -3.11`/`python` launcher on Windows.
+In the desktop app, type `/` and choose **Codex Orchestration**. CLI and IDE users can invoke it through `/skills` or `$`.
 
-The picker is the source of truth for the exact label. Depending on the client, it may appear as `/codex-orchestration`, `$codex-orchestration`, or `$codex-orchestration:codex-orchestration`.
+Setup requires Python 3.11 or newer. Use `python3` on macOS/Linux or an available `py -3.11` or `python` launcher on Windows.
 
-## Set it up once
+## Quick start
 
-For a Sol orchestrator and Luna executor:
+### OpenAI-only team
+
+Use the model selected for the task as orchestrator and Luna as the default executor:
 
 ```text
 /codex-orchestration setup executor: GPT-5.6 Luna Extra High
 ```
 
-That is the normal setup. The skill resolves the friendly `Extra High` label to Codex's `xhigh` effort ID. If you leave out the advisor, it means `advisor: none`; Codex does not ask a second unnecessary question.
-
-This direct quickstart assumes the Sol root and Luna executor are available through the same OpenAI provider. Direct child model overrides keep the root provider; use the custom-agent path below when providers differ.
-
-Add a second-opinion model when the extra review is worth it:
+Add a second OpenAI model as advisor:
 
 ```text
-/codex-orchestration setup executor: GPT-5.6 Luna Extra High, advisor: GPT-5.6 Terra high
+/codex-orchestration setup executor: GPT-5.6 Luna Extra High, advisor: GPT-5.6 Terra High
 ```
 
-Codex resolves the display names against the active model catalog, previews the personal config change, checks the active binary plus the known PATH/Desktop clients, and applies the clean setup. Pass any other installation to the configurator with `--compat-bin`. It never changes the model selected for the current task.
+Setup previews and validates the personal routing policy before applying it. Start a new task afterward.
 
-Then start a new task, select the model you want as orchestrator, and work normally:
+### Claude Fable 5 as advisor
+
+Use Claude Fable 5 to critique plans while your selected Codex model stays in charge:
 
 ```text
-Implement the authentication changes and run the relevant tests.
+/codex-orchestration setup executor: GPT-5.6 Luna Extra High, advisor: Claude Fable 5 Extra High
 ```
 
-You do not invoke Codex Orchestration again for ordinary work. The saved policy-guided route is already part of Codex's multi-agent flow.
+This route uses the official Claude Code CLI through a bundled, read-only MCP bridge. It requires a compatible first-party Claude login and does not need an Anthropic API key in Codex.
 
-Useful controls:
+The bridge accepts one plan-review packet, disables Claude tools and session persistence, verifies the runtime model, and requires `PLAN_APPROVED` or `PLAN_REVISE`.
+
+If Claude is unavailable or returns an invalid result, Codex treats the advisor as unavailable. Failure is never approval.
+
+## Bring any model and create any role
+
+Codex supports custom agents with their own model, effort, instructions, sandbox, tools, MCP servers, and skills.
+
+Ask Codex Orchestration to create project roles for you:
+
+```text
+/codex-orchestration create these project roles:
+
+- researcher
+  model: <model-id>
+  provider: <configured-provider-id>
+  effort: high
+  sandbox: read-only
+  job: gather evidence and cite sources
+
+- writer
+  model: <model-id>
+  effort: medium
+  job: turn approved research into the final draft
+
+- reviewer
+  model: <model-id>
+  effort: high
+  sandbox: read-only
+  job: check accuracy, gaps, and weak claims
+```
+
+Codex previews the native custom-agent files under `.codex/agents/`. After you approve the files, start a new task so Codex loads the roles.
+
+Ask for personal roles only when you want them available across projects. Those files live under `~/.codex/agents/`.
+
+The plugin safely manages its built-in advisor and executor seats. Other role names are normal Codex custom agents and remain user-owned.
+
+### Common roles
+
+| Role | Good at |
+| --- | --- |
+| Advisor | Critiquing a plan before expensive work starts |
+| Executor | Implementing a bounded part of an approved plan |
+| Researcher | Gathering evidence, APIs, papers, or repository context |
+| Reviewer | Finding bugs, security risks, regressions, or missing tests |
+| Writer | Producing documentation, articles, reports, or launch copy |
+| Supervisor | Checking progress and reporting exceptions to the root |
+
+Roles should be narrow. The orchestrator remains the only model that owns the whole task.
+
+## Describe the workflow at the start of a task
+
+Once the models and roles are available, tell Codex how to use them.
+
+```text
+Use this workflow for the task:
+
+1. The model I selected for this task is the root orchestrator.
+2. The root creates the plan.
+3. Claude Fable 5 reviews the plan as advisor.
+4. The root accepts only valid feedback and revises the plan.
+5. GPT-5.6 Luna Extra High executors implement independent slices.
+6. The root integrates, tests, verifies, and gives me the final answer.
+
+Do not skip a required review. Do not let child agents create their own teams.
+```
+
+Or define a custom sequence:
+
+```text
+Researcher -> root synthesis -> reviewer -> writer -> root verification
+```
+
+Codex follows the saved and task-level instructions, while keeping authority, safety, and final judgment with the root model.
+
+## Use it with Codex Goals
+
+Set a Goal normally, then tell Codex to use your team:
+
+```text
+/goal Ship the authentication redesign with tests and migration notes.
+
+Use my configured advisor and executor workflow until the Goal is genuinely complete.
+```
+
+The Goal remains owned by Codex. This plugin does not create, pause, clear, or change Goal limits unless you explicitly use Codex's Goal controls.
+
+## Roles and permissions
+
+Subagents inherit the current task's permission mode. Choose the parent permission mode before delegation.
+
+A custom role may request a narrower sandbox such as `read-only`. It cannot silently expand the authority granted by the parent task.
+
+Codex Orchestration never bypasses approvals, changes credentials, creates provider access, or weakens your security settings.
+
+## Model and provider routes
+
+| Route | How it works |
+| --- | --- |
+| Same-provider Codex model | Exact model and effort are requested when Codex spawns the role. |
+| Claude Fable 5 advisor | Bundled root-only MCP bridge uses the authenticated Claude Code CLI. |
+| Other provider | A native custom agent pins an already configured `model_provider`. |
+| Project role | Stored in `.codex/agents/` and loaded for that trusted project. |
+| Personal role | Stored in `~/.codex/agents/` and loaded across projects. |
+
+Custom Codex providers use a compatible wire protocol and authentication setup. A raw provider endpoint or API key is not automatically interchangeable with Codex.
+
+## Useful controls
 
 ```text
 /codex-orchestration status
 /codex-orchestration status --require-effective
-/codex-orchestration setup executor: GPT-5.6 Terra high
+/codex-orchestration setup executor: GPT-5.6 Terra High
 /codex-orchestration disable
+/codex-orchestration remove custom roles personally
 ```
 
-Running `setup` again changes the saved route policy. `disable` restores the values that existed before setup and leaves unrelated Codex settings alone.
+`status --require-effective` is the automation and release gate. It exits nonzero for incompatible clients, conflicts, overrides, incomplete controls, unavailable routes, or orphaned managed roles.
 
-`status` distinguishes a policy that is merely installed from one that is effective in the current workspace. `status --require-effective` is the automation/release gate: it exits nonzero for incompatible clients, conflicts, overrides, incomplete controls, unavailable custom agents, or orphaned managed personal roles. Neither form proves a live child route or infers the selected task model's multi-agent version, so start the new task with a current v2 root such as Sol or Terra.
+`disable` restores the values that existed before built-in routing setup. It leaves unrelated Codex configuration alone.
 
-For one task only, use an inline override without changing the saved default:
+## Important boundaries
 
-```text
-/codex-orchestration executor: GPT-5.6 Terra high — fix the failing tests below.
-```
+- Codex must already be able to access the model through its current provider, a configured compatible provider, or the bundled Fable route.
+- The saved workflow is policy-guided routing, not a separate scheduler or an engine-level global executor switch.
+- Codex decides whether delegation is useful, how many independent roles to run, and when direct work is safer.
+- Exact runtime identity is called confirmed only when the client exposes effective model, provider, and effort metadata.
+- Full-history forks can inherit the root route, so different routed roles use bounded, self-contained handoffs.
+- Existing custom-agent updates and removal remain fail-closed on Windows when safe metadata preservation cannot be proven.
 
-## What it feels like
-
-```text
-         Start a normal Codex task with GPT-5.6 Sol Extra High
-                                |
-                                v
-                    SOL IS THE ORCHESTRATOR
-              understand | plan | decide | delegate
-                         /                 \
-                        /                   \
-            Simple or tightly          Non-trivial plan and
-              coupled work              advisor configured
-                  |                            |
-                  v                            v
-             Sol handles it            ADVISOR checks the plan
-                                               |
-                                               v
-                                      Sol accepts or fixes advice
-                                               |
-                         +---------------------+
-                         |
-                         v
-                Bounded execution would help?
-                         /                 \
-                       no                   yes
-                       |                     |
-                       v                     v
-                  Sol continues       LUNA / TERRA executor(s)
-                                      build bounded slice(s)
-                         \                 /
-                          +-------+-------+
-                                  |
-                                  v
-                       SOL REVIEWS AND INTEGRATES
-                         verifies | answers you
-```
-
-Codex still decides whether a plan is useful, whether to delegate, how many independent slices exist, and what can run safely in parallel. Plan and Goal behavior stay exactly where they already live in Codex.
-
-“Use Luna for execution” means the saved policy tells the root to request the Luna route for every executor that Codex chooses to delegate to. It does not force a subagent for a one-line change, mechanically enforce the request, or stop the root from doing tightly coupled work. Forcing every edit through another agent would add overhead and work against Codex's own judgment.
-
-If you say `no subagents`, that wins.
-
-## The three roles
-
-### Orchestrator: the lead
-
-This is simply the model you selected for the task. It understands the request, makes the important decisions, decides whether delegation helps, integrates every handoff, runs final verification, and owns the answer.
-
-Codex-Orchestration never asks you to configure a second top-tier orchestrator.
-
-### Advisor: the second opinion
-
-The advisor is optional. It sees a self-contained packet containing the requirements, repository facts, plan, proposed executor slices, risks, acceptance criteria, and verification checks.
-
-It looks for missed requirements, bad assumptions, shallow tasks, overlapping file ownership, unsafe parallel work, and weak tests. It reports only to the orchestrator—never to an executor—and begins with one of these signals:
-
-```text
-PLAN_APPROVED   No material gap was found in the supplied plan.
-PLAN_REVISE    Material gaps were found; prioritized fixes follow.
-```
-
-The orchestrator decides which advice to use. The advisor does not become a second boss, rewrite the plan behind the root's back, or supervise workers.
-
-When configured, advisor review is a gate for a non-trivial executor plan unless the user explicitly says `advisor best-effort`. An unavailable or malformed advisor response is never treated as approval.
-
-### Executor: the builder
-
-An executor receives one bounded task packet: objective, relevant context, constraints, owned files, dependencies, acceptance criteria, and the smallest useful verification command.
-
-It implements that slice and reports changed files, checks, blockers, and remaining risks to the orchestrator. It does not contact the advisor, broaden the project, or spawn another team.
-
-## How the one-time config works
-
-Codex-Orchestration does not add a proxy or invent a new scheduler. It configures the current Codex multi-agent tool.
-
-The managed part of `~/.codex/config.toml` is conceptually this small:
-
-```toml
-[features.multi_agent_v2]
-hide_spawn_agent_metadata = false
-tool_namespace = "agents"
-
-multi_agent_mode_hint_text = """
-The current task model is the root orchestrator. Codex decides when delegation
-helps. Routed children stay bounded and never spawn descendants.
-"""
-
-usage_hint_text = """
-For executor work, spawn model = "gpt-5.6-luna",
-reasoning_effort = "xhigh", fork_turns = "none".
-Never silently substitute the root model.
-"""
-```
-
-The real generated text also carries the advisor rules, task-packet contract, user-override rules, and an ownership marker used for safe updates and removal.
-
-Four details matter:
-
-1. `hide_spawn_agent_metadata = false` exposes the per-spawn `model`, `reasoning_effort`, `agent_type`, and service-tier inputs. It does not choose a child model.
-2. `tool_namespace = "agents"` puts the configurable v2 team tools under `agents`. In the Desktop build live-tested on July 10, 2026 (`0.144.0-alpha.4`), the reserved `collaboration.spawn_agent` schema rejected the expanded model/effort route; `agents` accepted it and spawned Luna at `xhigh`. This is a control-surface setting, not an executor selector.
-3. `usage_hint_text` puts the chosen Luna or Terra route directly on Codex's spawn tool. This is what tells the root which model and effort to request for delegated execution.
-4. Codex-Orchestration deliberately uses `fork_turns = "none"` for every different child route. Full-history forks inherit the root and reject overrides; Codex can also accept a positive partial fork, but `none` avoids copied history and requires a deliberate self-contained packet.
-
-The installer writes those values through Codex App Server's own `config/read` and atomic `config/batchWrite` APIs. That preserves unrelated tables, comments, inline comments, and custom multi-agent limits; validates the complete config; and detects concurrent edits. The policy takes effect in new tasks. A small namespaced state file records its schema, config path, selected seats, the four managed values, and the exact pre-setup snapshots needed by `disable`; it uses restrictive file permissions where supported. A normal clean setup contains generated policy text, the namespace value, seat IDs, and that restoration metadata. If you explicitly replace your own hint text, its exact old value must be kept for restoration—so never put credentials in routing hints.
-
-The setup sets `tool_namespace = "agents"` because the currently validated Desktop route needs that namespace for expanded child-model controls. It changes the callable namespace; it does not name Luna, force a spawn, or replace Codex's delegation judgment.
-
-The setup also does **not** force `enabled = true` for a Sol or Terra root. Current Sol and Terra model metadata already selects multi-agent v2. Forcing the feature globally can produce an under-development warning and can conflict with older `agents.max_threads` configuration.
-
-## What config can and cannot prove
-
-The full policy becomes durable spawn-tool guidance for later tasks that use a v2 root and do not override it with a higher-precedence config layer. Codex still decides whether to delegate and must issue the requested route; exact child use is confirmed only by runtime evidence. This is policy-guided routing, not an engine-level executor selector.
-
-But these two lines alone are not an executor configuration:
-
-```toml
-[features.multi_agent_v2]
-hide_spawn_agent_metadata = false
-tool_namespace = "agents"
-```
-
-Those two lines configure the control surface used by the currently validated Desktop build: spawn metadata is visible and the v2 tools live under `agents`. They still do not configure an executor. Neither says “use Luna.” Neither line names an effort, a fork mode, or any root/child rule. Without `usage_hint_text`, no persistent default tells Sol to request Luna when it delegates, so the root can still spawn its inherited model.
-
-The full generated policy adds the missing model route, effort, fork mode, root/child boundaries, advisor behavior, and failure rule. The skill is the setup and control plane: it resolves real model IDs, validates compatibility, installs safely, reports status, supports an advisor, handles cross-provider custom agents, and reverses its own changes. It is not consuming tokens in every later task.
-
-One hard boundary remains: Codex has no global `executor_model = ...` engine switch today. Same-provider config routing is tool-level policy plus a runtime-validated `model` argument, not a hardcoded scheduler. Setup can prove config parsing and policy effectiveness; it cannot bind the provider of a future root task or prove a future spawn. When the spawn tool accepts an exact route, call that `route accepted`. Call a model `used and confirmed` only when the client explicitly exposes effective runtime metadata. A namespaced custom agent provides the stronger persistent pin needed for cross-provider routing.
-
-## Current compatibility
-
-| Situation | Behavior |
-| --- | --- |
-| Current Codex with a Sol or Terra root | One-time native policy; use Codex normally afterward. |
-| Desktop `0.144.0-alpha.4`, live-tested July 10, 2026 | `agents` accepted `model=gpt-5.6-luna` plus `reasoning_effort=xhigh`; the default `collaboration` namespace rejected the expanded schema. Capability-test other builds. |
-| Luna selected as the root | Luna currently declares multi-agent v1, so the v2 policy is not the right root route. Luna is best used here as a child of a Sol/Terra v2 root. |
-| Older Codex that rejects `multi_agent_mode_hint_text` | The installer refuses to break its shared config and keeps the per-task skill fallback available. Update that client before enabling the persistent preset. |
-| OpenAI root and OpenAI executor | Direct per-spawn model route; simplest setup. |
-| Different provider for advisor or executor | Use a loaded, namespaced custom agent with an already configured provider. |
-| Windows custom-agent path | New managed roles can be created, but updating or removing existing role files fails closed because inode/metadata-safe replacement is unavailable. Native App Server policy setup is a separate path. |
-
-Desktop and CLI normally share `~/.codex/config.toml`. The setup asks the target binary, the `codex` on your PATH, and the Desktop binary when present to parse the complete four-field preset in an isolated home. That proves config compatibility, not a live child route. Report `route accepted` or `used and confirmed` only from the exact runtime evidence described above; the installer does not guess compatibility from a version number.
-
-A trusted project's `.codex/config.toml` or a managed layer can override the personal preset in that workspace. Run `status` from the target project; setup rolls back if the policy is already overridden there, but another project can have different higher-precedence settings.
-
-Named Codex profiles (`codex --profile ...`) are separate user layers. The one-command setup manages the default user config; a profile can override it. If you rely on named profiles, inspect that profile separately or use the task-local fallback instead of assuming the base policy wins.
-
-Do not use Codex Fast mode when the goal is maximum allowance savings. A supported child may inherit the root's priority service tier, which can reduce the saving even when the child model is Luna.
-
-## Older-client fallback
-
-If a client cannot load the persistent policy, invoke the skill with the work in the same prompt:
-
-```text
-/codex-orchestration executor: GPT-5.6 Luna Extra High — implement the requested feature.
-```
-
-The skill uses the strongest child control that client exposes. On current v2 surfaces it passes the exact model and effort with `fork_turns = "none"`. If exact routing is unavailable, it says so. It never counts an inherited-root child as the requested executor.
-
-## Advisor or executor from another provider
-
-A model name alone cannot create provider access. An Anthropic advisor, for example, needs an existing authenticated Codex-compatible provider plus a personal custom agent loaded before the task starts.
-
-Codex custom providers use the Responses wire protocol. A raw Anthropic Messages endpoint and key are not interchangeable. A supported route such as Amazon Bedrock may also be appropriate.
-
-Once the provider is configured and tested, setup can save the namespaced roles:
-
-```text
-/codex-orchestration setup executor: GPT-5.6 Luna Extra High, advisor: Fable 5 Extra High, advisor provider: <existing-provider-id>
-```
-
-For this path, Codex-Orchestration creates only:
-
-```text
-~/.codex/agents/codex-orchestration-executor-<personal-id>.toml
-~/.codex/agents/codex-orchestration-advisor-<personal-id>.toml
-```
-
-The matching role names carry the same stable, `CODEX_HOME`-specific suffix. That prevents older project-scoped Codex-Orchestration roles from accidentally shadowing the personal route. Setup verifies the personal files and refuses a same-name project collision in the current workspace.
-
-It never writes credentials or creates a provider definition. See [Codex custom providers](https://learn.chatgpt.com/docs/config-file/config-advanced#custom-model-providers).
-
-Custom-agent files and the native policy live in separate storage systems, so cross-provider setup is a two-phase operation rather than one atomic commit. If the native phase fails after roles were created, Codex-Orchestration previews and removes only the newly managed roles. After an interruption, run `status --require-effective`; it reports managed personal roles that the native policy does not reference. Edited or user-owned files are never removed automatically.
-
-Project-scoped custom agents remain available for teams that want inspectable role files in a trusted repository. Project roles have higher precedence, so a deliberately duplicated personal role name can shadow a global agent route. Run `status` in the project before relying on a custom-agent preset.
-
-## Can it save about 65%?
-
-It can save roughly 65% of **model-weighted Codex credits** in an executor-heavy example. It cannot promise 65% fewer raw tokens.
-
-OpenAI's published token credit rates, checked July 9, 2026, price GPT-5.6 Luna at 20% of GPT-5.6 Sol for input, cached input, and output. If 20% of a comparable token mix stays with Sol and 80% moves to Luna:
-
-```text
-relative credits = 0.20 + (0.80 × 0.20) = 0.36
-illustrative reduction                         = 64%
-```
-
-That is the “about 65%” claim. In practice, the orchestrator still pays for planning, review, integration, and verification. Advisor calls, copied context, retries, tools, and unnecessary agents add overhead. Multi-agent work can use more raw tokens even while consuming fewer high-end-model credits.
-
-Lower model-weighted credits can make shared five-hour and applicable weekly allowances last longer, but the extension depends on the workload, plan, context, service tier, and real delegation mix; it is not guaranteed.
-
-The benefit is simple: you do not need the frontier model for every stage. A robust plan plus a capable coding model can handle much of the execution volume, while the strongest model checks the result before it reaches you.
-
-## What it never changes
-
-- The current task model remains the only orchestrator.
-- Codex still decides whether to plan, delegate, or work directly.
-- No fixed three-agent or five-agent swarm is created.
-- Goal state is not created or changed by this plugin.
-- Executors never coordinate around the orchestrator.
-- Permissions, approvals, tools, hooks, and credentials are not weakened.
-- An accepted route is not reported as a confirmed runtime model unless the client exposes that metadata.
+If you say `no subagents`, that always wins.
 
 ## Update
 
@@ -285,47 +245,47 @@ codex plugin marketplace upgrade codex-orchestration
 codex plugin add codex-orchestration@codex-orchestration
 ```
 
-Start a new task so Codex loads the updated skill. Run `/codex-orchestration status --require-effective` to gate an existing native preset; run `setup` again to update its managed policy.
-
-Custom agents created by versions 0.1–0.3 remain supported. The older backup-first migration command is still available when exact legacy output is detected; edited or user-owned files are never guessed at or deleted.
+Start a new task so Codex loads the updated plugin and roles.
 
 ## Uninstall
 
-First disable the persistent policy:
+First disable the saved routing policy:
 
 ```text
 /codex-orchestration disable
 ```
 
-If you created cross-provider or project custom agents, use `/codex-orchestration remove custom roles personally` or ask it to remove the roles for the current project. It previews the removal and deletes only fully validated namespaced files, including the home-specific v0.4+ names when present. On Windows, existing managed custom-role removal is intentionally unavailable and requires manual review; native policy disable remains separate.
-
-Then remove the plugin:
+Preview and remove plugin-managed custom roles if you created them. Review user-owned arbitrary roles separately.
 
 ```bash
 codex plugin remove codex-orchestration@codex-orchestration
 codex plugin marketplace remove codex-orchestration
 ```
 
-Uninstalling the plugin does not silently delete a policy or custom-agent file that may still affect future tasks.
+Removing the plugin does not silently delete configuration that may still affect later tasks.
 
 ## Develop and validate
 
 ```bash
+python3 -m pip install -r requirements-dev.txt
+python3 -m compileall -q plugins tests scripts
+python3 -m ruff check plugins tests scripts
 python3 -m unittest discover -s tests -v
+python3 tests/plugin_lifecycle_smoke.py
+python3 scripts/release_check.py
 ```
 
-The suite covers the native App Server protocol, capability detection, generated policy contract, setup/status/disable, exact restoration, custom agents, packaging, migration safety, model inspection, and an isolated real-CLI marketplace lifecycle. See the [production-readiness audit](docs/production-readiness-audit.md), [security policy](SECURITY.md), and [release process](RELEASE.md) for the maintained ship gates.
+See the [production-readiness audit](docs/production-readiness-audit.md), [security policy](SECURITY.md), and [release process](RELEASE.md).
+
+Technical details live in [providers and models](plugins/codex-orchestration/skills/codex-orchestration/references/providers-and-models.md).
 
 ## Design sources
 
 - [OpenAI: Subagents and custom agents](https://learn.chatgpt.com/docs/agent-configuration/subagents)
-- [OpenAI: Codex App Server](https://learn.chatgpt.com/docs/app-server)
 - [OpenAI: Codex configuration](https://learn.chatgpt.com/docs/config-file/config-reference)
-- [OpenAI: Build skills](https://learn.chatgpt.com/docs/build-skills)
+- [OpenAI: Custom model providers](https://learn.chatgpt.com/docs/config-file/config-advanced#custom-model-providers)
+- [OpenAI: Codex App Server](https://learn.chatgpt.com/docs/app-server)
 - [OpenAI: Build plugins](https://learn.chatgpt.com/docs/build-plugins)
-- [OpenAI: Codex pricing and usage limits](https://learn.chatgpt.com/docs/pricing)
-- [Anthropic: Building effective agents](https://www.anthropic.com/engineering/building-effective-agents)
-- [Anthropic: How we built our multi-agent research system](https://www.anthropic.com/engineering/multi-agent-research-system)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Codex-Orchestration
 
-Use your strongest model where judgment matters. Let a faster, cheaper model handle the execution work that consumes most of the context and usage.
+Use your strongest model where judgment matters. Let a faster, cheaper model handle eligible execution work that consumes most of the context and usage.
 
 The model you select when you start a Codex task is already the orchestrator. If you start with GPT-5.6 Sol Extra High, Sol plans, delegates, reviews, and answers. You only choose the executor and, if you want one, an advisor.
 
@@ -45,19 +45,20 @@ Then start a new task, select the model you want as orchestrator, and work norma
 Implement the authentication changes and run the relevant tests.
 ```
 
-You do not invoke Codex Orchestration again for ordinary work. The saved policy is already part of Codex's multi-agent flow.
+You do not invoke Codex Orchestration again for ordinary work. The saved policy-guided route is already part of Codex's multi-agent flow.
 
 Useful controls:
 
 ```text
 /codex-orchestration status
+/codex-orchestration status --require-effective
 /codex-orchestration setup executor: GPT-5.6 Terra high
 /codex-orchestration disable
 ```
 
-Running `setup` again changes the default. `disable` restores the values that existed before setup and leaves unrelated Codex settings alone.
+Running `setup` again changes the saved route policy. `disable` restores the values that existed before setup and leaves unrelated Codex settings alone.
 
-`status` distinguishes a policy that is merely installed from one that is effective in the current workspace. It cannot infer the selected task model's multi-agent version, so start the new task with a current v2 root such as Sol or Terra.
+`status` distinguishes a policy that is merely installed from one that is effective in the current workspace. `status --require-effective` is the automation/release gate: it exits nonzero for incompatible clients, conflicts, overrides, incomplete controls, unavailable custom agents, or orphaned managed personal roles. Neither form proves a live child route or infers the selected task model's multi-agent version, so start the new task with a current v2 root such as Sol or Terra.
 
 For one task only, use an inline override without changing the saved default:
 
@@ -104,7 +105,7 @@ For one task only, use an inline override without changing the saved default:
 
 Codex still decides whether a plan is useful, whether to delegate, how many independent slices exist, and what can run safely in parallel. Plan and Goal behavior stay exactly where they already live in Codex.
 
-“Use Luna for execution” means the saved policy supplies the Luna route for every executor that Codex chooses to delegate to. It does not force a subagent for a one-line change, or stop the root from doing tightly coupled work. Forcing every edit through another agent would add overhead and work against Codex's own judgment.
+“Use Luna for execution” means the saved policy tells the root to request the Luna route for every executor that Codex chooses to delegate to. It does not force a subagent for a one-line change, mechanically enforce the request, or stop the root from doing tightly coupled work. Forcing every edit through another agent would add overhead and work against Codex's own judgment.
 
 If you say `no subagents`, that wins.
 
@@ -175,9 +176,9 @@ The setup sets `tool_namespace = "agents"` because the currently validated Deskt
 
 The setup also does **not** force `enabled = true` for a Sol or Terra root. Current Sol and Terra model metadata already selects multi-agent v2. Forcing the feature globally can produce an under-development warning and can conflict with older `agents.max_threads` configuration.
 
-## Is config alone enough?
+## What config can and cannot prove
 
-Yes—the full policy becomes the saved routing default for later tasks that use a v2 root and do not override it with a higher-precedence config layer. Codex still decides whether to delegate, and exact child use is confirmed only by runtime evidence. That is the point of the one-time setup.
+The full policy becomes durable spawn-tool guidance for later tasks that use a v2 root and do not override it with a higher-precedence config layer. Codex still decides whether to delegate and must issue the requested route; exact child use is confirmed only by runtime evidence. This is policy-guided routing, not an engine-level executor selector.
 
 But these two lines alone are not an executor configuration:
 
@@ -191,7 +192,7 @@ Those two lines configure the control surface used by the currently validated De
 
 The full generated policy adds the missing model route, effort, fork mode, root/child boundaries, advisor behavior, and failure rule. The skill is the setup and control plane: it resolves real model IDs, validates compatibility, installs safely, reports status, supports an advisor, handles cross-provider custom agents, and reverses its own changes. It is not consuming tokens in every later task.
 
-One honest boundary remains: Codex has no global `executor_model = ...` engine switch today. Same-provider config routing is strong tool-level guidance plus a runtime-validated `model` argument, not a new hardcoded scheduler. When the spawn tool accepts an exact route, Codex has validated the requested model and effort; call that `route accepted`. Call a model `used and confirmed` only when the client explicitly exposes effective runtime metadata. A namespaced custom agent provides the stronger persistent pin needed for cross-provider routing.
+One hard boundary remains: Codex has no global `executor_model = ...` engine switch today. Same-provider config routing is tool-level policy plus a runtime-validated `model` argument, not a hardcoded scheduler. Setup can prove config parsing and policy effectiveness; it cannot bind the provider of a future root task or prove a future spawn. When the spawn tool accepts an exact route, call that `route accepted`. Call a model `used and confirmed` only when the client explicitly exposes effective runtime metadata. A namespaced custom agent provides the stronger persistent pin needed for cross-provider routing.
 
 ## Current compatibility
 
@@ -203,6 +204,7 @@ One honest boundary remains: Codex has no global `executor_model = ...` engine s
 | Older Codex that rejects `multi_agent_mode_hint_text` | The installer refuses to break its shared config and keeps the per-task skill fallback available. Update that client before enabling the persistent preset. |
 | OpenAI root and OpenAI executor | Direct per-spawn model route; simplest setup. |
 | Different provider for advisor or executor | Use a loaded, namespaced custom agent with an already configured provider. |
+| Windows custom-agent path | New managed roles can be created, but updating or removing existing role files fails closed because inode/metadata-safe replacement is unavailable. Native App Server policy setup is a separate path. |
 
 Desktop and CLI normally share `~/.codex/config.toml`. The setup asks the target binary, the `codex` on your PATH, and the Desktop binary when present to parse the complete four-field preset in an isolated home. That proves config compatibility, not a live child route. Report `route accepted` or `used and confirmed` only from the exact runtime evidence described above; the installer does not guess compatibility from a version number.
 
@@ -245,6 +247,8 @@ The matching role names carry the same stable, `CODEX_HOME`-specific suffix. Tha
 
 It never writes credentials or creates a provider definition. See [Codex custom providers](https://learn.chatgpt.com/docs/config-file/config-advanced#custom-model-providers).
 
+Custom-agent files and the native policy live in separate storage systems, so cross-provider setup is a two-phase operation rather than one atomic commit. If the native phase fails after roles were created, Codex-Orchestration previews and removes only the newly managed roles. After an interruption, run `status --require-effective`; it reports managed personal roles that the native policy does not reference. Edited or user-owned files are never removed automatically.
+
 Project-scoped custom agents remain available for teams that want inspectable role files in a trusted repository. Project roles have higher precedence, so a deliberately duplicated personal role name can shadow a global agent route. Run `status` in the project before relying on a custom-agent preset.
 
 ## Can it save about 65%?
@@ -281,7 +285,7 @@ codex plugin marketplace upgrade codex-orchestration
 codex plugin add codex-orchestration@codex-orchestration
 ```
 
-Start a new task so Codex loads the updated skill. Run `/codex-orchestration status` to inspect an existing native preset; run `setup` again to update its managed policy.
+Start a new task so Codex loads the updated skill. Run `/codex-orchestration status --require-effective` to gate an existing native preset; run `setup` again to update its managed policy.
 
 Custom agents created by versions 0.1–0.3 remain supported. The older backup-first migration command is still available when exact legacy output is detected; edited or user-owned files are never guessed at or deleted.
 
@@ -293,7 +297,7 @@ First disable the persistent policy:
 /codex-orchestration disable
 ```
 
-If you created cross-provider or project custom agents, use `/codex-orchestration remove custom roles personally` or ask it to remove the roles for the current project. It previews the removal and deletes only fully validated namespaced files, including the home-specific v0.4 names when present.
+If you created cross-provider or project custom agents, use `/codex-orchestration remove custom roles personally` or ask it to remove the roles for the current project. It previews the removal and deletes only fully validated namespaced files, including the home-specific v0.4+ names when present. On Windows, existing managed custom-role removal is intentionally unavailable and requires manual review; native policy disable remains separate.
 
 Then remove the plugin:
 
@@ -310,7 +314,7 @@ Uninstalling the plugin does not silently delete a policy or custom-agent file t
 python3 -m unittest discover -s tests -v
 ```
 
-The suite covers the native App Server protocol, capability detection, generated policy contract, setup/status/disable, exact restoration, custom agents, packaging, migration safety, model inspection, and an isolated real-CLI marketplace lifecycle.
+The suite covers the native App Server protocol, capability detection, generated policy contract, setup/status/disable, exact restoration, custom agents, packaging, migration safety, model inspection, and an isolated real-CLI marketplace lifecycle. See the [production-readiness audit](docs/production-readiness-audit.md), [security policy](SECURITY.md), and [release process](RELEASE.md) for the maintained ship gates.
 
 ## Design sources
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,21 @@
+# Release process
+
+1. Replace `Unreleased` in `CHANGELOG.md` with the release date.
+2. Confirm `.codex-plugin/plugin.json`, the changelog, the installed package, and lifecycle fixture all use the same semantic version.
+3. Run:
+
+   ```bash
+   python3 -m compileall -q plugins tests scripts
+   python3 -m ruff check plugins tests scripts
+   python3 -m unittest discover -s tests -v
+   python3 tests/plugin_lifecycle_smoke.py
+   python3 scripts/release_check.py
+   ```
+
+4. From a new Desktop task, verify one direct same-provider child route. Record `route accepted`; record `used and confirmed` only if the client exposes effective child model/provider/effort metadata.
+5. Merge only after every protected check passes.
+6. Create a signed annotated tag named `v<manifest-version>` at the reviewed merge commit.
+7. Re-run `python3 scripts/release_check.py --require-tag` and publish a GitHub release from that tag using the matching changelog section.
+8. Install from the public marketplace in a clean Codex home, start a new task, and verify setup, `status --require-effective`, and disable.
+
+Never move a published release tag. If a release is bad, fix forward with a new version and retain the old tag as provenance.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,9 +13,10 @@
    ```
 
 4. From a new Desktop task, verify one direct same-provider child route. Record `route accepted`; record `used and confirmed` only if the client exposes effective child model/provider/effort metadata.
-5. Merge only after every protected check passes.
-6. Create a signed annotated tag named `v<manifest-version>` at the reviewed merge commit.
-7. Re-run `python3 scripts/release_check.py --require-tag` and publish a GitHub release from that tag using the matching changelog section.
-8. Install from the public marketplace in a clean Codex home, start a new task, and verify setup, `status --require-effective`, and disable.
+5. If Claude Fable 5 is included in the release, verify setup, status, one `review_plan` call, the exact runtime model metadata, and disable/restore from a first-party Claude login.
+6. Merge only after every protected check passes.
+7. Create a signed annotated tag named `v<manifest-version>` at the reviewed merge commit.
+8. Re-run `python3 scripts/release_check.py --require-tag` and publish a GitHub release from that tag using the matching changelog section.
+9. Install from the public marketplace in a clean Codex home, start a new task, and verify setup, `status --require-effective`, and disable.
 
 Never move a published release tag. If a release is bad, fix forward with a new version and retain the old tag as provenance.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security policy
+
+## Supported versions
+
+Security fixes are made on the latest released version. Upgrade before reporting a problem that is already fixed on `main`.
+
+## Report a vulnerability
+
+Do not open a public issue for a suspected vulnerability. Use [GitHub private vulnerability reporting](https://github.com/Cjbuilds/Codex-Orchestration/security/advisories/new) and include:
+
+- the affected version and Codex client version;
+- operating system and installation scope;
+- a minimal reproduction;
+- the security impact and any known workaround.
+
+Do not include credentials, tokens, or private configuration. You should receive an acknowledgement within seven days. A coordinated disclosure date will be agreed after the impact and fix are verified.
+
+## Security boundaries
+
+Codex-Orchestration writes only its documented Codex routing fields and managed custom-agent files. It does not create providers, handle provider credentials, weaken sandbox or approval settings, or guarantee that policy-guided routing is engine-enforced. See the README for the exact runtime-verification boundary.

--- a/docs/production-readiness-audit.md
+++ b/docs/production-readiness-audit.md
@@ -6,11 +6,14 @@ Audit date: 2026-07-12. Baseline: `a674a81` (`0.4.0`).
 
 | Severity | Shortcoming | Resolution in 0.5.0 |
 | --- | --- | --- |
+| High | The README led with internal routing details and did not explain the product's general multi-model role workflow. | Lead with a plain-language definition, a provider-neutral workflow diagram, the value proposition, and then installation and examples. |
+| High | Claude Fable 5 was developed separately, so the launch branch could not truthfully advertise the requested advisor workflow. | Integrate the opt-in, root-only Fable bridge, disabled by default, with login checks, runtime-model confirmation, and fail-closed review decisions. |
 | High | `main` was an unprotected mutable distribution branch. | Require pull requests, current required checks, resolved conversations, admin enforcement, and block force-push/deletion. |
 | High | Same-provider routing could be mistaken for an engine-enforced executor selector. | Describe it as policy-guided routing and distinguish config compatibility, effective policy, accepted route, and confirmed runtime identity. |
 | Medium | Restore-state persistence failure ignored the config rollback status and could report false success. | Validate rollback status and report that managed fields may remain whenever rollback is not proven. |
 | Medium | Status always exited zero for conflicts, overrides, incomplete controls, or unavailable roles. | Add `--require-effective` and negative-path coverage. |
 | Medium | Cross-provider setup spans separate role-file and native-policy transactions. | Detect orphaned managed roles, require bounded cleanup on phase-two failure, and document interruption recovery. |
+| Medium | The skill explained only fixed advisor/executor seats, leaving arbitrary project roles, workflow ordering, Goal behavior, and permissions ambiguous. | Add native custom-role creation rules, project and personal scopes, user ownership, provider checks, bounded handoffs, and explicit Goal/permission boundaries. |
 | Medium | GitHub Actions used mutable major tags and the repository did not require SHA pinning. | Pin actions to full reviewed SHAs, restrict Actions, and add Dependabot updates. |
 | Medium | Windows support was claimed without CI or the custom-role update/removal limitation. | Add Windows/macOS portability checks and document the Windows fail-closed boundary. |
 | Medium | Released version `0.4.0` had no immutable tag or GitHub release. | Add a tag/version release gate; `0.5.0` must ship from a signed `v0.5.0` tag and matching GitHub release. |
@@ -23,6 +26,8 @@ Audit date: 2026-07-12. Baseline: `a674a81` (`0.4.0`).
 - Codex currently exposes no global engine field that hard-wires one executor model. The native path installs durable routing policy on the spawn tool; the root still decides whether to delegate and supplies the route.
 - Setup-time config parsing cannot prove a future signed-in task will accept a route or expose its effective child identity. A live release check is required.
 - Direct model overrides inherit the root provider. Cross-provider use requires a provider-pinned custom agent that the user configured and authenticated separately.
+- Claude Fable 5 is a narrow built-in exception: it uses the authenticated first-party Claude Code CLI through a read-only local MCP bridge and is available only as the root's plan advisor.
+- "Any model" means a model reachable through Codex's current provider, an already configured compatible custom provider, or a deliberately bundled bridge. The plugin does not create accounts, credentials, or protocol compatibility.
 - Custom-agent updates and removal remain fail-closed on Windows because the implementation cannot preserve the same inode/metadata guarantees there. Native App Server policy setup is a separate path.
 - The two cross-provider storage systems cannot be committed atomically by the current public interfaces. Status and bounded managed-role cleanup provide recovery without deleting edited or user-owned files.
 

--- a/docs/production-readiness-audit.md
+++ b/docs/production-readiness-audit.md
@@ -1,0 +1,29 @@
+# Production-readiness audit
+
+Audit date: 2026-07-12. Baseline: `a674a81` (`0.4.0`).
+
+## Release blockers found
+
+| Severity | Shortcoming | Resolution in 0.5.0 |
+| --- | --- | --- |
+| High | `main` was an unprotected mutable distribution branch. | Require pull requests, current required checks, resolved conversations, admin enforcement, and block force-push/deletion. |
+| High | Same-provider routing could be mistaken for an engine-enforced executor selector. | Describe it as policy-guided routing and distinguish config compatibility, effective policy, accepted route, and confirmed runtime identity. |
+| Medium | Restore-state persistence failure ignored the config rollback status and could report false success. | Validate rollback status and report that managed fields may remain whenever rollback is not proven. |
+| Medium | Status always exited zero for conflicts, overrides, incomplete controls, or unavailable roles. | Add `--require-effective` and negative-path coverage. |
+| Medium | Cross-provider setup spans separate role-file and native-policy transactions. | Detect orphaned managed roles, require bounded cleanup on phase-two failure, and document interruption recovery. |
+| Medium | GitHub Actions used mutable major tags and the repository did not require SHA pinning. | Pin actions to full reviewed SHAs, restrict Actions, and add Dependabot updates. |
+| Medium | Windows support was claimed without CI or the custom-role update/removal limitation. | Add Windows/macOS portability checks and document the Windows fail-closed boundary. |
+| Medium | Released version `0.4.0` had no immutable tag or GitHub release. | Add a tag/version release gate; `0.5.0` must ship from a signed `v0.5.0` tag and matching GitHub release. |
+| Low | Code scanning, dependency alerts, private vulnerability reporting, ownership, contribution, and release policies were absent. | Add CodeQL, Dependabot, `SECURITY.md`, `CODEOWNERS`, `CONTRIBUTING.md`, and `RELEASE.md`; enable repository security features. |
+| Low | CI had no static-quality baseline. | Add a pinned Ruff check and Dependabot updates for the development tool. |
+| Low | The documented fixed v2 concurrency count was stale. | Defer to the effective Codex/config limit instead of hard-coding a count. |
+
+## Deliberate boundaries that remain
+
+- Codex currently exposes no global engine field that hard-wires one executor model. The native path installs durable routing policy on the spawn tool; the root still decides whether to delegate and supplies the route.
+- Setup-time config parsing cannot prove a future signed-in task will accept a route or expose its effective child identity. A live release check is required.
+- Direct model overrides inherit the root provider. Cross-provider use requires a provider-pinned custom agent that the user configured and authenticated separately.
+- Custom-agent updates and removal remain fail-closed on Windows because the implementation cannot preserve the same inode/metadata guarantees there. Native App Server policy setup is a separate path.
+- The two cross-provider storage systems cannot be committed atomically by the current public interfaces. Status and bounded managed-role cleanup provide recovery without deleting edited or user-owned files.
+
+These are platform boundaries, not hidden guarantees. A future Codex-native executor selector or transactional custom-agent API would justify revisiting them.

--- a/plugins/codex-orchestration/.codex-plugin/plugin.json
+++ b/plugins/codex-orchestration/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-orchestration",
   "version": "0.5.0",
-  "description": "Configure Codex once so the selected task model leads while efficient models handle delegated execution.",
+  "description": "Bring compatible models into Codex, assign roles, and run them as one guided workflow.",
   "author": {
     "name": "CJ Zafir",
     "url": "https://github.com/Cjbuilds"
@@ -17,23 +17,25 @@
     "usage-limits"
   ],
   "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
   "interface": {
     "displayName": "Codex Orchestration",
-    "shortDescription": "One-time efficient executor routing",
-    "longDescription": "Keep the selected task model as Codex's orchestrator, optionally add a root-facing plan advisor, and persist an efficient executor route through Codex's own multi-agent configuration.",
+    "shortDescription": "Build multi-model Codex workflows",
+    "longDescription": "Assign compatible models to roles such as advisor, executor, or researcher, describe the handoff order, and let Codex orchestrate the work.",
     "developerName": "CJ Zafir",
     "category": "Productivity",
     "websiteURL": "https://github.com/Cjbuilds/Codex-Orchestration",
     "brandColor": "#C8A951",
     "capabilities": [
-      "Persistent model routing",
+      "Multi-model workflows",
+      "Custom agent roles",
       "Plan review",
-      "Subagent workflows"
+      "Efficient execution"
     ],
     "defaultPrompt": [
-      "/codex-orchestration setup executor: GPT-5.6 Luna Extra High",
-      "$codex-orchestration:codex-orchestration status",
-      "$codex-orchestration:codex-orchestration disable"
+      "/codex-orchestration setup executor: GPT-5.6 Luna Extra High, advisor: Claude Fable 5 Extra High",
+      "/codex-orchestration create project role: researcher",
+      "$codex-orchestration:codex-orchestration status"
     ]
   }
 }

--- a/plugins/codex-orchestration/.codex-plugin/plugin.json
+++ b/plugins/codex-orchestration/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-orchestration",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Configure Codex once so the selected task model leads while efficient models handle delegated execution.",
   "author": {
     "name": "CJ Zafir",
@@ -23,6 +23,8 @@
     "longDescription": "Keep the selected task model as Codex's orchestrator, optionally add a root-facing plan advisor, and persist an efficient executor route through Codex's own multi-agent configuration.",
     "developerName": "CJ Zafir",
     "category": "Productivity",
+    "websiteURL": "https://github.com/Cjbuilds/Codex-Orchestration",
+    "brandColor": "#C8A951",
     "capabilities": [
       "Persistent model routing",
       "Plan review",

--- a/plugins/codex-orchestration/.codex-plugin/plugin.json
+++ b/plugins/codex-orchestration/.codex-plugin/plugin.json
@@ -33,7 +33,7 @@
       "Efficient execution"
     ],
     "defaultPrompt": [
-      "/codex-orchestration setup executor: GPT-5.6 Luna Extra High, advisor: Claude Fable 5 Extra High",
+      "/codex-orchestration setup executor: GPT-5.6 Luna Extra High, advisor: Claude Fable 5 High",
       "/codex-orchestration create project role: researcher",
       "$codex-orchestration:codex-orchestration status"
     ]

--- a/plugins/codex-orchestration/.mcp.json
+++ b/plugins/codex-orchestration/.mcp.json
@@ -1,0 +1,29 @@
+{
+  "mcpServers": {
+    "fable-advisor-python3": {
+      "command": "python3",
+      "args": [
+        "skills/codex-orchestration/scripts/fable_advisor_mcp.py"
+      ],
+      "cwd": ".",
+      "enabled": false
+    },
+    "fable-advisor-python": {
+      "command": "python",
+      "args": [
+        "skills/codex-orchestration/scripts/fable_advisor_mcp.py"
+      ],
+      "cwd": ".",
+      "enabled": false
+    },
+    "fable-advisor-py": {
+      "command": "py",
+      "args": [
+        "-3.11",
+        "skills/codex-orchestration/scripts/fable_advisor_mcp.py"
+      ],
+      "cwd": ".",
+      "enabled": false
+    }
+  }
+}

--- a/plugins/codex-orchestration/skills/codex-orchestration/SKILL.md
+++ b/plugins/codex-orchestration/skills/codex-orchestration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: codex-orchestration
-description: Configure or use Codex's current task model as the root orchestrator with a chosen efficient executor and optional root-only plan advisor. Use when the user invokes Codex Orchestration to set up, inspect, change, disable, or temporarily override multi-model subagent routing. Preserve Codex's own planning, Goal, delegation, integration, and verification behavior.
+description: Build multi-model Codex workflows by assigning compatible models to roles such as advisor, executor, researcher, reviewer, writer, or supervisor. Use when the user invokes Codex Orchestration to create custom roles, define a workflow, or set up, inspect, change, disable, or temporarily override model routing. Keep the selected task model as root and preserve Codex's planning, Goal, permissions, integration, and verification behavior.
 ---
 
 # Codex Orchestration
@@ -11,19 +11,24 @@ This skill adds a model route to Codex's existing multi-agent flow. It does not 
 
 ## Understand the command
 
-Support four simple forms:
+Support these simple forms:
 
 ```text
 /codex-orchestration setup executor: GPT-5.6 Luna Extra High
+/codex-orchestration setup executor: GPT-5.6 Luna Extra High, advisor: Claude Fable 5 Extra High
+/codex-orchestration create project role: researcher
+/codex-orchestration create personal roles: researcher, writer, reviewer
 /codex-orchestration status
 /codex-orchestration disable
 /codex-orchestration remove custom roles personally
 /codex-orchestration executor: GPT-5.6 Terra high — <one task only>
 ```
 
-`setup` installs or updates the personal one-time routing policy. `status` inspects it. `disable` restores its pre-setup values. `remove custom roles` cleans only verified agent files and does not require seat values. An invocation with seats and work but no control verb is a current-task override and must not rewrite config.
+`setup` installs or updates the personal one-time routing policy. `create project role` or `create personal role` creates native Codex custom-agent files. `status` inspects built-in routing. `disable` restores its pre-setup values.
 
-The executor is required for setup or a task-local override. The advisor is optional: if omitted, it means `advisor: none`. Do not ask a separate advisor question unless the user asks for help choosing one.
+`remove custom roles` cleans only verified plugin-managed advisor/executor files. Arbitrary native roles are user-owned. An invocation with seats and work but no control verb is a current-task override and must not rewrite config.
+
+The executor is required for setup or a task-local override. It is not required for a custom-role creation request. The advisor is optional: if omitted, it means `advisor: none`. Do not ask a separate advisor question unless the user asks for help choosing one.
 
 If the executor is missing, ask only:
 
@@ -41,13 +46,39 @@ For a task-local request, append `— <original task>`. Keep every supplied modi
 
 If an old prompt contains `orchestrator:`, explain that the current task model already owns that role. Ignore that seat instead of switching or persisting it.
 
-Normalize `Extra High` to `xhigh`. Resolve display names to exact IDs only through the executing host's model catalog, picker, a loaded custom agent, or official provider documentation. Never invent an ID. For persistent direct routing, resolve `auto` to the catalog's concrete default.
+Normalize `Extra High` to `xhigh` for Codex models. `Claude Fable 5 Extra High` is the built-in advisor label; map it to `--advisor-fable --advisor-effort max`, not the Codex model catalog. Resolve every other display name to an exact ID only through the executing host's model catalog, picker, a loaded custom agent, or official provider documentation. Never invent an ID. For persistent direct routing, resolve `auto` to the catalog's concrete default.
 
 Read [providers-and-models.md](references/providers-and-models.md) before setup, when clients disagree, when a model is absent, when providers differ, or when custom agents or legacy migration are involved.
 
+## Create arbitrary custom roles
+
+Use native Codex custom-agent files for roles beyond the built-in advisor and executor seats. Examples include researcher, reviewer, writer, supervisor, security auditor, browser debugger, or domain expert.
+
+Use project scope when the user says `project`, `repo`, `workspace`, or `current project`. Write to `<trusted-project>/.codex/agents/<role-name>.toml`. Use personal scope only when explicitly requested and write to `~/.codex/agents/<role-name>.toml`.
+
+Before writing:
+
+1. Normalize the role name to lowercase snake case and validate `^[a-z][a-z0-9_]{0,62}$`.
+2. Require a clear purpose and `developer_instructions` that keep the role bounded.
+3. Resolve the model and effort from the active catalog or a user-confirmed exact ID.
+4. If `model_provider` is supplied, require an existing configured and authenticated compatible provider. Never create provider access or collect credentials.
+5. Use the current task permission mode by default. Add `sandbox_mode` only when the user requests it. A role may request a narrower sandbox; it never bypasses the parent task's authority.
+6. Keep `agents.max_depth = 1` behavior unless the user explicitly asks for nested agents. A custom role should not create descendants by default.
+7. Refuse symlinked paths, duplicate agent names, malformed TOML, and overwriting an existing file without explicit replacement approval.
+
+A custom agent file must define `name`, `description`, and `developer_instructions`. It may also define `model`, `model_reasoning_effort`, `model_provider`, `sandbox_mode`, `mcp_servers`, and `skills.config` when supported.
+
+Preview the path and complete TOML before writing. A literal create request authorizes a clean new file after preview. Replacing or deleting an existing user-owned role requires a separate explicit decision.
+
+Do not add the plugin ownership marker to arbitrary roles. Do not claim `disable` or `remove custom roles` will remove them. Tell the user to start a new task after creation so Codex loads the new roles.
+
+When the user supplies a sequence such as `researcher -> reviewer -> writer`, preserve it as task-level workflow instructions. The root orchestrator owns every handoff, resolves conflicting feedback, verifies the result, and may skip only optional steps.
+
+If the user combines a workflow with a Codex Goal, leave Goal lifecycle and limits under Codex's normal Goal controls. The orchestration policy operates inside the Goal; this skill does not silently create, pause, resume, or clear it.
+
 ## One-time native setup
 
-Use this path for a current same-provider setup such as Sol root to Luna or Terra executors.
+Use this path for a current same-provider setup such as Sol root to Luna or Terra executors. Claude Fable 5 is the one built-in cross-provider advisor exception because it runs through the bundled read-only MCP bridge and the user's authenticated Claude Code CLI.
 
 1. Identify the Codex binary used by the active host. Do not assume the shell `codex` is the Desktop binary.
 2. Resolve the exact executor and optional advisor IDs and efforts from that host.
@@ -70,20 +101,22 @@ python3 <skill-dir>/scripts/configure_native_routing.py \
   --apply
 ```
 
-Add `--advisor-model` and `--advisor-effort` only when an advisor was supplied. Omission persists `advisor: none`.
+Add `--advisor-model` and `--advisor-effort` for a same-provider Codex advisor. For Claude Fable 5, use `--advisor-fable --advisor-effort max`. The configurator requires Claude Code to be logged in through a first-party Pro or Max account, chooses an available Python 3.11+ MCP launcher, and performs only an auth/capability check during setup. It never extracts a token, writes a credential, or makes a model call during setup or status. Omission persists `advisor: none`.
 
 The configurator capability-tests the complete four-field preset on the active target, `codex` on PATH when different, the known macOS Desktop binary when present, and every explicit `--compat-bin`. A successful isolated config probe means that client can parse the preset; it is not a live child-model confirmation. Report `route accepted` or `used and confirmed` only from the exact live spawn evidence defined below. Ask about other Codex/IDE installations that share this config only when the environment suggests they exist, and pass their binaries explicitly. If the request or active host indicates a named `--profile`, explain that normal setup manages the default user layer and is not verified for that profile; do not add a routine question for users with no profile signal. If a checked client rejects any managed field, stop before apply. Recommend updating it or using the task-local fallback. `--allow-incompatible-client` requires a separate explicit user decision because it can make the shared config unreadable to that client.
 
 For the current validated v2 direct route, set `tool_namespace = "agents"`. Live testing on Desktop `0.144.0-alpha.4` showed that the default reserved `collaboration.spawn_agent` schema rejected expanded model/effort metadata, while `agents` accepted the same request and spawned Luna at `xhigh`. Treat this as a required control-surface setting for that tested path, not as the executor selection. `usage_hint_text` carries the actual executor/advisor route.
 
-Do not add `enabled = true` for a Sol or Terra root. Their current model metadata selects v2. The configurator intentionally manages only:
+Do not add `enabled = true` for a Sol or Terra root. Their current model metadata selects v2. The configurator intentionally manages these routing fields:
 
 - `features.multi_agent_v2.hide_spawn_agent_metadata`;
 - `features.multi_agent_v2.tool_namespace`;
 - `features.multi_agent_v2.multi_agent_mode_hint_text`;
 - `features.multi_agent_v2.usage_hint_text`.
 
-It uses Codex App Server's `config/read` and `config/batchWrite` APIs, not a home-grown TOML rewrite. It preserves unrelated settings and comments, validates the whole effective config, and uses the user-layer version to detect races. Restore snapshots are limited to the four owned config fields; the namespaced state also records schema/version markers, config path, selected seats, and scalar-conversion metadata when needed. If the user explicitly replaces existing hint text, the exact prior text is stored for restoration; warn them never to place credentials in routing hints.
+When Claude Fable 5 is selected, it additionally manages only the plugin-scoped `enabled` override for the chosen bundled MCP launcher and any launcher variant already overridden by the user. All bundled variants are disabled by default. The original override values are stored and restored by `disable`. Codex's TOML editor may retain an inert empty table header after deleting the last override; never rewrite the file merely to remove that cosmetic header.
+
+It uses Codex App Server's `config/read` and `config/batchWrite` APIs, not a home-grown TOML rewrite. It preserves unrelated settings and comments, validates the whole effective config, and uses the user-layer version to detect races. Restore snapshots cover the four routing fields plus the narrowly scoped MCP overrides only when Fable is selected; the namespaced state also records schema/version markers, config path, selected seats, and scalar-conversion metadata when needed. If the user explicitly replaces existing hint text, the exact prior text is stored for restoration; warn them never to place credentials in routing hints.
 
 If a user-authored mode or usage hint already exists, do not replace it automatically. Show the conflict. Use `--replace-existing-policy` only after the user explicitly approves replacing and later restoring those exact values.
 
@@ -121,9 +154,25 @@ Disable must remain available even if an older client is incompatible with the a
 
 For personal v0.4 custom roles, preview and apply removal with `configure_orchestration.py --scope personal --personal-route-names --remove-saved-roles`. For older fixed-name personal roles, run a separate preview without `--personal-route-names`. Project removal uses `--scope project --root <trusted-project> --remove-saved-roles`. Delete only files that the configurator fully validates as managed; edited or user-owned files require manual review.
 
+## Claude Fable 5 advisor
+
+Use this built-in route when the user names Claude Fable 5. Do not create a custom provider or custom-agent file for it.
+
+In every user-facing status or result, use the exact name `Claude Fable 5`. Report authentication as `first-party login ready`; do not expose or restate Claude account-plan metadata.
+
+Prerequisites:
+
+- the official `claude` CLI is installed;
+- `claude auth status` reports a first-party Pro or Max login;
+- a Python 3.11+ launcher is available.
+
+The plugin packages three disabled MCP launcher variants for macOS, Linux, and Windows. Setup enables exactly the compatible variant through the plugin's namespaced config. At review time the MCP server removes API-key and Bedrock/Vertex/Foundry override variables, re-checks first-party login, and invokes `claude -p --model claude-fable-5` with `--safe-mode`, no tools, no session persistence, prompt suggestions disabled, and JSON output. The saved route pins the model and effort; the root cannot replace them through tool arguments.
+
+The bridge accepts only one self-contained `packet`. It requires `PLAN_APPROVED` or `PLAN_REVISE` as the first non-empty line and requires runtime `modelUsage` to confirm `claude-fable-5`. Any auth, transport, format, or model-confirmation failure is `advisor unavailable`, never approval. It returns no account identifier or credential.
+
 ## Durable or cross-provider custom agents
 
-Direct `model` routing is same-provider. A different provider needs an already authenticated Codex-compatible provider and a loaded custom agent that pins `model_provider`.
+Direct `model` routing is same-provider. Except for the built-in Claude Fable 5 MCP route above, a different provider needs an already authenticated Codex-compatible provider and a loaded custom agent that pins `model_provider`.
 
 Use the existing standalone-agent configurator for this extended path. Personal scope is required for machine-local provider IDs and affects all projects, so the user's explicit cross-provider `setup` request must name or confirm the existing provider ID. Never create provider definitions, collect keys in chat, or write credentials.
 
@@ -238,6 +287,8 @@ PLAN_REVISE
 
 The root adjudicates every suggestion and owns the revised plan. Allow at most one confirmation pass after a material revision. A configured advisor is a gate for a non-trivial executor plan by default. Transport failure, malformed output, inaccessible routing, or missing context means `advisor unavailable`, never approval; stop before executor work unless the user explicitly made the advisor best-effort.
 
+For Claude Fable 5, call the configured MCP server's `review_plan` tool instead of spawning an advisor child. It remains root-only and read-only; executors never receive the tool or direct it.
+
 ## Executor handoff
 
 Give each executor one bounded packet with:
@@ -289,6 +340,7 @@ Never call that 65% fewer raw tokens, a guaranteed five-hour or weekly-limit sav
 ## Resources
 
 - `scripts/configure_native_routing.py`: one-time native setup, status, update, and disable.
+- `scripts/fable_advisor_mcp.py`: fail-closed Claude Fable 5 plan-review bridge.
 - `scripts/configure_orchestration.py`: namespaced custom agents, provider pins, safe removal, and legacy migration.
 - `scripts/inspect_models.py`: fallible host-catalog diagnostics.
 - [providers-and-models.md](references/providers-and-models.md): detailed capability, provider, compatibility, persistence, and usage boundaries.

--- a/plugins/codex-orchestration/skills/codex-orchestration/SKILL.md
+++ b/plugins/codex-orchestration/skills/codex-orchestration/SKILL.md
@@ -95,9 +95,13 @@ For status:
 python3 <skill-dir>/scripts/configure_native_routing.py \
   --codex-bin <active-codex-binary> \
   --status
+
+python3 <skill-dir>/scripts/configure_native_routing.py \
+  --codex-bin <active-codex-binary> \
+  --status --require-effective
 ```
 
-Run status from the target project. Report the current task model as the orchestrator, the configured executor and advisor, whether the personal policy is installed and effective in that workspace, whether effective spawn controls are visible, whether the effective tool namespace is `agents`, the target config path, and checked-client compatibility. State that the installer cannot infer v2 activation for the model selected in a task; current Sol or Terra is the intended root.
+Run status from the target project. The first form is descriptive. Use `--require-effective` for automation and release gates; it returns nonzero for incompatible clients, conflicts, overrides, incomplete controls, unavailable agent routes, or orphaned v0.4+ personal roles. Report the current task model as the orchestrator, the configured executor and advisor, whether the personal policy is installed and effective in that workspace, whether effective spawn controls are visible, whether the effective tool namespace is `agents`, the target config path, and checked-client compatibility. State that neither status form proves a live route or infers v2 activation for the model selected in a task; current Sol or Terra is the intended root.
 
 To change seats, run normal `setup` again. The configurator keeps the original restore snapshot rather than treating its own managed values as user settings.
 
@@ -149,6 +153,18 @@ python3 <skill-dir>/scripts/configure_native_routing.py \
 ```
 
 Omit `--advisor-agent` when none is configured. `--personal-route-names` generates stable CODEX_HOME-specific names and prints them for the native command. The native configurator verifies exactly one matching personal file and refuses a same-name project role in the current workspace. A custom-agent file is a stronger durable model/provider pin than a direct tool hint, but runtime identity is confirmed only when the host exposes it. Start a new task so Codex loads the role files.
+
+These are two separate storage transactions. If the native command fails after the role transaction applied, immediately preview and then apply:
+
+```bash
+python3 <skill-dir>/scripts/configure_orchestration.py \
+  --scope personal \
+  --personal-route-names \
+  --codex-bin <active-codex-binary> \
+  --remove-saved-roles
+```
+
+Remove only files the configurator validates as managed. If cleanup fails or the operation was interrupted, stop and run native `--status --require-effective`; report each orphaned managed role for manual review. Never claim the two stores changed atomically. On Windows, new managed roles can be created, but updating or removing an existing role fails closed; explain that limitation before choosing the custom-agent path.
 
 The standalone configurator also retains project-scoped saved roles, safe removal, and opt-in migration for releases 0.1–0.3. It must never change the root model, permissions, credentials, or global agent limits.
 

--- a/plugins/codex-orchestration/skills/codex-orchestration/agents/openai.yaml
+++ b/plugins/codex-orchestration/skills/codex-orchestration/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "Codex Orchestration"
-  short_description: "One-time efficient executor routing"
-  default_prompt: "Use $codex-orchestration to set up an efficient executor while the selected task model stays in charge."
+  short_description: "Build multi-model Codex workflows"
+  default_prompt: "Use $codex-orchestration to assign compatible models to roles and configure my workflow."
 
 policy:
   allow_implicit_invocation: false

--- a/plugins/codex-orchestration/skills/codex-orchestration/references/providers-and-models.md
+++ b/plugins/codex-orchestration/skills/codex-orchestration/references/providers-and-models.md
@@ -6,7 +6,7 @@ Use this reference for setup, client compatibility, custom providers, or a route
 
 1. The model selected for the Codex task is the root orchestrator.
 2. A current Sol or Terra root uses multi-agent v2.
-3. The saved policy supplies the exact route for every delegated executor and optional advisor.
+3. The saved policy tells the root which exact route to request for every delegated executor and optional advisor.
 4. Codex still decides whether a spawn helps.
 5. Every different-model, different-effort, or custom-agent child uses `fork_turns = "none"` and a self-contained packet.
 6. The root reviews and verifies all child work.
@@ -27,7 +27,7 @@ These facts were source-checked and runtime-tested on July 10, 2026. Always capa
 | `usage_hint_text` | Appended to the spawn tool description | Carries the exact executor/advisor route where the root chooses children. |
 | `multi_agent_mode_hint_text` | Replaces the default proactive/explicit mode hint and is sent to root and child tasks | Must contain both root and child boundaries. |
 | `fork_turns` default | `all` | Different model/effort/role overrides are rejected unless the call uses `none` or a positive partial fork. |
-| v2 default concurrency | Four active threads including the root | Normally at most three children run concurrently. Codex chooses the useful count. |
+| Effective concurrency | Determined by the active Codex version and `agents.max_threads` configuration | This plugin never changes the limit or forces a worker count. |
 | Older CLI 0.142.5 | Rejects `multi_agent_mode_hint_text` as an unknown feature-table field | Never write the global native policy without checking every known shared-config client. |
 
 The installer does not infer this from version strings. It launches each detected binary with an isolated `CODEX_HOME` and probes whether it can parse all four managed fields. That is a config-compatibility check, not proof of a live child route.
@@ -90,6 +90,8 @@ There is no global Codex field named `executor_model`. The native same-provider 
 - optional effective-runtime confirmation when the client exposes it.
 
 That is strong routing, but it is not a separate engine-level scheduler. The root can still choose not to delegate. Tool acceptance proves Codex accepted and validated the requested route; it does not guarantee that every client exposes the effective post-start identity. If the model ignores the required route or the tool rejects it, report that mismatch rather than claiming success.
+
+Setup runs before a future task chooses its root, so it cannot persist a mechanically verified future root-provider identity. Direct routes are valid only when the active task can establish that the requested model belongs to the inherited root provider. If provider identity is missing or ambiguous, fail closed and use a provider-pinned custom agent.
 
 A custom-agent file is the stronger persistent pin for a reusable role because the role config can set `model`, `model_reasoning_effort`, and `model_provider`. A stronger live parent override can still win, so confirm the effective child metadata either way.
 
@@ -200,6 +202,10 @@ Treat a saved scope as one complete team anchored by its executor. A missing sam
 
 The standalone-agent configurator remains dry-run first, rejects symlinks and hard links, preserves supported metadata, journals multi-file transactions without storing config contents, refuses edited or user-owned files, and uses opt-in backup-first migration for known output from versions 0.1–0.3.
 
+The role-file transaction and native App Server policy transaction are independent. After a phase-two failure, remove only fully validated newly managed roles. Native status reports collision-resistant managed personal roles that are not referenced by its current restore state, and `--require-effective` treats them as unhealthy. This recovery is compensating cleanup, not atomicity across the two stores.
+
+On Windows, the custom-agent configurator can create a new role but refuses in-place update or removal of an existing managed role because it cannot prove the Unix inode/metadata-preservation contract. Native App Server policy setup and disable are separate and remain capability-tested through the active Codex binary.
+
 ## Provider boundaries
 
 Direct v2 `model` overrides retain the parent's provider. They are the simplest route for an OpenAI root and OpenAI Luna/Terra child.
@@ -235,7 +241,7 @@ Named profile-v2 files are separate selected user layers. The default command do
 
 ## Concurrency and service tier
 
-V2 defaults to four total active threads, including the root. That means up to three concurrent children by default. Root plus five children would require six total, but this plugin never changes the limit or forces five children. Codex should parallelize only independent slices with non-overlapping write ownership.
+The effective concurrency limit belongs to the active Codex version and `agents.max_threads` configuration. This plugin never changes that limit or forces a worker count. Codex should parallelize only independent slices with non-overlapping write ownership.
 
 Child service tier can inherit from the parent when supported. There is no portable “force standard tier” spawn setting that works across current catalogs. If allowance savings are the priority, do not enable Fast/priority on the root.
 
@@ -244,6 +250,7 @@ Child service tier can inherit from the parent when supported. There is no porta
 Use precise language:
 
 - `native policy installed`: managed user policy exists; activation still depends on root model and effective workspace config;
+- `policy effective`: the managed fields win in the current workspace; this is still not a live spawn;
 - `pinned custom agent available`: matching role loaded, not yet used;
 - `route accepted`: exact controls were accepted and validated by the current tool;
 - `unverified prompt preference`: no exact control available;

--- a/plugins/codex-orchestration/skills/codex-orchestration/references/providers-and-models.md
+++ b/plugins/codex-orchestration/skills/codex-orchestration/references/providers-and-models.md
@@ -26,6 +26,7 @@ These facts were source-checked and runtime-tested on July 10, 2026. Always capa
 | `tool_namespace = "agents"` | On live-tested Desktop `0.144.0-alpha.4`, the default `collaboration` namespace rejected expanded model/effort metadata; `agents` accepted it and spawned Luna at `xhigh`. | Required for this validated direct-routing path. It changes the callable namespace but does not select Luna. |
 | `usage_hint_text` | Appended to the spawn tool description | Carries the exact executor/advisor route where the root chooses children. |
 | `multi_agent_mode_hint_text` | Replaces the default proactive/explicit mode hint and is sent to root and child tasks | Must contain both root and child boundaries. |
+| Claude Fable 5 MCP route | Root-only `review_plan` tool invokes the authenticated Claude Code CLI headlessly | Built-in cross-provider advisor exception; no custom Codex provider or advisor child. |
 | `fork_turns` default | `all` | Different model/effort/role overrides are rejected unless the call uses `none` or a positive partial fork. |
 | Effective concurrency | Determined by the active Codex version and `agents.max_threads` configuration | This plugin never changes the limit or forces a worker count. |
 | Older CLI 0.142.5 | Rejects `multi_agent_mode_hint_text` as an unknown feature-table field | Never write the global native policy without checking every known shared-config client. |
@@ -76,6 +77,8 @@ For a durable custom-agent route it uses:
 agent_type="codex_orchestration_executor", fork_turns="none"
 agent_type="codex_orchestration_advisor", fork_turns="none"
 ```
+
+For Claude Fable 5 it names the enabled bundled MCP server and tells the root to call its `review_plan` tool. This is a root tool call, not `spawn_agent`, so `fork_turns` does not apply.
 
 The custom mode text is visible in spawned children too. That is why it says: if root, orchestrate; if child, stay within the packet and never spawn.
 
@@ -148,7 +151,7 @@ Restore state lives at:
 ~/.codex/.codex-orchestration-routing.json
 ```
 
-It contains the prior and managed values of the four owned fields, chosen seat IDs, schema/version markers, scalar-conversion metadata when needed, and config path. It never copies provider definitions, auth stores, or config outside those fields. A normal clean setup contains generated policy text, the namespace value, seat IDs, and restoration metadata. Explicit replacement must retain the user's exact old hint text so disable can restore it; routing hints must never contain credentials. State is written with a same-directory atomic replacement and restrictive file mode where supported. If persistence fails after config apply, the configurator rolls the config back using the returned version.
+It contains the prior and managed values of the four routing fields, chosen seat IDs, schema/version markers, scalar-conversion metadata when needed, and config path. When Claude Fable 5 is selected, it also records only the plugin-scoped MCP launcher overrides that setup touched. It never copies provider definitions, auth stores, account identifiers, or credentials. A normal clean setup contains generated policy text, the namespace value, seat IDs, and restoration metadata. Explicit replacement must retain the user's exact old hint text so disable can restore it; routing hints must never contain credentials. State is written with a same-directory atomic replacement and restrictive file mode where supported. If persistence fails after config apply, the configurator rolls the config back using the returned version.
 
 Disable compares every current managed value before restoration. If the user edited a managed field after setup, it stops instead of erasing that work. Without state, each surviving marker proves ownership only of that hint string. Disable may safely remove the marked string or strings, but it leaves metadata visibility and the tool namespace unchanged because their previous values are unknown.
 
@@ -210,6 +213,10 @@ On Windows, the custom-agent configurator can create a new role but refuses in-p
 
 Direct v2 `model` overrides retain the parent's provider. They are the simplest route for an OpenAI root and OpenAI Luna/Terra child.
 
+Claude Fable 5 is the explicit built-in exception. The plugin does not pretend it is a Codex model or translate Anthropic into the Responses protocol. Instead, a disabled-by-default local MCP server invokes the official `claude` CLI with the user's first-party Pro or Max login. Setup enables one Python 3.11+ launcher variant, and disable restores every prior plugin override value. Codex's TOML editor can retain an inert empty table header after its final key is deleted; the configurator does not risk a broad TOML rewrite for cosmetic cleanup.
+
+The bridge removes `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, and Bedrock/Vertex/Foundry selection variables from the child environment. It re-checks `claude auth status`, pins `claude-fable-5` and the saved effort, disables tools and session persistence, disables prompt suggestions, and requires JSON runtime metadata to confirm the model. Setup and status never make a model call.
+
 A cross-provider seat normally needs:
 
 1. a provider already defined and authenticated in the user's Codex config;
@@ -226,6 +233,8 @@ Codex custom providers currently use the Responses wire protocol. An Anthropic M
 A task-local advisor is review-only by instruction. Do not claim it is mechanically read-only unless the effective child sandbox confirms that.
 
 A saved advisor requests `sandbox_mode = "read-only"`, but live parent permission overrides may be reapplied to children. Keep the behavioral prohibition on edits and mutation even with the requested sandbox.
+
+The Claude Fable 5 advisor is mechanically narrower than a child: the MCP tool accepts only a review packet, launches Claude with safe mode and no tools, and exposes no edit or shell operation. It still has open-world model access, so the packet must be deliberate and self-contained.
 
 Advisor failure is never approval. A configured advisor is required for a non-trivial executor plan unless the user explicitly marks it best-effort. Transport failure, malformed output, missing context, or wrong route becomes `advisor unavailable`; stop before executor work by default, or disclose and continue under the root only in best-effort mode.
 

--- a/plugins/codex-orchestration/skills/codex-orchestration/scripts/configure_native_routing.py
+++ b/plugins/codex-orchestration/skills/codex-orchestration/scripts/configure_native_routing.py
@@ -30,12 +30,21 @@ except ModuleNotFoundError as exc:  # pragma: no cover - Python < 3.11
     raise SystemExit("Python 3.11 or newer is required (missing tomllib).") from exc
 
 
-POLICY_VERSION = 1
-STATE_SCHEMA = 1
+POLICY_VERSION = 2
+STATE_SCHEMA = 2
+SUPPORTED_STATE_SCHEMAS = {1, 2}
 MANAGED_MARKER = "[codex-orchestration managed-policy v1]"
 STATE_FILENAME = ".codex-orchestration-routing.json"
 PROBE_VALUE = "CODEX_ORCHESTRATION_CAPABILITY_PROBE"
 ROUTING_TOOL_NAMESPACE = "agents"
+PLUGIN_ID = "codex-orchestration@codex-orchestration"
+FABLE_MODEL = "claude-fable-5"
+FABLE_EFFORTS = {"low", "medium", "high", "max"}
+FABLE_SERVERS = {
+    "fable-advisor-python3": ("python3", []),
+    "fable-advisor-python": ("python", []),
+    "fable-advisor-py": ("py", ["-3.11"]),
+}
 RPC_TIMEOUT_SECONDS = 20
 PROBE_TIMEOUT_SECONDS = 15
 MODEL_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:+/@-]{0,199}$")
@@ -88,6 +97,11 @@ def parse_args() -> argparse.Namespace:
     advisor = parser.add_mutually_exclusive_group()
     advisor.add_argument("--advisor-model", help="Optional exact advisor model ID.")
     advisor.add_argument("--advisor-agent", help="Optional loaded advisor agent name.")
+    advisor.add_argument(
+        "--advisor-fable",
+        action="store_true",
+        help="Use the bundled Claude Fable 5 advisor through Claude Code.",
+    )
     parser.add_argument(
         "--advisor-effort",
         default="auto",
@@ -136,6 +150,7 @@ def _validate_args(args: argparse.Namespace) -> None:
             args.executor_agent,
             args.advisor_model,
             args.advisor_agent,
+            args.advisor_fable,
         )
     ):
         raise ConfigurationError("--status does not accept seat settings.")
@@ -145,6 +160,7 @@ def _validate_args(args: argparse.Namespace) -> None:
             args.executor_agent,
             args.advisor_model,
             args.advisor_agent,
+            args.advisor_fable,
         )
     ):
         raise ConfigurationError("--disable does not accept seat settings.")
@@ -162,6 +178,12 @@ def _validate_args(args: argparse.Namespace) -> None:
         raise ConfigurationError(
             "A custom advisor agent owns its effort; omit --advisor-effort."
         )
+    if args.advisor_fable:
+        effort = "max" if args.advisor_effort == "auto" else args.advisor_effort
+        if effort not in FABLE_EFFORTS:
+            raise ConfigurationError(
+                "Claude Fable 5 effort must be one of: low, medium, high, max."
+            )
     for label, value, pattern in (
         ("executor model", args.executor_model, MODEL_RE),
         ("advisor model", args.advisor_model, MODEL_RE),
@@ -482,6 +504,25 @@ def snapshot_edit(key_path: str, saved: dict[str, Any]) -> dict[str, Any] | None
     }
 
 
+def fable_key_path(server: str) -> str:
+    return (
+        f"plugins.{json.dumps(PLUGIN_ID)}.mcp_servers."
+        f"{json.dumps(server)}.enabled"
+    )
+
+
+def _valid_snapshot(saved: Any, expected: type | tuple[type, ...]) -> bool:
+    if not (
+        isinstance(saved, dict)
+        and isinstance(saved.get("known"), bool)
+        and isinstance(saved.get("present"), bool)
+    ):
+        return False
+    if saved["known"] and saved["present"]:
+        return "value" in saved and isinstance(saved["value"], expected)
+    return True
+
+
 def _read_state(path: Path) -> dict[str, Any] | None:
     if not path.exists():
         return None
@@ -494,7 +535,7 @@ def _read_state(path: Path) -> dict[str, Any] | None:
         state = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise ConfigurationError(f"Could not read routing state {path}: {exc}") from exc
-    if not isinstance(state, dict) or state.get("schema") != STATE_SCHEMA:
+    if not isinstance(state, dict) or state.get("schema") not in SUPPORTED_STATE_SCHEMAS:
         raise ConfigurationError(f"Unknown routing state schema in {path}.")
     if state.get("managed_by") != "codex-orchestration":
         raise ConfigurationError(f"Routing state is not owned by this plugin: {path}")
@@ -526,6 +567,12 @@ def _read_state(path: Path) -> dict[str, Any] | None:
             kind == "agent"
             and isinstance(route.get("agent"), str)
             and AGENT_RE.fullmatch(route["agent"])
+        ) or (
+            label == "advisor"
+            and kind == "fable"
+            and route.get("model") == FABLE_MODEL
+            and route.get("effort") in FABLE_EFFORTS
+            and route.get("server") in FABLE_SERVERS
         )
         if not valid:
             raise ConfigurationError(f"Routing state has an invalid {label} route: {path}")
@@ -534,21 +581,22 @@ def _read_state(path: Path) -> dict[str, Any] | None:
         raise ConfigurationError(f"Routing state has no restore values: {path}")
     for key in ("mode", "usage", "metadata", "namespace"):
         saved = previous.get(key)
-        if not (
-            isinstance(saved, dict)
-            and isinstance(saved.get("known"), bool)
-            and isinstance(saved.get("present"), bool)
-        ):
+        expected = bool if key == "metadata" else str
+        if not _valid_snapshot(saved, expected):
             raise ConfigurationError(f"Routing state has invalid {key} restore data: {path}")
-        if saved["known"] and saved["present"] and "value" not in saved:
-            raise ConfigurationError(f"Routing state has incomplete {key} restore data: {path}")
-        if saved["known"] and saved["present"]:
-            value = saved["value"]
-            expected = bool if key == "metadata" else str
-            if not isinstance(value, expected):
-                raise ConfigurationError(
-                    f"Routing state has an invalid {key} restore value: {path}"
-                )
+    managed_mcp = managed.get("mcp")
+    previous_mcp = previous.get("mcp")
+    if managed_mcp is not None or previous_mcp is not None:
+        if not (
+            isinstance(managed_mcp, dict)
+            and bool(managed_mcp)
+            and set(managed_mcp).issubset(FABLE_SERVERS)
+            and all(isinstance(value, bool) for value in managed_mcp.values())
+            and isinstance(previous_mcp, dict)
+            and set(previous_mcp) == set(managed_mcp)
+            and all(_valid_snapshot(value, bool) for value in previous_mcp.values())
+        ):
+            raise ConfigurationError(f"Routing state has invalid MCP restore data: {path}")
     return state
 
 
@@ -739,9 +787,77 @@ def resolve_model_effort(
     return resolved
 
 
+def select_fable_server() -> str:
+    for server, (launcher, prefix) in FABLE_SERVERS.items():
+        executable = shutil.which(launcher)
+        if not executable:
+            continue
+        try:
+            result = subprocess.run(
+                [executable, *prefix, "--version"],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                timeout=PROBE_TIMEOUT_SECONDS,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            continue
+        match = re.search(r"Python\s+(\d+)\.(\d+)", result.stdout)
+        if result.returncode == 0 and match and tuple(map(int, match.groups())) >= (3, 11):
+            return server
+    raise ConfigurationError(
+        "Claude Fable 5 requires a Python 3.11+ launcher named python3, python, "
+        "or py. Install one and retry."
+    )
+
+
+def verify_fable_prerequisites() -> dict[str, str]:
+    try:
+        from fable_advisor_mcp import AdvisorError, check_claude_auth, resolve_claude
+    except ImportError as exc:  # pragma: no cover - corrupt package
+        raise ConfigurationError("The bundled Claude Fable 5 bridge is missing.") from exc
+    try:
+        claude = resolve_claude()
+        auth = check_claude_auth(claude)
+        help_result = subprocess.run(
+            [str(claude), "--help"],
+            env={
+                key: value
+                for key, value in os.environ.items()
+                if key
+                not in {
+                    "ANTHROPIC_API_KEY",
+                    "ANTHROPIC_AUTH_TOKEN",
+                    "CLAUDE_CODE_USE_BEDROCK",
+                    "CLAUDE_CODE_USE_VERTEX",
+                    "CLAUDE_CODE_USE_FOUNDRY",
+                }
+            },
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            timeout=PROBE_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (AdvisorError, OSError, subprocess.TimeoutExpired) as exc:
+        raise ConfigurationError(str(exc)) from exc
+    required = ("--model", "--effort", "--safe-mode", "--prompt-suggestions")
+    missing = [flag for flag in required if flag not in help_result.stdout]
+    if help_result.returncode != 0 or missing:
+        detail = ", ".join(missing) if missing else f"exit {help_result.returncode}"
+        raise ConfigurationError(
+            f"Claude Code is too old for the Fable advisor bridge ({detail}); update it."
+        )
+    return {"claude": str(claude), **auth}
+
+
 def _route_summary(route: dict[str, Any]) -> str:
     if route["kind"] == "agent":
         return f"custom agent {route['agent']}"
+    if route["kind"] == "fable":
+        effort = "Extra High" if route["effort"] == "max" else route["effort"]
+        return f"Claude Fable 5 {effort}"
     return f"{route['model']}@{route['effort']}"
 
 
@@ -839,13 +955,21 @@ Explicit user instructions win, including no-subagents and task-local seat overr
 
 If you are a spawned child, stay inside the supplied packet, report only to the root, and never spawn descendants. An advisor reviews only the root's packet and never contacts executors. An executor never redesigns the root plan or contacts the advisor.
 """
-    advisor_hint = (
-        "For an advisor review, call this tool with "
-        f"{_spawn_route(advisor)}, fork_turns = \"none\". Send the complete "
-        "review packet and require PLAN_APPROVED or PLAN_REVISE."
-        if advisor is not None
-        else "No advisor route is configured."
-    )
+    if advisor is not None and advisor["kind"] == "fable":
+        advisor_hint = (
+            "For an advisor review, call `review_plan` from MCP server "
+            f"{json.dumps(advisor['server'])} with one complete packet. This is a "
+            "read-only root tool call, not a spawned child. Require PLAN_APPROVED or "
+            "PLAN_REVISE and fail closed if the tool is unavailable."
+        )
+    elif advisor is not None:
+        advisor_hint = (
+            "For an advisor review, call this tool with "
+            f"{_spawn_route(advisor)}, fork_turns = \"none\". Send the complete "
+            "review packet and require PLAN_APPROVED or PLAN_REVISE."
+        )
+    else:
+        advisor_hint = "No advisor route is configured."
     usage = f"""{MANAGED_MARKER}
 If you are the root task model, you are the orchestrator. Apply these routes only to children you decide to create.
 
@@ -907,6 +1031,17 @@ def _current_values(config: dict[str, Any]) -> dict[str, Any]:
         "namespace": nested_get(
             config, "features", "multi_agent_v2", "tool_namespace"
         ),
+        "mcp": {
+            server: nested_get(
+                config,
+                "plugins",
+                PLUGIN_ID,
+                "mcp_servers",
+                server,
+                "enabled",
+            )
+            for server in FABLE_SERVERS
+        },
     }
 
 
@@ -916,13 +1051,20 @@ def _is_managed(value: Any) -> bool:
 
 def _managed_matches(state: dict[str, Any], current: dict[str, Any]) -> bool:
     managed = state.get("managed")
-    return (
+    base_matches = (
         isinstance(managed, dict)
         and current["mode"] == managed.get("mode")
         and current["usage"] == managed.get("usage")
         and current["metadata"] is False
         and managed.get("namespace") == ROUTING_TOOL_NAMESPACE
         and current["namespace"] == ROUTING_TOOL_NAMESPACE
+    )
+    if not base_matches:
+        return False
+    managed_mcp = managed.get("mcp")
+    return managed_mcp is None or all(
+        current["mcp"].get(server, MISSING) == enabled
+        for server, enabled in managed_mcp.items()
     )
 
 
@@ -1006,6 +1148,15 @@ def _status(
             print(f"Executor: {_route_summary(state['executor'])}")
             advisor = state.get("advisor")
             print(f"Advisor: {_route_summary(advisor) if advisor else 'none'}")
+            if isinstance(advisor, dict) and advisor.get("kind") == "fable":
+                try:
+                    verify_fable_prerequisites()
+                except ConfigurationError as exc:
+                    print(f"Claude Fable 5: unavailable — {exc}")
+                else:
+                    print(
+                        "Claude Fable 5: ready — first-party login; no model call made"
+                    )
             try:
                 verified = verify_agent_routes(
                     app.codex_home,
@@ -1094,6 +1245,7 @@ def _prepare_setup_state(
         previous = existing_state.get("previous")
         if not isinstance(previous, dict):
             raise ConfigurationError("Managed routing state is missing its restore data.")
+        previous = dict(previous)
         scalar_origin = existing_state.get("scalar_origin")
         if isinstance(scalar_origin, bool):
             managed_feature = existing_state.get("managed_feature")
@@ -1234,6 +1386,59 @@ def _prepare_setup_state(
         ]
         managed_feature = None
 
+    existing_managed = existing_state.get("managed", {}) if existing_state else {}
+    manage_mcp = (
+        isinstance(advisor, dict)
+        and advisor.get("kind") == "fable"
+        or isinstance(existing_managed, dict)
+        and isinstance(existing_managed.get("mcp"), dict)
+    )
+    managed_mcp: dict[str, bool] | None = None
+    if manage_mcp:
+        previous_mcp = previous.get("mcp")
+        if not isinstance(previous_mcp, dict):
+            previous_mcp = {}
+        selected = advisor.get("server") if isinstance(advisor, dict) else None
+        existing_mcp = (
+            existing_managed.get("mcp")
+            if isinstance(existing_managed, dict)
+            and isinstance(existing_managed.get("mcp"), dict)
+            else {}
+        )
+        touched = set(existing_mcp)
+        touched.update(
+            server for server, value in current["mcp"].items() if value is not MISSING
+        )
+        if isinstance(selected, str):
+            touched.add(selected)
+        for server in touched:
+            if server not in previous_mcp:
+                previous_mcp[server] = snapshot(current["mcp"][server])
+        previous["mcp"] = previous_mcp
+        managed_mcp = {server: server == selected for server in FABLE_SERVERS if server in touched}
+        for server, enabled in managed_mcp.items():
+            edits.append(
+                {
+                    "keyPath": fable_key_path(server),
+                    "value": enabled,
+                    "mergeStrategy": "replace",
+                }
+            )
+            rollback_edit = snapshot_edit(
+                fable_key_path(server), snapshot(current["mcp"][server])
+            )
+            if rollback_edit is not None:
+                rollback.append(rollback_edit)
+
+    managed = {
+        "mode": mode,
+        "usage": usage,
+        "metadata": False,
+        "namespace": ROUTING_TOOL_NAMESPACE,
+    }
+    if managed_mcp is not None:
+        managed["mcp"] = managed_mcp
+
     state = {
         "schema": STATE_SCHEMA,
         "policy_version": POLICY_VERSION,
@@ -1241,12 +1446,7 @@ def _prepare_setup_state(
         "config_file": str(config_path),
         "executor": executor,
         "advisor": advisor,
-        "managed": {
-            "mode": mode,
-            "usage": usage,
-            "metadata": False,
-            "namespace": ROUTING_TOOL_NAMESPACE,
-        },
+        "managed": managed,
         "previous": previous,
         "scalar_origin": scalar_origin,
         "managed_feature": managed_feature,
@@ -1298,6 +1498,9 @@ def _disable(
                 "Managed routing fields were edited after setup. Refusing to erase "
                 "those changes; restore the managed values or remove them manually."
             )
+        previous = state.get("previous")
+        if not isinstance(previous, dict):
+            raise ConfigurationError("Routing state has no restore data.")
         scalar_origin = state.get("scalar_origin")
         if isinstance(scalar_origin, bool):
             if current["feature"] != state.get("managed_feature"):
@@ -1313,9 +1516,6 @@ def _disable(
                 }
             ]
         else:
-            previous = state.get("previous")
-            if not isinstance(previous, dict):
-                raise ConfigurationError("Routing state has no restore data.")
             edits = [
                 edit
                 for edit in (
@@ -1338,6 +1538,16 @@ def _disable(
                 )
                 if edit is not None
             ]
+        previous_mcp = previous.get("mcp")
+        if isinstance(previous_mcp, dict):
+            edits.extend(
+                edit
+                for edit in (
+                    snapshot_edit(fable_key_path(server), previous_mcp[server])
+                    for server in previous_mcp
+                )
+                if edit is not None
+            )
         print("Will restore the pre-setup values of every owned routing field.")
     if not apply:
         print("Dry run only. Re-run with --disable --apply after reviewing this preview.")
@@ -1412,6 +1622,7 @@ def main() -> int:
                 executor = {"kind": "agent", "agent": args.executor_agent}
 
             advisor: dict[str, Any] | None = None
+            fable_auth: dict[str, str] | None = None
             if args.advisor_model:
                 advisor_effort = resolve_model_effort(
                     "Advisor",
@@ -1427,6 +1638,17 @@ def main() -> int:
                 }
             elif args.advisor_agent:
                 advisor = {"kind": "agent", "agent": args.advisor_agent}
+            elif args.advisor_fable:
+                server = select_fable_server()
+                fable_auth = verify_fable_prerequisites()
+                advisor = {
+                    "kind": "fable",
+                    "model": FABLE_MODEL,
+                    "effort": (
+                        "max" if args.advisor_effort == "auto" else args.advisor_effort
+                    ),
+                    "server": server,
+                }
 
             verified_agents = verify_agent_routes(
                 app.codex_home,
@@ -1449,6 +1671,11 @@ def main() -> int:
             print("Orchestrator: model selected when each Codex task starts")
             print(f"Executor: {_route_summary(executor)}")
             print(f"Advisor: {_route_summary(advisor) if advisor else 'none'}")
+            if fable_auth is not None:
+                print(
+                    "Claude Fable 5 login: ready — first-party; "
+                    "setup makes no model call"
+                )
             if verified_agents:
                 print(
                     "Custom-agent files: "

--- a/plugins/codex-orchestration/skills/codex-orchestration/scripts/configure_native_routing.py
+++ b/plugins/codex-orchestration/skills/codex-orchestration/scripts/configure_native_routing.py
@@ -41,6 +41,12 @@ PROBE_TIMEOUT_SECONDS = 15
 MODEL_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:+/@-]{0,199}$")
 AGENT_RE = re.compile(r"^[a-z][a-z0-9_]{0,62}$")
 EFFORT_RE = re.compile(r"^[a-z][a-z0-9_-]{0,31}$")
+PERSONAL_MANAGED_ROLE_RE = re.compile(
+    r"^codex_orchestration_(?:executor|advisor)_[0-9a-f]{12}$"
+)
+CUSTOM_AGENT_MANAGED_MARKER = (
+    "# Managed by codex-orchestration. Standalone custom agent v2."
+)
 MISSING = object()
 
 
@@ -58,6 +64,14 @@ def parse_args() -> argparse.Namespace:
     action = parser.add_mutually_exclusive_group()
     action.add_argument("--status", action="store_true")
     action.add_argument("--disable", action="store_true")
+    parser.add_argument(
+        "--require-effective",
+        action="store_true",
+        help=(
+            "With --status, return 1 unless the policy is installed, effective, "
+            "client-compatible, complete, and free of unavailable or orphaned roles."
+        ),
+    )
 
     executor = parser.add_mutually_exclusive_group()
     executor.add_argument("--executor-model", help="Exact model ID for direct routing.")
@@ -112,6 +126,8 @@ def parse_args() -> argparse.Namespace:
 
 
 def _validate_args(args: argparse.Namespace) -> None:
+    if args.require_effective and not args.status:
+        raise ConfigurationError("--require-effective requires --status.")
     if args.status and args.apply:
         raise ConfigurationError("--status cannot be combined with --apply.")
     if args.status and any(
@@ -296,7 +312,7 @@ class AppServer:
                     "clientInfo": {
                         "name": "codex_orchestration_installer",
                         "title": "Codex Orchestration Installer",
-                        "version": "0.4.0",
+                        "version": "0.5.0",
                     },
                     "capabilities": {"experimentalApi": True},
                 },
@@ -729,6 +745,54 @@ def _route_summary(route: dict[str, Any]) -> str:
     return f"{route['model']}@{route['effort']}"
 
 
+def _managed_personal_roles(codex_home: Path) -> tuple[dict[str, Path], list[str]]:
+    """Find only collision-resistant v0.4 personal roles owned by this plugin."""
+
+    roles: dict[str, Path] = {}
+    issues: list[str] = []
+    directory = codex_home / "agents"
+    if not directory.exists() and not directory.is_symlink():
+        return roles, issues
+    if directory.is_symlink() or not directory.is_dir():
+        return roles, [f"managed-role directory is unsafe: {directory}"]
+    for path in sorted(directory.glob("*.toml")):
+        if path.is_symlink() or not path.is_file():
+            continue
+        try:
+            content = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            issues.append(f"could not inspect {path}: {exc}")
+            continue
+        if not content.startswith(CUSTOM_AGENT_MANAGED_MARKER + "\n"):
+            continue
+        try:
+            parsed = tomllib.loads(content)
+        except tomllib.TOMLDecodeError as exc:
+            issues.append(f"managed role is malformed: {path}: {exc}")
+            continue
+        name = parsed.get("name")
+        if not isinstance(name, str) or not PERSONAL_MANAGED_ROLE_RE.fullmatch(name):
+            continue
+        if name in roles:
+            issues.append(f"managed role {name!r} is duplicated")
+            continue
+        roles[name] = path
+    return roles, issues
+
+
+def _referenced_agent_names(state: dict[str, Any] | None) -> set[str]:
+    names: set[str] = set()
+    if not isinstance(state, dict):
+        return names
+    for key in ("executor", "advisor"):
+        route = state.get(key)
+        if isinstance(route, dict) and route.get("kind") == "agent":
+            name = route.get("agent")
+            if isinstance(name, str):
+                names.add(name)
+    return names
+
+
 def _spawn_route(route: dict[str, Any]) -> str:
     if route["kind"] == "agent":
         return f'agent_type = {json.dumps(route["agent"])}'
@@ -883,11 +947,14 @@ def _status(
     target: Path,
     codex_home: Path | None,
     binaries: list[Path],
+    require_effective: bool,
 ) -> int:
+    clients_compatible = True
     for binary in binaries:
         supported, detail = supports_native_policy(binary)
         label = "compatible" if supported else f"incompatible ({detail})"
         print(f"Client: {binary} ({binary_version(binary)}) — {label}")
+        clients_compatible = clients_compatible and supported
     with AppServer(target, codex_home) as app:
         workspace = Path.cwd().resolve()
         read_result = app.request(
@@ -948,16 +1015,39 @@ def _status(
                 )
             except (ConfigurationError, KeyError, TypeError) as exc:
                 print(f"Custom-agent route: unavailable — {exc}")
+                agent_routes_available = False
             else:
+                agent_routes_available = True
                 if verified:
                     print(
                         "Custom-agent route: verified — "
                         + ", ".join(str(path) for path in verified)
                     )
         elif routing_state.startswith("installed"):
+            agent_routes_available = False
             print("Seats: managed policy found; local state is unavailable")
         elif state is not None:
+            agent_routes_available = False
             print("Seats: suppressed because restore state is stale or conflicting")
+        else:
+            agent_routes_available = False
+
+        managed_roles, role_issues = _managed_personal_roles(app.codex_home)
+        referenced_roles = _referenced_agent_names(state if state_matches else None)
+        orphaned_roles = {
+            name: path
+            for name, path in managed_roles.items()
+            if name not in referenced_roles
+        }
+        for issue in role_issues:
+            print(f"Managed custom-agent inspection: unavailable — {issue}")
+        if orphaned_roles:
+            rendered = ", ".join(
+                f"{name} ({path})" for name, path in sorted(orphaned_roles.items())
+            )
+            print(f"Orphaned managed custom agents: {rendered}")
+        else:
+            print("Orphaned managed custom agents: none")
         if effective["metadata"] is False:
             print("V2 spawn metadata setting: visible when a v2 root is selected")
         else:
@@ -966,7 +1056,19 @@ def _status(
             print(f"V2 tool namespace: {ROUTING_TOOL_NAMESPACE}")
         else:
             print("V2 tool namespace: not routed through agents in this workspace")
-    return 0
+        print(
+            "Routing validation: not performed — config compatibility and policy "
+            "effectiveness do not prove route acceptance or the effective child model"
+        )
+        healthy = (
+            clients_compatible
+            and routing_state.startswith("installed and effective")
+            and state_matches
+            and agent_routes_available
+            and not role_issues
+            and not orphaned_roles
+        )
+    return 1 if require_effective and not healthy else 0
 
 
 def _prepare_setup_state(
@@ -1255,7 +1357,12 @@ def main() -> int:
         target = resolve_binary(args.codex_bin)
         binaries = discover_compatibility_binaries(target, args.compat_bin)
         if args.status:
-            return _status(target, args.codex_home, binaries)
+            return _status(
+                target,
+                args.codex_home,
+                binaries,
+                args.require_effective,
+            )
         # Disable must remain available when the policy itself is what makes an
         # older shared-config client incompatible.
         _compatibility_report(
@@ -1339,7 +1446,7 @@ def main() -> int:
                 args.replace_existing_policy,
             )
             print(f"Config: {app.config_path}")
-            print(f"Orchestrator: model selected when each Codex task starts")
+            print("Orchestrator: model selected when each Codex task starts")
             print(f"Executor: {_route_summary(executor)}")
             print(f"Advisor: {_route_summary(advisor) if advisor else 'none'}")
             if verified_agents:
@@ -1389,16 +1496,22 @@ def main() -> int:
                 _write_state(state_path, new_state)
             except (ConfigurationError, OSError) as state_exc:
                 try:
-                    _batch_write(
+                    rollback_result = _batch_write(
                         app,
                         rollback,
                         result.get("version"),
                         reload_user_config=True,
                     )
+                    if rollback_result.get("status") not in {"ok", "okOverridden"}:
+                        raise ConfigurationError(
+                            "unexpected rollback status "
+                            f"{rollback_result.get('status')!r}"
+                        )
                 except ConfigurationError as rollback_exc:
                     raise ConfigurationError(
                         "Config was written but state persistence and automatic rollback "
-                        f"both failed. State error: {state_exc}; rollback: {rollback_exc}"
+                        "both failed; the user config may still contain managed fields. "
+                        f"State error: {state_exc}; rollback: {rollback_exc}"
                     ) from state_exc
                 raise ConfigurationError(
                     f"Could not persist restore state; config write was rolled back: {state_exc}"
@@ -1425,12 +1538,17 @@ def main() -> int:
                 )
             if not effective_matches:
                 try:
-                    _batch_write(
+                    rollback_result = _batch_write(
                         app,
                         rollback,
                         verify_version,
                         reload_user_config=True,
                     )
+                    if rollback_result.get("status") not in {"ok", "okOverridden"}:
+                        raise ConfigurationError(
+                            "unexpected rollback status "
+                            f"{rollback_result.get('status')!r}"
+                        )
                     if state is None:
                         _remove_state(state_path)
                     else:

--- a/plugins/codex-orchestration/skills/codex-orchestration/scripts/fable_advisor_mcp.py
+++ b/plugins/codex-orchestration/skills/codex-orchestration/scripts/fable_advisor_mcp.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Read-only MCP bridge from Codex to Claude Fable 5 through Claude Code."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+from typing import Any
+
+
+STATE_FILENAME = ".codex-orchestration-routing.json"
+FABLE_MODEL = "claude-fable-5"
+SUPPORTED_EFFORTS = {"low", "medium", "high", "max"}
+CLAUDE_TIMEOUT_SECONDS = 600
+AUTH_TIMEOUT_SECONDS = 20
+SENSITIVE_ENV = {
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_AUTH_TOKEN",
+    "CLAUDE_CODE_USE_BEDROCK",
+    "CLAUDE_CODE_USE_VERTEX",
+    "CLAUDE_CODE_USE_FOUNDRY",
+}
+SYSTEM_PROMPT = """You are Claude Fable 5 acting only as a plan advisor to Codex's root orchestrator.
+Review the supplied self-contained packet for material correctness, missing constraints, unsafe sequencing, ownership conflicts, and verification gaps. Do not edit files, call tools, spawn agents, contact executors, or attempt implementation.
+
+Your first non-empty line must be exactly PLAN_APPROVED or PLAN_REVISE.
+Use PLAN_APPROVED only when no material gap is present. Use PLAN_REVISE when correction is needed, followed by a concise prioritized list in which every gap has a concrete correction. Ignore style preferences. Report only to the root orchestrator."""
+
+
+class AdvisorError(RuntimeError):
+    pass
+
+
+def codex_home() -> Path:
+    value = os.environ.get("CODEX_HOME")
+    return Path(value).expanduser() if value else Path.home() / ".codex"
+
+
+def sanitized_environment() -> dict[str, str]:
+    env = os.environ.copy()
+    for name in SENSITIVE_ENV:
+        env.pop(name, None)
+    return env
+
+
+def resolve_claude() -> Path:
+    found = shutil.which("claude")
+    if found:
+        return Path(found).resolve()
+    candidates = (
+        Path.home() / ".local" / "bin" / "claude",
+        Path("/usr/local/bin/claude"),
+        Path("/opt/homebrew/bin/claude"),
+    )
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate.resolve()
+    raise AdvisorError("Claude Code is not installed or `claude` is not on PATH.")
+
+
+def _run_json(command: list[str], *, timeout: int) -> dict[str, Any]:
+    try:
+        result = subprocess.run(
+            command,
+            env=sanitized_environment(),
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise AdvisorError(f"Could not run Claude Code: {exc}") from exc
+    if result.returncode != 0:
+        raise AdvisorError(f"Claude Code exited with {result.returncode}.")
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise AdvisorError("Claude Code returned malformed JSON.") from exc
+    if not isinstance(payload, dict):
+        raise AdvisorError("Claude Code returned an unexpected JSON value.")
+    return payload
+
+
+def check_claude_auth(claude: Path | None = None) -> dict[str, str]:
+    executable = claude or resolve_claude()
+    payload = _run_json([str(executable), "auth", "status"], timeout=AUTH_TIMEOUT_SECONDS)
+    subscription = payload.get("subscriptionType")
+    if not (
+        payload.get("loggedIn") is True
+        and payload.get("authMethod") == "claude.ai"
+        and payload.get("apiProvider") == "firstParty"
+        and subscription in {"pro", "max"}
+    ):
+        raise AdvisorError(
+            "Claude Code must be logged in through a first-party Pro or Max account; "
+            "run `claude auth login` and try again."
+        )
+    return {
+        "auth_method": "claude.ai",
+        "api_provider": "firstParty",
+    }
+
+
+def load_fable_route(home: Path | None = None) -> dict[str, str]:
+    path = (home or codex_home()) / STATE_FILENAME
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise AdvisorError("Claude Fable 5 is not configured; run setup first.") from exc
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise AdvisorError(f"Could not read the routing state: {exc}") from exc
+    route = payload.get("advisor") if isinstance(payload, dict) else None
+    if not isinstance(route, dict) or route.get("kind") != "fable":
+        raise AdvisorError("Claude Fable 5 is not the configured advisor.")
+    model = route.get("model")
+    effort = route.get("effort")
+    if model != FABLE_MODEL or effort not in SUPPORTED_EFFORTS:
+        raise AdvisorError("The saved Claude Fable 5 route is invalid.")
+    return {"model": model, "effort": effort}
+
+
+def review_plan(packet: str) -> dict[str, Any]:
+    if not isinstance(packet, str) or not packet.strip():
+        raise AdvisorError("`packet` must be a non-empty self-contained review packet.")
+    route = load_fable_route()
+    claude = resolve_claude()
+    auth = check_claude_auth(claude)
+    command = [
+        str(claude),
+        "-p",
+        "--model",
+        route["model"],
+        "--effort",
+        route["effort"],
+        "--safe-mode",
+        "--tools",
+        "",
+        "--permission-mode",
+        "dontAsk",
+        "--no-session-persistence",
+        "--prompt-suggestions",
+        "false",
+        "--output-format",
+        "json",
+        "--system-prompt",
+        SYSTEM_PROMPT,
+    ]
+    try:
+        result = subprocess.run(
+            command,
+            input=packet,
+            env=sanitized_environment(),
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=CLAUDE_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise AdvisorError(f"Claude Fable 5 review failed: {exc}") from exc
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "no diagnostic"
+        raise AdvisorError(f"Claude Fable 5 exited with {result.returncode}: {detail}")
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise AdvisorError("Claude Fable 5 returned malformed JSON.") from exc
+    if not isinstance(payload, dict) or not isinstance(payload.get("result"), str):
+        raise AdvisorError("Claude Fable 5 returned an unexpected response.")
+    review = payload["result"].strip()
+    first = next((line.strip() for line in review.splitlines() if line.strip()), "")
+    if first not in {"PLAN_APPROVED", "PLAN_REVISE"}:
+        raise AdvisorError("Claude Fable 5 omitted the required plan decision.")
+    usage = payload.get("modelUsage")
+    used_models = sorted(usage) if isinstance(usage, dict) else []
+    if FABLE_MODEL not in used_models:
+        raise AdvisorError("Runtime metadata did not confirm Claude Fable 5.")
+    return {
+        "decision": first,
+        "review": review,
+        "model": FABLE_MODEL,
+        "effort": route["effort"],
+        "auth_method": auth["auth_method"],
+        "used_models": used_models,
+    }
+
+
+def tool_definitions() -> list[dict[str, Any]]:
+    annotations = {
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    }
+    return [
+        {
+            "name": "review_plan",
+            "title": "Review a plan with Claude Fable 5",
+            "description": (
+                "Send one self-contained, read-only plan-review packet to the configured "
+                "Claude Fable 5 advisor."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "packet": {
+                        "type": "string",
+                        "description": "Complete context, plan, risks, slices, and checks.",
+                    }
+                },
+                "required": ["packet"],
+                "additionalProperties": False,
+            },
+            "annotations": annotations,
+        },
+        {
+            "name": "status",
+            "title": "Check Claude Fable 5 advisor status",
+            "description": "Check the saved route and Claude Code login without a model call.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": False,
+            },
+            "annotations": annotations,
+        },
+    ]
+
+
+def _tool_result(payload: dict[str, Any], *, is_error: bool = False) -> dict[str, Any]:
+    return {
+        "content": [{"type": "text", "text": json.dumps(payload, sort_keys=True)}],
+        "isError": is_error,
+    }
+
+
+def handle_request(request: dict[str, Any]) -> dict[str, Any] | None:
+    method = request.get("method")
+    request_id = request.get("id")
+    if request_id is None:
+        return None
+    if method == "initialize":
+        result = {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {"tools": {"listChanged": False}},
+            "serverInfo": {"name": "codex-orchestration-fable-advisor", "version": "1.0.0"},
+        }
+    elif method == "ping":
+        result = {}
+    elif method == "tools/list":
+        result = {"tools": tool_definitions()}
+    elif method == "tools/call":
+        params = request.get("params")
+        name = params.get("name") if isinstance(params, dict) else None
+        arguments = params.get("arguments", {}) if isinstance(params, dict) else {}
+        try:
+            if name == "review_plan":
+                packet = arguments.get("packet") if isinstance(arguments, dict) else None
+                result = _tool_result(review_plan(packet))
+            elif name == "status":
+                route = load_fable_route()
+                auth = check_claude_auth()
+                result = _tool_result({"available": True, **route, **auth})
+            else:
+                raise AdvisorError(f"Unknown tool: {name!r}.")
+        except AdvisorError as exc:
+            result = _tool_result({"available": False, "error": str(exc)}, is_error=True)
+    else:
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": {"code": -32601, "message": f"Method not found: {method}"},
+        }
+    return {"jsonrpc": "2.0", "id": request_id, "result": result}
+
+
+def main() -> int:
+    for line in sys.stdin:
+        try:
+            request = json.loads(line)
+            if not isinstance(request, dict):
+                raise ValueError("request must be an object")
+            response = handle_request(request)
+        except (json.JSONDecodeError, ValueError) as exc:
+            response = {
+                "jsonrpc": "2.0",
+                "id": None,
+                "error": {"code": -32700, "message": str(exc)},
+            }
+        if response is not None:
+            print(json.dumps(response, separators=(",", ":")), flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+# Production scripts remain standard-library only. This file is for CI/development.
+ruff==0.15.21

--- a/scripts/release_check.py
+++ b/scripts/release_check.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Validate release metadata before tagging Codex-Orchestration."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import re
+import subprocess
+import sys
+
+
+SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$")
+CHANGELOG_VERSION_RE = re.compile(r"^## ([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?)\s+—\s+(.+)$", re.MULTILINE)
+
+
+class ReleaseCheckError(RuntimeError):
+    pass
+
+
+def run_check(root: Path, require_tag: bool) -> str:
+    manifest_path = root / "plugins/codex-orchestration/.codex-plugin/plugin.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    version = manifest.get("version")
+    if not isinstance(version, str) or not SEMVER_RE.fullmatch(version):
+        raise ReleaseCheckError(f"manifest version is not semantic: {version!r}")
+
+    changelog = (root / "CHANGELOG.md").read_text(encoding="utf-8")
+    match = CHANGELOG_VERSION_RE.search(changelog)
+    if match is None:
+        raise ReleaseCheckError("changelog has no version heading")
+    if match.group(1) != version:
+        raise ReleaseCheckError(
+            f"manifest version {version} does not match latest changelog {match.group(1)}"
+        )
+
+    lifecycle = (root / "tests/plugin_lifecycle_smoke.py").read_text(encoding="utf-8")
+    if f'NEW_VERSION = "{version}"' not in lifecycle:
+        raise ReleaseCheckError("lifecycle NEW_VERSION does not match the manifest")
+
+    if require_tag:
+        result = subprocess.run(
+            ["git", "tag", "--points-at", "HEAD"],
+            cwd=root,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=10,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise ReleaseCheckError(f"could not inspect release tags: {result.stderr.strip()}")
+        expected = f"v{version}"
+        if expected not in result.stdout.splitlines():
+            raise ReleaseCheckError(f"HEAD is not tagged with {expected}")
+        if match.group(2).strip().lower() == "unreleased":
+            raise ReleaseCheckError("tagged release still says Unreleased in CHANGELOG.md")
+
+    return version
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-root", type=Path, default=Path(__file__).resolve().parents[1])
+    parser.add_argument("--require-tag", action="store_true")
+    args = parser.parse_args()
+    try:
+        version = run_check(args.repo_root.resolve(), args.require_tag)
+    except (OSError, json.JSONDecodeError, ReleaseCheckError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    print(f"Release metadata is consistent for {version}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/plugin_lifecycle_smoke.py
+++ b/tests/plugin_lifecycle_smoke.py
@@ -199,7 +199,11 @@ def main() -> int:
         )
     )
     current_version = manifest.get("version")
-    assert_equal(current_version, NEW_VERSION, "checkout release version")
+    if not isinstance(current_version, str):
+        raise SmokeFailure("checkout release version is not a string")
+    assert_equal(
+        current_version.split("+", 1)[0], NEW_VERSION, "checkout release base version"
+    )
 
     with tempfile.TemporaryDirectory(prefix="codex-orchestration-lifecycle-") as raw:
         temp = Path(raw)

--- a/tests/plugin_lifecycle_smoke.py
+++ b/tests/plugin_lifecycle_smoke.py
@@ -2,7 +2,7 @@
 """Exercise a real Codex plugin install, Git upgrade, and both setup routes.
 
 A disposable bare Git marketplace is served over loopback HTTP. The real Codex
-CLI installs 0.3.0, runs its documented marketplace-upgrade command after 0.4.0
+CLI installs 0.3.0, runs its documented marketplace-upgrade command after 0.5.0
 is pushed to that Git remote, installs the refreshed package, verifies its cache,
 and runs native-policy plus custom-agent setup/status/cleanup in isolation.
 """
@@ -30,7 +30,7 @@ PLUGIN_ID = "codex-orchestration@codex-orchestration"
 MARKETPLACE_NAME = "codex-orchestration"
 OLD_RELEASE = "d93b86e735a12a9fefcfd35b0b35199ce3e9a2a7"
 OLD_VERSION = "0.3.0"
-NEW_VERSION = "0.4.0"
+NEW_VERSION = "0.5.0"
 COMMAND_TIMEOUT_SECONDS = 60
 
 
@@ -421,6 +421,65 @@ def main() -> int:
                 "installed package contents",
             )
 
+            native_configurator = (
+                installed_root
+                / "skills"
+                / "codex-orchestration"
+                / "scripts"
+                / "configure_native_routing.py"
+            )
+            direct_native_command = [
+                sys.executable,
+                str(native_configurator),
+                "--codex-bin",
+                codex,
+                "--codex-home",
+                str(codex_home),
+                "--allow-incompatible-client",
+                "--executor-model",
+                "gpt-5.6-luna",
+                "--executor-effort",
+                "xhigh",
+            ]
+            direct_preview = run(direct_native_command, cwd=project, env=env)
+            if "Dry run only" not in direct_preview.stdout:
+                raise SmokeFailure("Direct native setup did not report a dry run")
+            direct_apply = run(
+                [*direct_native_command, "--apply"], cwd=project, env=env
+            )
+            if "Native routing policy installed" not in direct_apply.stdout:
+                raise SmokeFailure("Direct native setup did not install its policy")
+            direct_status = run(
+                [
+                    sys.executable,
+                    str(native_configurator),
+                    "--codex-bin",
+                    codex,
+                    "--codex-home",
+                    str(codex_home),
+                    "--status",
+                    "--require-effective",
+                ],
+                cwd=project,
+                env=env,
+            )
+            if "Executor: gpt-5.6-luna@xhigh" not in direct_status.stdout:
+                raise SmokeFailure("Direct native status lost the selected model route")
+            run(
+                [
+                    sys.executable,
+                    str(native_configurator),
+                    "--codex-bin",
+                    codex,
+                    "--codex-home",
+                    str(codex_home),
+                    "--disable",
+                    "--apply",
+                ],
+                cwd=project,
+                env=env,
+            )
+
             fake_codex = temp / "fake-codex"
             write_fake_codex(fake_codex)
             configurator = (
@@ -479,13 +538,6 @@ def main() -> int:
                 if expected not in executor:
                     raise SmokeFailure(f"Generated executor is missing {expected!r}")
 
-            native_configurator = (
-                installed_root
-                / "skills"
-                / "codex-orchestration"
-                / "scripts"
-                / "configure_native_routing.py"
-            )
             native_command = [
                 sys.executable,
                 str(native_configurator),
@@ -523,6 +575,7 @@ def main() -> int:
                     "--codex-home",
                     str(codex_home),
                     "--status",
+                    "--require-effective",
                 ],
                 cwd=project,
                 env=env,

--- a/tests/test_configure_orchestration.py
+++ b/tests/test_configure_orchestration.py
@@ -1544,9 +1544,7 @@ multi_agent = true'''
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
             path = root / "agent.toml"
-            # Keep the fixture byte-exact on Windows; the production reader uses
-            # newline="" so CRLF translation must not mask the intended branch.
-            path.write_bytes(b"old\n")
+            path.write_text("old\n", encoding="utf-8")
 
             child = os.fork()
             if child == 0:  # pragma: no cover - assertions run in parent
@@ -2084,7 +2082,9 @@ multi_agent = true'''
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
             path = root / "agent.toml"
-            path.write_text("old\n", encoding="utf-8")
+            # Keep the fixture byte-exact on Windows; the production reader uses
+            # newline="" so CRLF translation must not mask the intended branch.
+            path.write_bytes(b"old\n")
 
             with (
                 mock.patch.object(CONFIGURE.os, "name", "nt"),

--- a/tests/test_configure_orchestration.py
+++ b/tests/test_configure_orchestration.py
@@ -1544,7 +1544,9 @@ multi_agent = true'''
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
             path = root / "agent.toml"
-            path.write_text("old\n", encoding="utf-8")
+            # Keep the fixture byte-exact on Windows; the production reader uses
+            # newline="" so CRLF translation must not mask the intended branch.
+            path.write_bytes(b"old\n")
 
             child = os.fork()
             if child == 0:  # pragma: no cover - assertions run in parent

--- a/tests/test_fable_advisor_mcp.py
+++ b/tests/test_fable_advisor_mcp.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+from unittest import mock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = (
+    REPO_ROOT
+    / "plugins"
+    / "codex-orchestration"
+    / "skills"
+    / "codex-orchestration"
+    / "scripts"
+    / "fable_advisor_mcp.py"
+)
+SPEC = importlib.util.spec_from_file_location("fable_advisor_mcp", SCRIPT)
+assert SPEC and SPEC.loader
+FABLE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(FABLE)
+
+
+class FableAdvisorMcpTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.home = Path(self.temp.name)
+        (self.home / FABLE.STATE_FILENAME).write_text(
+            json.dumps(
+                {
+                    "advisor": {
+                        "kind": "fable",
+                        "model": "claude-fable-5",
+                        "effort": "max",
+                        "server": "fable-advisor-python3",
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    @staticmethod
+    def completed(command: list[str], stdout: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(command, 0, stdout, "")
+
+    def test_review_is_pinned_sanitized_read_only_and_runtime_confirmed(self) -> None:
+        calls: list[tuple[list[str], dict[str, object]]] = []
+
+        def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+            calls.append((command, kwargs))
+            if command[-2:] == ["auth", "status"]:
+                return self.completed(
+                    command,
+                    json.dumps(
+                        {
+                            "loggedIn": True,
+                            "authMethod": "claude.ai",
+                            "apiProvider": "firstParty",
+                            "subscriptionType": "max",
+                        }
+                    ),
+                )
+            return self.completed(
+                command,
+                json.dumps(
+                    {
+                        "result": "PLAN_APPROVED\nNo material gap found.",
+                        "modelUsage": {"claude-fable-5": {"outputTokens": 12}},
+                    }
+                ),
+            )
+
+        env = {
+            "CODEX_HOME": str(self.home),
+            "ANTHROPIC_API_KEY": "must-not-leak",
+            "ANTHROPIC_AUTH_TOKEN": "must-not-leak",
+            "CLAUDE_CODE_USE_BEDROCK": "1",
+        }
+        with (
+            mock.patch.dict(os.environ, env, clear=False),
+            mock.patch.object(FABLE, "resolve_claude", return_value=Path("/fake/claude")),
+            mock.patch.object(FABLE.subprocess, "run", side_effect=fake_run),
+        ):
+            result = FABLE.review_plan("Review this complete plan.")
+
+        self.assertEqual(result["decision"], "PLAN_APPROVED")
+        self.assertEqual(result["model"], "claude-fable-5")
+        self.assertEqual(result["used_models"], ["claude-fable-5"])
+        self.assertNotIn("subscription_type", result)
+        review_command, review_kwargs = calls[1]
+        self.assertIn("--safe-mode", review_command)
+        self.assertNotIn("--bare", review_command)
+        self.assertEqual(review_command[review_command.index("--model") + 1], "claude-fable-5")
+        self.assertEqual(review_command[review_command.index("--effort") + 1], "max")
+        self.assertEqual(
+            review_command[review_command.index("--prompt-suggestions") + 1], "false"
+        )
+        self.assertEqual(review_kwargs["input"], "Review this complete plan.")
+        sanitized = review_kwargs["env"]
+        self.assertIsInstance(sanitized, dict)
+        for name in FABLE.SENSITIVE_ENV:
+            self.assertNotIn(name, sanitized)
+
+    def test_invalid_decision_or_unconfirmed_model_fails_closed(self) -> None:
+        auth = self.completed(
+            ["claude", "auth", "status"],
+            json.dumps(
+                {
+                    "loggedIn": True,
+                    "authMethod": "claude.ai",
+                    "apiProvider": "firstParty",
+                    "subscriptionType": "pro",
+                }
+            ),
+        )
+        malformed = self.completed(
+            ["claude"],
+            json.dumps(
+                {
+                    "result": "Looks good.",
+                    "modelUsage": {"claude-fable-5": {}},
+                }
+            ),
+        )
+        with (
+            mock.patch.dict(os.environ, {"CODEX_HOME": str(self.home)}),
+            mock.patch.object(FABLE, "resolve_claude", return_value=Path("/fake/claude")),
+            mock.patch.object(FABLE.subprocess, "run", side_effect=[auth, malformed]),
+        ):
+            with self.assertRaisesRegex(FABLE.AdvisorError, "required plan decision"):
+                FABLE.review_plan("packet")
+
+        unconfirmed = self.completed(
+            ["claude"],
+            json.dumps(
+                {
+                    "result": "PLAN_REVISE\nFix the verification step.",
+                    "modelUsage": {"claude-haiku-4-5": {}},
+                }
+            ),
+        )
+        with (
+            mock.patch.dict(os.environ, {"CODEX_HOME": str(self.home)}),
+            mock.patch.object(FABLE, "resolve_claude", return_value=Path("/fake/claude")),
+            mock.patch.object(FABLE.subprocess, "run", side_effect=[auth, unconfirmed]),
+        ):
+            with self.assertRaisesRegex(FABLE.AdvisorError, "did not confirm"):
+                FABLE.review_plan("packet")
+
+    def test_mcp_surface_exposes_only_bounded_tools(self) -> None:
+        initialized = FABLE.handle_request(
+            {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}
+        )
+        self.assertEqual(initialized["result"]["serverInfo"]["name"], "codex-orchestration-fable-advisor")
+        listed = FABLE.handle_request(
+            {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}}
+        )
+        tools = listed["result"]["tools"]
+        self.assertEqual([tool["name"] for tool in tools], ["review_plan", "status"])
+        for tool in tools:
+            self.assertTrue(tool["annotations"]["readOnlyHint"])
+            self.assertFalse(tool["annotations"]["destructiveHint"])
+        review_schema = tools[0]["inputSchema"]
+        self.assertEqual(review_schema["required"], ["packet"])
+        self.assertFalse(review_schema["additionalProperties"])
+
+    def test_status_does_not_expose_account_plan_metadata(self) -> None:
+        with (
+            mock.patch.object(FABLE, "load_fable_route", return_value={"model": "claude-fable-5", "effort": "max"}),
+            mock.patch.object(
+                FABLE,
+                "check_claude_auth",
+                return_value={"auth_method": "claude.ai", "api_provider": "firstParty"},
+            ),
+        ):
+            response = FABLE.handle_request(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 3,
+                    "method": "tools/call",
+                    "params": {"name": "status", "arguments": {}},
+                }
+            )
+        text = response["result"]["content"][0]["text"]
+        self.assertNotIn("subscription", text.lower())
+        self.assertNotIn("account_plan", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_native_routing.py
+++ b/tests/test_native_routing.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 import io
 import json
+import os
 from pathlib import Path
 import subprocess
 import sys
@@ -75,7 +76,24 @@ def version():
     return int(version_file.read_text()) if version_file.exists() else 0
 
 def set_path(root, path, value):
-    parts = path.split(".")
+    parts = []
+    current_part = []
+    quoted = False
+    escaped = False
+    for character in path:
+        if escaped:
+            current_part.append(character)
+            escaped = False
+        elif character == "\\" and quoted:
+            escaped = True
+        elif character == '"':
+            quoted = not quoted
+        elif character == "." and not quoted:
+            parts.append("".join(current_part))
+            current_part = []
+        else:
+            current_part.append(character)
+    parts.append("".join(current_part))
     current = root
     for part in parts[:-1]:
         if not isinstance(current.get(part), dict):
@@ -227,6 +245,32 @@ class NativeRoutingTests(unittest.TestCase):
         self.codex = self.root / "fake-codex"
         self.codex.write_text(textwrap.dedent(FAKE_CODEX), encoding="utf-8")
         self.codex.chmod(0o755)
+        self.bin = self.root / "bin"
+        self.bin.mkdir()
+        self.claude = self.bin / "claude"
+        self.claude.write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env python3
+                import json
+                import sys
+                if sys.argv[1:] == ["auth", "status"]:
+                    print(json.dumps({
+                        "loggedIn": True,
+                        "authMethod": "claude.ai",
+                        "apiProvider": "firstParty",
+                        "subscriptionType": "max",
+                    }))
+                    raise SystemExit(0)
+                if sys.argv[1:] == ["--help"]:
+                    print("--model --effort --safe-mode --prompt-suggestions")
+                    raise SystemExit(0)
+                raise SystemExit(2)
+                """
+            ),
+            encoding="utf-8",
+        )
+        self.claude.chmod(0o755)
 
     def tearDown(self) -> None:
         self.temp.cleanup()
@@ -238,6 +282,8 @@ class NativeRoutingTests(unittest.TestCase):
         allow_incompatible: bool = True,
     ) -> subprocess.CompletedProcess[str]:
         compatibility = ["--allow-incompatible-client"] if allow_incompatible else []
+        env = os.environ.copy()
+        env["PATH"] = f"{self.bin}{os.pathsep}{env.get('PATH', '')}"
         result = subprocess.run(
             [
                 sys.executable,
@@ -254,6 +300,7 @@ class NativeRoutingTests(unittest.TestCase):
             stderr=subprocess.PIPE,
             timeout=20,
             check=False,
+            env=env,
         )
         if check and result.returncode != 0:
             self.fail(f"command failed\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}")
@@ -905,6 +952,65 @@ class NativeRoutingTests(unittest.TestCase):
         usage = feature["usage_hint_text"]
         self.assertIn('agent_type = "codex_orchestration_executor"', usage)
         self.assertIn('agent_type = "codex_orchestration_advisor"', usage)
+
+    def test_fable_setup_status_update_and_disable_restore_mcp_policy(self) -> None:
+        initial = {
+            "features": {
+                "multi_agent_v2": {"max_concurrent_threads_per_session": 5}
+            },
+            "plugins": {
+                NATIVE.PLUGIN_ID: {
+                    "mcp_servers": {
+                        "fable-advisor-python3": {"enabled": False},
+                        "fable-advisor-python": {"enabled": True},
+                    }
+                }
+            },
+            "unrelated": {"keep": True},
+        }
+        (self.home / ".fake-user-config.json").write_text(
+            json.dumps(initial), encoding="utf-8"
+        )
+        setup = self.run_script(
+            "--executor-model",
+            "gpt-5.6-luna",
+            "--executor-effort",
+            "xhigh",
+            "--advisor-fable",
+            "--advisor-effort",
+            "max",
+            "--apply",
+        )
+        self.assertIn("Claude Fable 5 Extra High", setup.stdout)
+        config = self.read_fake_config()
+        servers = config["plugins"][NATIVE.PLUGIN_ID]["mcp_servers"]
+        self.assertTrue(servers["fable-advisor-python3"]["enabled"])
+        self.assertFalse(servers["fable-advisor-python"]["enabled"])
+        self.assertNotIn("fable-advisor-py", servers)
+        state = json.loads(
+            (self.home / NATIVE.STATE_FILENAME).read_text(encoding="utf-8")
+        )
+        self.assertEqual(state["advisor"]["kind"], "fable")
+        self.assertEqual(state["advisor"]["model"], "claude-fable-5")
+        self.assertIn("mcp", state["previous"])
+
+        status = self.run_script("--status")
+        self.assertIn("Claude Fable 5: ready", status.stdout)
+        self.assertIn("no model call made", status.stdout)
+
+        update = self.run_script(
+            "--executor-model",
+            "gpt-5.6-terra",
+            "--executor-effort",
+            "high",
+            "--apply",
+        )
+        self.assertIn("Advisor: none", update.stdout)
+        servers = self.read_fake_config()["plugins"][NATIVE.PLUGIN_ID]["mcp_servers"]
+        self.assertTrue(all(not entry["enabled"] for entry in servers.values()))
+
+        self.run_script("--disable", "--apply")
+        self.assertEqual(self.read_fake_config(), initial)
 
     def test_missing_or_project_shadowed_custom_agent_is_refused(self) -> None:
         missing = self.run_script(

--- a/tests/test_native_routing.py
+++ b/tests/test_native_routing.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import importlib.util
+import io
 import json
-import os
 from pathlib import Path
 import subprocess
 import sys
@@ -352,6 +352,10 @@ class NativeRoutingTests(unittest.TestCase):
         self.assertIn("Executor: gpt-5.6-luna@xhigh", status.stdout)
         self.assertIn("Advisor: none", status.stdout)
         self.assertIn("V2 tool namespace: agents", status.stdout)
+        self.assertIn("Routing validation: not performed", status.stdout)
+
+        required = self.run_script("--status", "--require-effective")
+        self.assertEqual(required.returncode, 0)
 
         disabled = self.run_script("--disable", "--apply")
         self.assertIn("Native routing disabled", disabled.stdout)
@@ -502,6 +506,10 @@ class NativeRoutingTests(unittest.TestCase):
         status = self.run_script("--status")
         self.assertIn("managed fields conflict", status.stdout)
         self.assertIn("Seats: suppressed", status.stdout)
+        required = self.run_script(
+            "--status", "--require-effective", check=False
+        )
+        self.assertEqual(required.returncode, 1)
         update = self.run_script(
             "--executor-model",
             "gpt-5.6-terra",
@@ -574,6 +582,69 @@ class NativeRoutingTests(unittest.TestCase):
             allow_incompatible=False,
         )
         self.assertIn("Native routing disabled", disabled.stdout)
+
+    def test_require_effective_rejects_inactive_and_incompatible_status(self) -> None:
+        inactive = self.run_script(
+            "--status", "--require-effective", check=False
+        )
+        self.assertEqual(inactive.returncode, 1)
+        self.assertIn("Native policy: inactive", inactive.stdout)
+
+        self.run_script(
+            "--executor-model",
+            "gpt-5.6-luna",
+            "--executor-effort",
+            "high",
+            "--apply",
+        )
+        old_codex = self.root / "old-status-codex"
+        old_codex.write_text(textwrap.dedent(FAKE_CODEX), encoding="utf-8")
+        old_codex.chmod(0o755)
+        incompatible = self.run_script(
+            "--status",
+            "--require-effective",
+            "--compat-bin",
+            str(old_codex),
+            check=False,
+        )
+        self.assertEqual(incompatible.returncode, 1)
+        self.assertIn("incompatible", incompatible.stdout)
+
+    def test_require_effective_rejects_orphaned_managed_personal_role(self) -> None:
+        self.run_script(
+            "--executor-model",
+            "gpt-5.6-luna",
+            "--executor-effort",
+            "high",
+            "--apply",
+        )
+        agents = self.home / "agents"
+        agents.mkdir()
+        orphan_name = "codex_orchestration_executor_012345abcdef"
+        (agents / "orphan.toml").write_text(
+            "\n".join(
+                (
+                    NATIVE.CUSTOM_AGENT_MANAGED_MARKER,
+                    f'name = "{orphan_name}"',
+                    'description = "Managed orphan"',
+                    'model = "gpt-5.6-luna"',
+                    'developer_instructions = "Stay bounded."',
+                    "",
+                )
+            ),
+            encoding="utf-8",
+        )
+        status = self.run_script(
+            "--status", "--require-effective", check=False
+        )
+        self.assertEqual(status.returncode, 1)
+        self.assertIn("Orphaned managed custom agents", status.stdout)
+        self.assertIn(orphan_name, status.stdout)
+
+    def test_require_effective_requires_status(self) -> None:
+        result = self.run_script("--require-effective", check=False)
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("requires --status", result.stderr)
 
     def test_state_from_another_config_is_refused(self) -> None:
         self.run_script(
@@ -684,6 +755,55 @@ class NativeRoutingTests(unittest.TestCase):
         )
         self.assertEqual(state["executor"]["model"], "gpt-5.6-luna")
 
+    def test_effective_readback_rejects_unexpected_rollback_status(self) -> None:
+        effective = {
+            "features": {
+                "multi_agent_v2": {
+                    "hide_spawn_agent_metadata": True,
+                    "tool_namespace": "collaboration",
+                }
+            }
+        }
+        (self.home / ".fake-effective-config.json").write_text(
+            json.dumps(effective), encoding="utf-8"
+        )
+        real_batch_write = NATIVE._batch_write
+        calls = 0
+
+        def batch_write(*args: object, **kwargs: object) -> dict[str, object]:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                return real_batch_write(*args, **kwargs)
+            return {"status": "unexpected", "version": "sha256:unknown"}
+
+        argv = [
+            str(SCRIPT),
+            "--codex-bin",
+            str(self.codex),
+            "--codex-home",
+            str(self.home),
+            "--allow-incompatible-client",
+            "--executor-model",
+            "gpt-5.6-luna",
+            "--executor-effort",
+            "high",
+            "--apply",
+        ]
+        stderr = io.StringIO()
+        with (
+            mock.patch.object(sys, "argv", argv),
+            mock.patch.object(NATIVE, "_batch_write", side_effect=batch_write),
+            mock.patch.object(sys, "stderr", stderr),
+        ):
+            result = NATIVE.main()
+
+        self.assertEqual(result, 2)
+        self.assertEqual(calls, 2)
+        self.assertIn("automatic rollback failed", stderr.getvalue())
+        self.assertIn("unexpected rollback status", stderr.getvalue())
+        self.assertTrue((self.home / NATIVE.STATE_FILENAME).exists())
+
     def test_ok_overridden_restores_every_owned_field(self) -> None:
         initial = {
             "features": {
@@ -725,6 +845,50 @@ class NativeRoutingTests(unittest.TestCase):
         self.assertEqual(feature["tool_namespace"], "agents")
         self.assertIn(NATIVE.MANAGED_MARKER, feature["usage_hint_text"])
         self.assertFalse((self.home / NATIVE.STATE_FILENAME).exists())
+
+    def test_state_failure_rejects_unexpected_rollback_status(self) -> None:
+        real_batch_write = NATIVE._batch_write
+        calls = 0
+
+        def batch_write(*args: object, **kwargs: object) -> dict[str, object]:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                return real_batch_write(*args, **kwargs)
+            return {"status": "unexpected", "version": "sha256:unknown"}
+
+        argv = [
+            str(SCRIPT),
+            "--codex-bin",
+            str(self.codex),
+            "--codex-home",
+            str(self.home),
+            "--allow-incompatible-client",
+            "--executor-model",
+            "gpt-5.6-luna",
+            "--executor-effort",
+            "high",
+            "--apply",
+        ]
+        stderr = io.StringIO()
+        with (
+            mock.patch.object(sys, "argv", argv),
+            mock.patch.object(
+                NATIVE,
+                "_write_state",
+                side_effect=NATIVE.ConfigurationError("forced state failure"),
+            ),
+            mock.patch.object(NATIVE, "_batch_write", side_effect=batch_write),
+            mock.patch.object(sys, "stderr", stderr),
+        ):
+            result = NATIVE.main()
+
+        self.assertEqual(result, 2)
+        self.assertEqual(calls, 2)
+        self.assertIn("may still contain managed fields", stderr.getvalue())
+        self.assertIn("unexpected rollback status", stderr.getvalue())
+        feature = self.read_fake_config()["features"]["multi_agent_v2"]
+        self.assertIn(NATIVE.MANAGED_MARKER, feature["usage_hint_text"])
 
     def test_custom_agent_route_and_optional_advisor(self) -> None:
         self.write_personal_agent("codex_orchestration_executor")

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -24,7 +24,7 @@ class PackagingTests(unittest.TestCase):
 
         self.assertEqual(manifest["name"], "codex-orchestration")
         self.assertEqual(manifest["skills"], "./skills/")
-        self.assertEqual(manifest["version"], "0.4.0")
+        self.assertEqual(manifest["version"], "0.5.0")
         self.assertRegex(
             manifest["version"],
             r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$",
@@ -89,7 +89,7 @@ class PackagingTests(unittest.TestCase):
         self.assertIn("@openai/codex@0.144.1", workflow)
         smoke_text = smoke.read_text(encoding="utf-8")
         self.assertIn('OLD_VERSION = "0.3.0"', smoke_text)
-        self.assertIn('NEW_VERSION = "0.4.0"', smoke_text)
+        self.assertIn('NEW_VERSION = "0.5.0"', smoke_text)
         self.assertIn("configure_native_routing.py", smoke_text)
         self.assertIn("configure_orchestration.py", smoke_text)
         self.assertIn('"marketplace",\n                    "upgrade"', smoke_text)
@@ -110,10 +110,10 @@ class PackagingTests(unittest.TestCase):
             encoding="utf-8"
         )
 
-        self.assertIn("Is config alone enough?", readme)
+        self.assertIn("What config can and cannot prove", readme)
         self.assertIn("Neither says “use Luna.”", readme)
         self.assertIn("no global `executor_model = ...`", readme)
-        self.assertIn("Same-provider config routing is strong tool-level guidance", readme)
+        self.assertIn("Same-provider config routing is tool-level policy", readme)
         self.assertIn('sets `tool_namespace = "agents"`', readme)
         self.assertIn("reserved `collaboration.spawn_agent` schema", readme)
         self.assertIn("does **not** force `enabled = true`", readme)

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -117,9 +117,9 @@ class PackagingTests(unittest.TestCase):
 
         self.assertIn("already the orchestrator", skill)
         self.assertIn("The current task model remains the root", skill)
-        self.assertIn("model you select when you start the task is the orchestrator", readme)
-        self.assertIn("ROOT MODEL / ORCHESTRATOR", readme)
-        self.assertIn("orchestrator remains the only model that owns the whole task", readme)
+        self.assertIn("model selected for the task stays in charge", readme)
+        self.assertIn("SOL — ROOT ORCHESTRATOR", readme)
+        self.assertIn("Codex remains the root orchestrator", readme)
         self.assertNotIn("--orchestrator-model", skill + readme)
 
     def test_readme_explains_policy_guided_route_without_overpromising(self) -> None:
@@ -128,26 +128,26 @@ class PackagingTests(unittest.TestCase):
             encoding="utf-8"
         )
 
-        self.assertIn("policy-guided routing, not a separate scheduler", readme)
-        self.assertIn("Codex decides whether delegation is useful", readme)
-        self.assertIn("Exact runtime identity is called confirmed only", readme)
-        self.assertIn("A model name alone does not create provider access", readme)
+        self.assertIn("Other providers must already be configured and authenticated", readme)
+        self.assertIn("never creates credentials or bypasses permissions", readme)
+        self.assertIn("Codex decides when delegation or parallel work is useful", readme)
+        self.assertIn("Fable 5 is a root-facing plan advisor, not a second orchestrator", readme)
         self.assertIn('ROUTING_TOOL_NAMESPACE = "agents"', native)
 
     def test_ascii_and_role_copy_are_plain_and_root_centered(self) -> None:
         readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
 
-        self.assertIn("ROOT MODEL / ORCHESTRATOR", readme)
-        self.assertIn("Optional specialist roles", readme)
-        self.assertIn("ORCHESTRATOR DECIDES", readme)
-        self.assertIn("Execution roles", readme)
-        self.assertIn("ORCHESTRATOR VERIFIES", readme)
+        self.assertIn("SOL — ROOT ORCHESTRATOR", readme)
+        self.assertIn("FABLE 5 — PLAN ADVISOR", readme)
+        self.assertIn("LUNA EXECUTOR 1", readme)
+        self.assertIn("LUNA EXECUTOR 2", readme)
+        self.assertIn("tests and delivers", readme)
         self.assertNotIn("SOL IS THE ORCHESTRATOR", readme)
 
     def test_readme_leads_with_the_product_before_installation(self) -> None:
         readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
 
-        what = readme.index("## What is Codex Orchestration?")
+        what = readme.index("## What does it do?")
         diagram = readme.index("## How it works")
         value = readme.index("## Why use it?")
         install = readme.index("## Install")
@@ -167,30 +167,36 @@ class PackagingTests(unittest.TestCase):
     def test_cross_provider_copy_names_the_real_protocol_boundary(self) -> None:
         readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
 
-        self.assertIn("config-file/config-advanced#custom-model-providers", readme)
-        self.assertIn("any compatible provider already configured and authenticated", readme)
-        self.assertIn("compatible wire protocol and authentication setup", readme)
-        self.assertIn("A raw provider endpoint or API key is not automatically", readme)
-        self.assertIn("A native custom agent pins an already configured `model_provider`", readme)
+        self.assertIn("Other models must already be available through Codex", readme)
+        self.assertIn("an authenticated, compatible provider", readme)
+        self.assertIn("do not need to add an Anthropic API key to Codex", readme)
         self.assertIn("`.codex/agents/`", readme)
         self.assertIn("`~/.codex/agents/`", readme)
 
-    def test_savings_copy_is_clear_and_qualified(self) -> None:
+    def test_speed_and_limit_copy_is_clear_and_qualified(self) -> None:
         readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
 
-        self.assertIn("Lower model-weighted cost", readme)
-        self.assertIn("Multi-agent work can use more raw tokens", readme)
-        self.assertIn("Savings depend on the models, workload, context, retries", readme)
-        self.assertIn("they are not guaranteed", readme)
+        self.assertIn("up to 2x faster on suitable tasks", readme)
+        self.assertIn("limits about 40% less often", readme)
+        self.assertIn("speed and limit figures are targets, not guarantees", readme)
+
+    def test_fable_is_the_primary_quick_start(self) -> None:
+        readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+
+        self.assertIn("## Quick start with Fable 5", readme)
+        self.assertIn(
+            "advisor: Claude Fable 5 High",
+            readme,
+        )
+        self.assertNotIn("advisor: GPT-5.6 Terra", readme)
 
     def test_update_and_uninstall_remove_managed_state_explicitly(self) -> None:
         readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
 
         self.assertIn("/codex-orchestration status", readme)
-        self.assertIn("First disable the saved routing policy", readme)
-        self.assertIn("restores the values that existed before built-in routing setup", readme)
-        self.assertIn("Review user-owned arbitrary roles separately", readme)
-        self.assertIn("does not silently delete configuration", readme)
+        self.assertIn("`disable` restores the Codex routing values", readme)
+        self.assertIn("does not delete user-owned custom roles", readme)
+        self.assertIn("Review and remove any user-owned custom roles separately", readme)
 
 
 if __name__ == "__main__":

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -25,6 +25,7 @@ class PackagingTests(unittest.TestCase):
         self.assertEqual(manifest["name"], "codex-orchestration")
         self.assertEqual(manifest["skills"], "./skills/")
         self.assertEqual(manifest["version"], "0.5.0")
+        self.assertEqual(manifest["mcpServers"], "./.mcp.json")
         self.assertRegex(
             manifest["version"],
             r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$",
@@ -44,6 +45,23 @@ class PackagingTests(unittest.TestCase):
         self.assertIn("config/batchWrite", native.read_text(encoding="utf-8"))
         self.assertIn("Standalone custom agent", custom.read_text(encoding="utf-8"))
 
+    def test_fable_mcp_is_packaged_and_disabled_until_selected(self) -> None:
+        mcp = json.loads((PLUGIN_ROOT / ".mcp.json").read_text(encoding="utf-8"))
+        servers = mcp["mcpServers"]
+        self.assertEqual(
+            set(servers),
+            {
+                "fable-advisor-python3",
+                "fable-advisor-python",
+                "fable-advisor-py",
+            },
+        )
+        for server in servers.values():
+            self.assertFalse(server["enabled"])
+            self.assertEqual(server["cwd"], ".")
+            self.assertIn("fable_advisor_mcp.py", server["args"][-1])
+        self.assertTrue((SKILL_ROOT / "scripts" / "fable_advisor_mcp.py").is_file())
+
     def test_explicit_invocation_metadata_is_consistent(self) -> None:
         metadata = (SKILL_ROOT / "agents" / "openai.yaml").read_text(encoding="utf-8")
         readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
@@ -52,10 +70,9 @@ class PackagingTests(unittest.TestCase):
         self.assertIn("allow_implicit_invocation: false", metadata)
         self.assertIn("/codex-orchestration setup executor:", readme)
         self.assertIn("GPT-5.6 Luna Extra High", readme)
-        self.assertIn("$codex-orchestration:codex-orchestration", readme)
+        self.assertIn("/codex-orchestration create these project roles:", readme)
         self.assertIn("/codex-orchestration status", readme)
         self.assertIn("/codex-orchestration disable", readme)
-        self.assertIn("advisor: none", readme)
         self.assertIn("codex plugin add codex-orchestration@codex-orchestration", readme)
 
     def test_starter_prompts_fit_codex_limits(self) -> None:
@@ -100,36 +117,43 @@ class PackagingTests(unittest.TestCase):
 
         self.assertIn("already the orchestrator", skill)
         self.assertIn("The current task model remains the root", skill)
-        self.assertIn("model you select when you start a Codex task is already", readme)
-        self.assertIn("SOL IS THE ORCHESTRATOR", readme)
+        self.assertIn("model you select when you start the task is the orchestrator", readme)
+        self.assertIn("ROOT MODEL / ORCHESTRATOR", readme)
+        self.assertIn("orchestrator remains the only model that owns the whole task", readme)
         self.assertNotIn("--orchestrator-model", skill + readme)
 
-    def test_readme_explains_config_only_route_without_overpromising(self) -> None:
+    def test_readme_explains_policy_guided_route_without_overpromising(self) -> None:
         readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
         native = (SKILL_ROOT / "scripts" / "configure_native_routing.py").read_text(
             encoding="utf-8"
         )
 
-        self.assertIn("What config can and cannot prove", readme)
-        self.assertIn("Neither says “use Luna.”", readme)
-        self.assertIn("no global `executor_model = ...`", readme)
-        self.assertIn("Same-provider config routing is tool-level policy", readme)
-        self.assertIn('sets `tool_namespace = "agents"`', readme)
-        self.assertIn("reserved `collaboration.spawn_agent` schema", readme)
-        self.assertIn("does **not** force `enabled = true`", readme)
+        self.assertIn("policy-guided routing, not a separate scheduler", readme)
+        self.assertIn("Codex decides whether delegation is useful", readme)
+        self.assertIn("Exact runtime identity is called confirmed only", readme)
+        self.assertIn("A model name alone does not create provider access", readme)
         self.assertIn('ROUTING_TOOL_NAMESPACE = "agents"', native)
 
     def test_ascii_and_role_copy_are_plain_and_root_centered(self) -> None:
         readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
 
-        self.assertIn("SOL IS THE ORCHESTRATOR", readme)
-        self.assertIn("ADVISOR checks the plan", readme)
-        self.assertIn("LUNA / TERRA executor(s)", readme)
-        self.assertIn("SOL REVIEWS AND INTEGRATES", readme)
-        self.assertIn("Advisor: the second opinion", readme)
-        self.assertIn("Executor: the builder", readme)
-        self.assertNotIn("Native Codex", readme)
-        self.assertNotIn("CURRENT SESSION MODEL", readme)
+        self.assertIn("ROOT MODEL / ORCHESTRATOR", readme)
+        self.assertIn("Optional specialist roles", readme)
+        self.assertIn("ORCHESTRATOR DECIDES", readme)
+        self.assertIn("Execution roles", readme)
+        self.assertIn("ORCHESTRATOR VERIFIES", readme)
+        self.assertNotIn("SOL IS THE ORCHESTRATOR", readme)
+
+    def test_readme_leads_with_the_product_before_installation(self) -> None:
+        readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+
+        what = readme.index("## What is Codex Orchestration?")
+        diagram = readme.index("## How it works")
+        value = readme.index("## Why use it?")
+        install = readme.index("## Install")
+        self.assertLess(what, diagram)
+        self.assertLess(diagram, value)
+        self.assertLess(value, install)
 
     def test_advisor_protocol_is_bounded_and_root_only(self) -> None:
         skill = (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
@@ -144,32 +168,29 @@ class PackagingTests(unittest.TestCase):
         readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
 
         self.assertIn("config-file/config-advanced#custom-model-providers", readme)
-        self.assertIn("Responses wire protocol", readme)
-        self.assertIn("Anthropic Messages", readme)
-        self.assertIn("Amazon Bedrock", readme)
-        self.assertIn("configured and tested", readme)
-        self.assertIn("<personal-id>.toml", readme)
-        self.assertIn("same-name project collision", readme)
+        self.assertIn("any compatible provider already configured and authenticated", readme)
+        self.assertIn("compatible wire protocol and authentication setup", readme)
+        self.assertIn("A raw provider endpoint or API key is not automatically", readme)
+        self.assertIn("A native custom agent pins an already configured `model_provider`", readme)
+        self.assertIn("`.codex/agents/`", readme)
+        self.assertIn("`~/.codex/agents/`", readme)
 
-    def test_savings_copy_distinguishes_credits_from_raw_tokens(self) -> None:
+    def test_savings_copy_is_clear_and_qualified(self) -> None:
         readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
 
-        self.assertIn("illustrative reduction", readme)
-        self.assertIn("64%", readme)
-        self.assertIn("cannot promise 65% fewer raw tokens", readme)
-        self.assertIn("model-weighted Codex credits", readme)
+        self.assertIn("Lower model-weighted cost", readme)
         self.assertIn("Multi-agent work can use more raw tokens", readme)
-        self.assertIn("shared five-hour", readme)
-        self.assertIn("weekly allowances", readme)
+        self.assertIn("Savings depend on the models, workload, context, retries", readme)
+        self.assertIn("they are not guaranteed", readme)
 
     def test_update_and_uninstall_remove_managed_state_explicitly(self) -> None:
         readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
 
         self.assertIn("/codex-orchestration status", readme)
-        self.assertIn("First disable the persistent policy", readme)
-        self.assertIn("restores the values that existed before setup", readme)
-        self.assertIn("does not silently delete a policy", readme)
-        self.assertIn("versions 0.1–0.3", readme)
+        self.assertIn("First disable the saved routing policy", readme)
+        self.assertIn("restores the values that existed before built-in routing setup", readme)
+        self.assertIn("Review user-owned arbitrary roles separately", readme)
+        self.assertIn("does not silently delete configuration", readme)
 
 
 if __name__ == "__main__":

--- a/tests/test_release_check.py
+++ b/tests/test_release_check.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "release_check.py"
+SPEC = importlib.util.spec_from_file_location("release_check", SCRIPT)
+assert SPEC and SPEC.loader
+RELEASE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(RELEASE)
+
+
+class ReleaseCheckTests(unittest.TestCase):
+    def test_checkout_release_metadata_is_consistent(self) -> None:
+        self.assertEqual(RELEASE.run_check(REPO_ROOT, require_tag=False), "0.5.0")
+
+    def test_unreleased_checkout_is_not_tag_ready(self) -> None:
+        with self.assertRaisesRegex(RELEASE.ReleaseCheckError, "not tagged"):
+            RELEASE.run_check(REPO_ROOT, require_tag=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_skill_contract.py
+++ b/tests/test_skill_contract.py
@@ -111,6 +111,36 @@ class SkillContractTests(unittest.TestCase):
         self.assertIn("verify_agent_routes", NATIVE_SCRIPT)
         self.assertIn("same-name project role", SKILL)
 
+    def test_arbitrary_roles_are_native_bounded_and_user_owned(self) -> None:
+        self.assertIn("## Create arbitrary custom roles", SKILL)
+        self.assertIn("<trusted-project>/.codex/agents/<role-name>.toml", SKILL)
+        self.assertIn("`~/.codex/agents/<role-name>.toml`", SKILL)
+        self.assertIn("model_provider", SKILL)
+        self.assertIn("current task permission mode by default", SKILL)
+        self.assertIn("never bypasses the parent task's authority", SKILL)
+        self.assertIn("Refuse symlinked paths", SKILL)
+        self.assertIn("Arbitrary native roles are user-owned", SKILL)
+        self.assertIn("start a new task after creation", SKILL)
+        self.assertIn("root orchestrator owns every handoff", SKILL)
+
+    def test_custom_workflows_preserve_goal_ownership(self) -> None:
+        self.assertIn("researcher -> reviewer -> writer", SKILL)
+        self.assertIn("leave Goal lifecycle and limits under Codex's normal Goal controls", SKILL)
+        self.assertIn("does not silently create, pause, resume, or clear it", SKILL)
+
+    def test_fable_is_a_bundled_root_only_mcp_advisor(self) -> None:
+        self.assertIn("Claude Fable 5 Extra High", SKILL)
+        self.assertIn("--advisor-fable --advisor-effort max", SKILL)
+        self.assertIn("built-in cross-provider advisor exception", SKILL)
+        self.assertIn("All bundled variants are disabled by default", SKILL)
+        self.assertIn("first-party Pro or Max account", SKILL)
+        self.assertIn("never extracts a token", SKILL)
+        self.assertIn("runtime `modelUsage` to confirm `claude-fable-5`", SKILL)
+        self.assertIn("call the configured MCP server's `review_plan` tool", SKILL)
+        self.assertIn("instead of spawning an advisor child", SKILL)
+        self.assertIn("use the exact name `Claude Fable 5`", SKILL)
+        self.assertIn("do not expose or restate Claude account-plan metadata", SKILL)
+
     def test_direct_routes_are_guarded_to_the_root_provider(self) -> None:
         self.assertIn("Direct model overrides keep the root's provider", SKILL)
         self.assertIn("target model is on the same provider", NATIVE_SCRIPT)


### PR DESCRIPTION
## Summary

Makes Codex Orchestration understandable and launch-ready as a general multi-model workflow plugin.

Users can bring any model that Codex can already access, assign it a role, define the handoff order, and let the selected root model coordinate the task or Goal.

## What changed

- rewrites the README around the product: definition, simple provider-neutral diagram, value, installation, quick starts, custom roles, workflows, Goals, and permissions
- replaces model-specific ASCII art with a generic root → specialists → execution → verification flow
- updates marketplace descriptions, capabilities, starter prompts, and skill metadata
- adds native arbitrary-role guidance for project and personal custom agents
- integrates Claude Fable 5 as an opt-in, root-only plan advisor through the official Claude Code CLI
- keeps every Fable MCP launcher disabled by default and enables only the compatible selected route
- validates first-party Claude login, pins claude-fable-5, disables tools and session persistence, confirms runtime model metadata, and fails closed on malformed review decisions
- preserves the production hardening already in this branch: rollback validation, status --require-effective, orphan detection, protected CI, CodeQL, pinned Actions, security/release docs, and portability checks
- expands the audit log and release checklist for Fable and arbitrary roles

## Product boundary

“Any model” means a model available through the current Codex provider, an already configured compatible custom provider, or a deliberately bundled bridge such as Fable. The plugin does not create accounts, credentials, provider compatibility, or broader permissions.

Codex remains the root orchestrator. The workflow is policy-guided routing through Codex’s native multi-agent and custom-agent controls, not a separate scheduler.

## Validation

- plugin manifest validator — passed
- skill quick validator — passed
- python3 -m compileall -q plugins tests scripts — passed
- Ruff 0.15.21 — passed
- python3 -m unittest discover -s tests -v — 149 passed
- python3 tests/plugin_lifecycle_smoke.py — installed 0.3.0, upgraded to 0.5.0, validated cache, native/custom setup, status, and cleanup
- python3 scripts/release_check.py — passed

## Release boundary

This PR does not merge, tag, or publish. After protected checks pass and review is complete, follow RELEASE.md: merge, date the changelog, perform the live route checks, create signed v0.5.0, verify the tag, and publish the matching GitHub release.

Draft PR #1 is now superseded by this integrated release candidate.