### PR TITLE
Make Fable advisor effort configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.5.0 — Unreleased
 
-- Make Claude Fable 5 advisor effort configurable, default it to `high`, support `low` through `max`, and treat user-facing `ultra` as an explicit alias for Claude Code's `max`.
+- Make Claude Fable 5 advisor effort configurable, default it to `high`, support `low` through `max`, treat user-facing `ultra` as an explicit alias for Claude Code's `max`, and fail `--require-effective` when the saved Fable route is unavailable.
 - Add Claude Fable 5 as an opt-in, root-only advisor through a bundled local MCP bridge to the authenticated Claude Code CLI.
 - Keep every Fable launcher disabled by default, enable only one compatible Python 3.11+ route, and restore prior plugin overrides on disable.
 - Pin `claude-fable-5`, remove provider override variables, disable tools and session persistence, and fail closed unless the plan signal and runtime model are valid.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.5.0 — Unreleased
 
+- Make Claude Fable 5 advisor effort configurable, default it to `high`, support `low` through `max`, and treat user-facing `ultra` as an explicit alias for Claude Code's `max`.
 - Add Claude Fable 5 as an opt-in, root-only advisor through a bundled local MCP bridge to the authenticated Claude Code CLI.
 - Keep every Fable launcher disabled by default, enable only one compatible Python 3.11+ route, and restore prior plugin overrides on disable.
 - Pin `claude-fable-5`, remove provider override variables, disable tools and session persistence, and fail closed unless the plan signal and runtime model are valid.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Select the model you want to lead the task, then run:
 /codex-orchestration setup executor: GPT-5.6 Luna Extra High, advisor: Claude Fable 5 High
 ```
 
+Fable defaults to **High**. You can choose **Low**, **Medium**, **High**, **XHigh**, or **Max**. **Ultra** is also accepted and uses Max because Claude Code does not expose a separate Ultra effort.
+
 This creates the default workflow:
 
 ```text

--- a/plugins/codex-orchestration/skills/codex-orchestration/SKILL.md
+++ b/plugins/codex-orchestration/skills/codex-orchestration/SKILL.md
@@ -134,7 +134,7 @@ python3 <skill-dir>/scripts/configure_native_routing.py \
   --status --require-effective
 ```
 
-Run status from the target project. The first form is descriptive. Use `--require-effective` for automation and release gates; it returns nonzero for incompatible clients, conflicts, overrides, incomplete controls, unavailable agent routes, or orphaned v0.4+ personal roles. Report the current task model as the orchestrator, the configured executor and advisor, whether the personal policy is installed and effective in that workspace, whether effective spawn controls are visible, whether the effective tool namespace is `agents`, the target config path, and checked-client compatibility. State that neither status form proves a live route or infers v2 activation for the model selected in a task; current Sol or Terra is the intended root.
+Run status from the target project. The first form is descriptive. Use `--require-effective` for automation and release gates; it returns nonzero for incompatible clients, conflicts, overrides, incomplete controls, an unavailable Fable or custom-agent route, or orphaned v0.4+ personal roles. Report the current task model as the orchestrator, the configured executor and advisor, whether the personal policy is installed and effective in that workspace, whether effective spawn controls are visible, whether the effective tool namespace is `agents`, the target config path, and checked-client compatibility. State that neither status form proves a live route or infers v2 activation for the model selected in a task; current Sol or Terra is the intended root.
 
 To change seats, run normal `setup` again. The configurator keeps the original restore snapshot rather than treating its own managed values as user settings.
 

--- a/plugins/codex-orchestration/skills/codex-orchestration/SKILL.md
+++ b/plugins/codex-orchestration/skills/codex-orchestration/SKILL.md
@@ -15,7 +15,7 @@ Support these simple forms:
 
 ```text
 /codex-orchestration setup executor: GPT-5.6 Luna Extra High
-/codex-orchestration setup executor: GPT-5.6 Luna Extra High, advisor: Claude Fable 5 Extra High
+/codex-orchestration setup executor: GPT-5.6 Luna Extra High, advisor: Claude Fable 5 High
 /codex-orchestration create project role: researcher
 /codex-orchestration create personal roles: researcher, writer, reviewer
 /codex-orchestration status
@@ -46,7 +46,7 @@ For a task-local request, append `— <original task>`. Keep every supplied modi
 
 If an old prompt contains `orchestrator:`, explain that the current task model already owns that role. Ignore that seat instead of switching or persisting it.
 
-Normalize `Extra High` to `xhigh` for Codex models. `Claude Fable 5 Extra High` is the built-in advisor label; map it to `--advisor-fable --advisor-effort max`, not the Codex model catalog. Resolve every other display name to an exact ID only through the executing host's model catalog, picker, a loaded custom agent, or official provider documentation. Never invent an ID. For persistent direct routing, resolve `auto` to the catalog's concrete default.
+Normalize `Extra High` to `xhigh`. For Claude Fable 5, accept `Low`, `Medium`, `High`, `XHigh`, `Max`, or `Ultra`. Omission or `Auto` means `High`; `Ultra` is a user-facing alias for Claude Code's actual `max` setting and must be reported as that mapping. Route Fable with `--advisor-fable --advisor-effort <normalized-effort>`, not through the Codex model catalog. Resolve every other display name to an exact ID only through the executing host's model catalog, picker, a loaded custom agent, or official provider documentation. Never invent an ID. For persistent direct routing, resolve `auto` to the catalog's concrete default.
 
 Read [providers-and-models.md](references/providers-and-models.md) before setup, when clients disagree, when a model is absent, when providers differ, or when custom agents or legacy migration are involved.
 
@@ -101,7 +101,7 @@ python3 <skill-dir>/scripts/configure_native_routing.py \
   --apply
 ```
 
-Add `--advisor-model` and `--advisor-effort` for a same-provider Codex advisor. For Claude Fable 5, use `--advisor-fable --advisor-effort max`. The configurator requires Claude Code to be logged in through a first-party Pro or Max account, chooses an available Python 3.11+ MCP launcher, and performs only an auth/capability check during setup. It never extracts a token, writes a credential, or makes a model call during setup or status. Omission persists `advisor: none`.
+Add `--advisor-model` and `--advisor-effort` for a same-provider Codex advisor. For Claude Fable 5, use `--advisor-fable`; add `--advisor-effort low|medium|high|xhigh|max` when the user chooses one. Omitting Fable effort defaults to `high`, while user-facing `ultra` is normalized to Claude Code's `max`. The configurator verifies that the installed Claude Code CLI advertises the selected effective effort. It also requires Claude Code to be logged in through a first-party Pro or Max account, chooses an available Python 3.11+ MCP launcher, and performs only an auth/capability check during setup. It never extracts a token, writes a credential, or makes a model call during setup or status. Omission persists `advisor: none`.
 
 The configurator capability-tests the complete four-field preset on the active target, `codex` on PATH when different, the known macOS Desktop binary when present, and every explicit `--compat-bin`. A successful isolated config probe means that client can parse the preset; it is not a live child-model confirmation. Report `route accepted` or `used and confirmed` only from the exact live spawn evidence defined below. Ask about other Codex/IDE installations that share this config only when the environment suggests they exist, and pass their binaries explicitly. If the request or active host indicates a named `--profile`, explain that normal setup manages the default user layer and is not verified for that profile; do not add a routine question for users with no profile signal. If a checked client rejects any managed field, stop before apply. Recommend updating it or using the task-local fallback. `--allow-incompatible-client` requires a separate explicit user decision because it can make the shared config unreadable to that client.
 
@@ -167,6 +167,8 @@ Prerequisites:
 - a Python 3.11+ launcher is available.
 
 The plugin packages three disabled MCP launcher variants for macOS, Linux, and Windows. Setup enables exactly the compatible variant through the plugin's namespaced config. At review time the MCP server removes API-key and Bedrock/Vertex/Foundry override variables, re-checks first-party login, and invokes `claude -p --model claude-fable-5` with `--safe-mode`, no tools, no session persistence, prompt suggestions disabled, and JSON output. The saved route pins the model and effort; the root cannot replace them through tool arguments.
+
+Fable effort is configurable per setup. The default is `high`; supported Claude Code values are `low`, `medium`, `high`, `xhigh`, and `max`. Accept `ultra` as an alias for `max`, save the effective Claude Code value, and disclose the alias mapping in setup output. Existing saved `max` routes remain valid.
 
 The bridge accepts only one self-contained `packet`. It requires `PLAN_APPROVED` or `PLAN_REVISE` as the first non-empty line and requires runtime `modelUsage` to confirm `claude-fable-5`. Any auth, transport, format, or model-confirmation failure is `advisor unavailable`, never approval. It returns no account identifier or credential.
 

--- a/plugins/codex-orchestration/skills/codex-orchestration/references/providers-and-models.md
+++ b/plugins/codex-orchestration/skills/codex-orchestration/references/providers-and-models.md
@@ -217,6 +217,8 @@ Claude Fable 5 is the explicit built-in exception. The plugin does not pretend i
 
 The bridge removes `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, and Bedrock/Vertex/Foundry selection variables from the child environment. It re-checks `claude auth status`, pins `claude-fable-5` and the saved effort, disables tools and session persistence, disables prompt suggestions, and requires JSON runtime metadata to confirm the model. Setup and status never make a model call.
 
+Fable setup defaults to `high`. It accepts the Claude Code effort values `low`, `medium`, `high`, `xhigh`, and `max`; the user-facing label `ultra` normalizes to the effective Claude Code value `max` because the CLI has no separate Ultra setting. Setup checks the installed CLI's advertised choices before persisting the route. The bridge reads only the normalized saved value, so tool callers cannot raise the effort at review time. Existing saved `max` routes remain compatible.
+
 A cross-provider seat normally needs:
 
 1. a provider already defined and authenticated in the user's Codex config;

--- a/plugins/codex-orchestration/skills/codex-orchestration/scripts/configure_native_routing.py
+++ b/plugins/codex-orchestration/skills/codex-orchestration/scripts/configure_native_routing.py
@@ -1170,6 +1170,7 @@ def _status(
             "model such as current Sol or Terra"
         )
         print(f"Config: {app.config_path}")
+        fable_available = True
         if state_matches:
             print(f"Executor: {_route_summary(state['executor'])}")
             advisor = state.get("advisor")
@@ -1178,6 +1179,7 @@ def _status(
                 try:
                     verify_fable_prerequisites(advisor["effort"])
                 except ConfigurationError as exc:
+                    fable_available = False
                     print(f"Claude Fable 5: unavailable — {exc}")
                 else:
                     print(
@@ -1242,6 +1244,7 @@ def _status(
             and routing_state.startswith("installed and effective")
             and state_matches
             and agent_routes_available
+            and fable_available
             and not role_issues
             and not orphaned_roles
         )

--- a/plugins/codex-orchestration/skills/codex-orchestration/scripts/configure_native_routing.py
+++ b/plugins/codex-orchestration/skills/codex-orchestration/scripts/configure_native_routing.py
@@ -39,7 +39,10 @@ PROBE_VALUE = "CODEX_ORCHESTRATION_CAPABILITY_PROBE"
 ROUTING_TOOL_NAMESPACE = "agents"
 PLUGIN_ID = "codex-orchestration@codex-orchestration"
 FABLE_MODEL = "claude-fable-5"
-FABLE_EFFORTS = {"low", "medium", "high", "max"}
+FABLE_DEFAULT_EFFORT = "high"
+FABLE_EFFORT_CHOICES = ("low", "medium", "high", "xhigh", "max")
+FABLE_EFFORTS = set(FABLE_EFFORT_CHOICES)
+FABLE_EFFORT_ALIASES = {"ultra": "max"}
 FABLE_SERVERS = {
     "fable-advisor-python3": ("python3", []),
     "fable-advisor-python": ("python", []),
@@ -179,11 +182,7 @@ def _validate_args(args: argparse.Namespace) -> None:
             "A custom advisor agent owns its effort; omit --advisor-effort."
         )
     if args.advisor_fable:
-        effort = "max" if args.advisor_effort == "auto" else args.advisor_effort
-        if effort not in FABLE_EFFORTS:
-            raise ConfigurationError(
-                "Claude Fable 5 effort must be one of: low, medium, high, max."
-            )
+        normalize_fable_effort(args.advisor_effort)
     for label, value, pattern in (
         ("executor model", args.executor_model, MODEL_RE),
         ("advisor model", args.advisor_model, MODEL_RE),
@@ -198,6 +197,19 @@ def _validate_args(args: argparse.Namespace) -> None:
     ):
         if value != "auto" and not EFFORT_RE.fullmatch(value):
             raise ConfigurationError(f"Invalid {label}: {value!r}.")
+
+
+def normalize_fable_effort(value: str) -> str:
+    """Return the Claude CLI effort for a user-facing Fable effort label."""
+
+    requested = FABLE_DEFAULT_EFFORT if value == "auto" else value
+    effective = FABLE_EFFORT_ALIASES.get(requested, requested)
+    if effective not in FABLE_EFFORTS:
+        supported = ", ".join((*FABLE_EFFORT_CHOICES, *FABLE_EFFORT_ALIASES))
+        raise ConfigurationError(
+            f"Claude Fable 5 effort must be one of: {supported}."
+        )
+    return effective
 
 
 def resolve_binary(value: str) -> Path:
@@ -812,7 +824,7 @@ def select_fable_server() -> str:
     )
 
 
-def verify_fable_prerequisites() -> dict[str, str]:
+def verify_fable_prerequisites(effort: str) -> dict[str, str]:
     try:
         from fable_advisor_mcp import AdvisorError, check_claude_auth, resolve_claude
     except ImportError as exc:  # pragma: no cover - corrupt package
@@ -849,6 +861,21 @@ def verify_fable_prerequisites() -> dict[str, str]:
         raise ConfigurationError(
             f"Claude Code is too old for the Fable advisor bridge ({detail}); update it."
         )
+    effort_match = re.search(
+        r"--effort\s+<level>.*?\((low[^)]*)\)",
+        help_result.stdout,
+        flags=re.DOTALL,
+    )
+    advertised_efforts = (
+        set(re.findall(r"[a-z]+", effort_match.group(1)))
+        if effort_match is not None
+        else set()
+    )
+    if effort not in advertised_efforts:
+        raise ConfigurationError(
+            f"Claude Code does not advertise Fable effort {effort!r}; "
+            "update Claude Code or choose a supported effort."
+        )
     return {"claude": str(claude), **auth}
 
 
@@ -856,8 +883,7 @@ def _route_summary(route: dict[str, Any]) -> str:
     if route["kind"] == "agent":
         return f"custom agent {route['agent']}"
     if route["kind"] == "fable":
-        effort = "Extra High" if route["effort"] == "max" else route["effort"]
-        return f"Claude Fable 5 {effort}"
+        return f"Claude Fable 5 {route['effort']}"
     return f"{route['model']}@{route['effort']}"
 
 
@@ -1150,7 +1176,7 @@ def _status(
             print(f"Advisor: {_route_summary(advisor) if advisor else 'none'}")
             if isinstance(advisor, dict) and advisor.get("kind") == "fable":
                 try:
-                    verify_fable_prerequisites()
+                    verify_fable_prerequisites(advisor["effort"])
                 except ConfigurationError as exc:
                     print(f"Claude Fable 5: unavailable — {exc}")
                 else:
@@ -1640,13 +1666,12 @@ def main() -> int:
                 advisor = {"kind": "agent", "agent": args.advisor_agent}
             elif args.advisor_fable:
                 server = select_fable_server()
-                fable_auth = verify_fable_prerequisites()
+                fable_effort = normalize_fable_effort(args.advisor_effort)
+                fable_auth = verify_fable_prerequisites(fable_effort)
                 advisor = {
                     "kind": "fable",
                     "model": FABLE_MODEL,
-                    "effort": (
-                        "max" if args.advisor_effort == "auto" else args.advisor_effort
-                    ),
+                    "effort": fable_effort,
                     "server": server,
                 }
 
@@ -1671,6 +1696,11 @@ def main() -> int:
             print("Orchestrator: model selected when each Codex task starts")
             print(f"Executor: {_route_summary(executor)}")
             print(f"Advisor: {_route_summary(advisor) if advisor else 'none'}")
+            if args.advisor_fable and args.advisor_effort in FABLE_EFFORT_ALIASES:
+                print(
+                    f"Advisor effort alias: {args.advisor_effort} -> "
+                    f"{advisor['effort']} (Claude Code effective value)"
+                )
             if fable_auth is not None:
                 print(
                     "Claude Fable 5 login: ready — first-party; "

--- a/plugins/codex-orchestration/skills/codex-orchestration/scripts/fable_advisor_mcp.py
+++ b/plugins/codex-orchestration/skills/codex-orchestration/scripts/fable_advisor_mcp.py
@@ -14,7 +14,7 @@ from typing import Any
 
 STATE_FILENAME = ".codex-orchestration-routing.json"
 FABLE_MODEL = "claude-fable-5"
-SUPPORTED_EFFORTS = {"low", "medium", "high", "max"}
+SUPPORTED_EFFORTS = {"low", "medium", "high", "xhigh", "max"}
 CLAUDE_TIMEOUT_SECONDS = 600
 AUTH_TIMEOUT_SECONDS = 20
 SENSITIVE_ENV = {

--- a/tests/test_fable_advisor_mcp.py
+++ b/tests/test_fable_advisor_mcp.py
@@ -36,7 +36,7 @@ class FableAdvisorMcpTests(unittest.TestCase):
                     "advisor": {
                         "kind": "fable",
                         "model": "claude-fable-5",
-                        "effort": "max",
+                        "effort": "high",
                         "server": "fable-advisor-python3",
                     }
                 }
@@ -99,7 +99,7 @@ class FableAdvisorMcpTests(unittest.TestCase):
         self.assertIn("--safe-mode", review_command)
         self.assertNotIn("--bare", review_command)
         self.assertEqual(review_command[review_command.index("--model") + 1], "claude-fable-5")
-        self.assertEqual(review_command[review_command.index("--effort") + 1], "max")
+        self.assertEqual(review_command[review_command.index("--effort") + 1], "high")
         self.assertEqual(
             review_command[review_command.index("--prompt-suggestions") + 1], "false"
         )
@@ -174,7 +174,7 @@ class FableAdvisorMcpTests(unittest.TestCase):
 
     def test_status_does_not_expose_account_plan_metadata(self) -> None:
         with (
-            mock.patch.object(FABLE, "load_fable_route", return_value={"model": "claude-fable-5", "effort": "max"}),
+            mock.patch.object(FABLE, "load_fable_route", return_value={"model": "claude-fable-5", "effort": "high"}),
             mock.patch.object(
                 FABLE,
                 "check_claude_auth",
@@ -192,6 +192,25 @@ class FableAdvisorMcpTests(unittest.TestCase):
         text = response["result"]["content"][0]["text"]
         self.assertNotIn("subscription", text.lower())
         self.assertNotIn("account_plan", text)
+
+    def test_saved_xhigh_and_legacy_max_efforts_remain_valid(self) -> None:
+        state_path = self.home / FABLE.STATE_FILENAME
+        for effort in ("xhigh", "max"):
+            with self.subTest(effort=effort):
+                state_path.write_text(
+                    json.dumps(
+                        {
+                            "advisor": {
+                                "kind": "fable",
+                                "model": "claude-fable-5",
+                                "effort": effort,
+                                "server": "fable-advisor-python3",
+                            }
+                        }
+                    ),
+                    encoding="utf-8",
+                )
+                self.assertEqual(FABLE.load_fable_route(self.home)["effort"], effort)
 
 
 if __name__ == "__main__":

--- a/tests/test_native_routing.py
+++ b/tests/test_native_routing.py
@@ -1095,6 +1095,66 @@ class NativeRoutingTests(unittest.TestCase):
         )
         self.assertFalse((self.home / NATIVE.STATE_FILENAME).exists())
 
+    def test_require_effective_rejects_unavailable_saved_fable_effort(self) -> None:
+        self.run_script(
+            "--executor-model",
+            "gpt-5.6-luna",
+            "--executor-effort",
+            "xhigh",
+            "--advisor-fable",
+            "--advisor-effort",
+            "xhigh",
+            "--apply",
+        )
+        self.claude.write_text(
+            self.claude.read_text(encoding="utf-8").replace(
+                "(low, medium, high, xhigh, max)",
+                "(low, medium, high, max)",
+            ),
+            encoding="utf-8",
+        )
+
+        status = self.run_script(
+            "--status",
+            "--require-effective",
+            check=False,
+        )
+
+        self.assertEqual(status.returncode, 1)
+        self.assertIn(
+            "Claude Code does not advertise Fable effort 'xhigh'",
+            status.stdout,
+        )
+
+    def test_require_effective_rejects_unavailable_fable_auth(self) -> None:
+        self.run_script(
+            "--executor-model",
+            "gpt-5.6-luna",
+            "--executor-effort",
+            "xhigh",
+            "--advisor-fable",
+            "--apply",
+        )
+        self.claude.write_text(
+            self.claude.read_text(encoding="utf-8").replace(
+                '"loggedIn": True',
+                '"loggedIn": False',
+            ),
+            encoding="utf-8",
+        )
+
+        status = self.run_script(
+            "--status",
+            "--require-effective",
+            check=False,
+        )
+
+        self.assertEqual(status.returncode, 1)
+        self.assertIn(
+            "must be logged in through a first-party Pro or Max account",
+            status.stdout,
+        )
+
     def test_missing_or_project_shadowed_custom_agent_is_refused(self) -> None:
         missing = self.run_script(
             "--executor-agent",

--- a/tests/test_native_routing.py
+++ b/tests/test_native_routing.py
@@ -263,7 +263,11 @@ class NativeRoutingTests(unittest.TestCase):
                     }))
                     raise SystemExit(0)
                 if sys.argv[1:] == ["--help"]:
-                    print("--model --effort --safe-mode --prompt-suggestions")
+                    print(
+                        "--model --effort <level> Effort level "
+                        "(low, medium, high, xhigh, max) "
+                        "--safe-mode --prompt-suggestions"
+                    )
                     raise SystemExit(0)
                 raise SystemExit(2)
                 """
@@ -981,7 +985,7 @@ class NativeRoutingTests(unittest.TestCase):
             "max",
             "--apply",
         )
-        self.assertIn("Claude Fable 5 Extra High", setup.stdout)
+        self.assertIn("Claude Fable 5 max", setup.stdout)
         config = self.read_fake_config()
         servers = config["plugins"][NATIVE.PLUGIN_ID]["mcp_servers"]
         self.assertTrue(servers["fable-advisor-python3"]["enabled"])
@@ -1011,6 +1015,85 @@ class NativeRoutingTests(unittest.TestCase):
 
         self.run_script("--disable", "--apply")
         self.assertEqual(self.read_fake_config(), initial)
+
+    def test_fable_effort_defaults_to_high_and_ultra_maps_to_max(self) -> None:
+        setup = self.run_script(
+            "--executor-model",
+            "gpt-5.6-luna",
+            "--executor-effort",
+            "xhigh",
+            "--advisor-fable",
+            "--apply",
+        )
+        self.assertIn("Advisor: Claude Fable 5 high", setup.stdout)
+        state = json.loads(
+            (self.home / NATIVE.STATE_FILENAME).read_text(encoding="utf-8")
+        )
+        self.assertEqual(state["advisor"]["effort"], "high")
+
+        update = self.run_script(
+            "--executor-model",
+            "gpt-5.6-luna",
+            "--executor-effort",
+            "xhigh",
+            "--advisor-fable",
+            "--advisor-effort",
+            "ultra",
+            "--apply",
+        )
+        self.assertIn("Advisor: Claude Fable 5 max", update.stdout)
+        self.assertIn("Advisor effort alias: ultra -> max", update.stdout)
+        state = json.loads(
+            (self.home / NATIVE.STATE_FILENAME).read_text(encoding="utf-8")
+        )
+        self.assertEqual(state["advisor"]["effort"], "max")
+
+    def test_fable_effort_normalization_accepts_every_public_label(self) -> None:
+        expected = {
+            "auto": "high",
+            "low": "low",
+            "medium": "medium",
+            "high": "high",
+            "xhigh": "xhigh",
+            "max": "max",
+            "ultra": "max",
+        }
+        for requested, effective in expected.items():
+            with self.subTest(requested=requested):
+                self.assertEqual(
+                    NATIVE.normalize_fable_effort(requested), effective
+                )
+
+        with self.assertRaisesRegex(
+            NATIVE.ConfigurationError, "low.*medium.*high.*xhigh.*max.*ultra"
+        ):
+            NATIVE.normalize_fable_effort("extreme")
+
+    def test_fable_setup_rejects_effort_missing_from_installed_claude(self) -> None:
+        self.claude.write_text(
+            self.claude.read_text(encoding="utf-8").replace(
+                "(low, medium, high, xhigh, max)",
+                "(low, medium, high, max)",
+            ),
+            encoding="utf-8",
+        )
+        result = self.run_script(
+            "--executor-model",
+            "gpt-5.6-luna",
+            "--executor-effort",
+            "xhigh",
+            "--advisor-fable",
+            "--advisor-effort",
+            "xhigh",
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn(
+            "Claude Code does not advertise Fable effort 'xhigh'",
+            result.stderr,
+        )
+        self.assertFalse((self.home / NATIVE.STATE_FILENAME).exists())
 
     def test_missing_or_project_shadowed_custom_agent_is_refused(self) -> None:
         missing = self.run_script(

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -188,6 +188,9 @@ class PackagingTests(unittest.TestCase):
             "advisor: Claude Fable 5 High",
             readme,
         )
+        self.assertIn("Fable defaults to **High**", readme)
+        self.assertIn("**Low**, **Medium**, **High**, **XHigh**, or **Max**", readme)
+        self.assertIn("**Ultra** is also accepted and uses Max", readme)
         self.assertNotIn("advisor: GPT-5.6 Terra", readme)
 
     def test_update_and_uninstall_remove_managed_state_explicitly(self) -> None:

--- a/tests/test_skill_contract.py
+++ b/tests/test_skill_contract.py
@@ -129,8 +129,10 @@ class SkillContractTests(unittest.TestCase):
         self.assertIn("does not silently create, pause, resume, or clear it", SKILL)
 
     def test_fable_is_a_bundled_root_only_mcp_advisor(self) -> None:
-        self.assertIn("Claude Fable 5 Extra High", SKILL)
-        self.assertIn("--advisor-fable --advisor-effort max", SKILL)
+        self.assertIn("advisor: Claude Fable 5 High", SKILL)
+        self.assertIn("Omission or `Auto` means `High`", SKILL)
+        self.assertIn("`Ultra` is a user-facing alias", SKILL)
+        self.assertIn("--advisor-fable --advisor-effort <normalized-effort>", SKILL)
         self.assertIn("built-in cross-provider advisor exception", SKILL)
         self.assertIn("All bundled variants are disabled by default", SKILL)
         self.assertIn("first-party Pro or Max account", SKILL)


### PR DESCRIPTION
## What changed

- Default Claude Fable 5 advisor effort to `high` instead of `max`.
- Accept `low`, `medium`, `high`, `xhigh`, and `max` as distinct saved Claude Code efforts.
- Accept user-facing `ultra` and normalize it to Claude Code's effective `max` value with an explicit setup message.
- Verify that the installed Claude Code CLI advertises the selected effort before saving the route.
- Preserve existing saved `max` routes and pass the normalized effort unchanged through the read-only Fable bridge.
- Fail `--status --require-effective` when the saved Fable effort or authentication becomes unavailable.
- Update the README, orchestration skill, provider reference, changelog, and contract tests.

## Why

Fable was previously fixed to `max` whenever users omitted an effort, which consumed more reasoning tokens than necessary and made `xhigh` unavailable. The default is now the lower-cost `high`, while users retain explicit control over stronger or lighter review effort.

## User impact

Users can configure examples such as `advisor: Claude Fable 5 Low`, `High`, `XHigh`, `Max`, or `Ultra`. Omitting the effort uses `High`. Because the current Claude Code CLI has no distinct Ultra setting, Ultra is transparently mapped to Max.

## Security review and validation

- Independent security review found and verified the `--require-effective` fail-open; the amended implementation was independently re-reviewed CLEAN.
- 156 unit and contract tests
- Ruff 0.15.21
- Bandit 1.9.4: zero medium/high issues across 4,949 production lines
- Detect-secrets: no new credentials; one pre-existing test-only sentinel was verified
- Pip-audit: no known development-tool vulnerabilities
- Python byte-compilation
- Plugin manifest validation
- Skill validation
- Git-backed install/upgrade/runtime lifecycle smoke
- Release metadata check
- GitHub CodeQL, secret scanning, and push protection
- `git diff --check`
