### PR TITLE
Prevent stale cache from remapping Planner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
-## 0.5.0 — Unreleased
+## 0.5.1 — Unreleased
 
+- Preserve explicit role labels exactly: a model supplied as `planner:` can never be reinterpreted as an Advisor, and Fable Planner uses only the Planner operations.
+- Give Planner support a new plugin version so marketplace upgrade and reinstall replace the affected Advisor-only `0.5.0` cache instead of reusing it.
 - Add an optional Planner route: a configured model drafts and revises the plan, while omission keeps planning with the root Codex model.
 - Let Claude Fable 5 act as Planner through bounded `create_plan` and `revise_plan` tools while preserving its existing Advisor workflow.
 - Run Planner and Advisor through a root-mediated approval loop that stops on `PLAN_APPROVED`, caps review at five rounds, and fails closed before execution when approval or a required route is unavailable.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ Fable 5 uses the official Claude Code CLI and a compatible first-party Claude lo
 - `executor` is required.
 - Planner and Advisor must use different configured model routes so the review is independent.
 
+Role labels are literal. A model after `planner:` plans; a model after `advisor:` reviews; a model after `executor:` implements. Codex must never move a model to a different role because that model was used differently in an older plugin version. If you specify Planner and Executor but omit Advisor, the workflow has no Advisor.
+
 Examples:
 
 ```text
@@ -160,7 +162,11 @@ codex plugin marketplace upgrade codex-orchestration
 codex plugin add codex-orchestration@codex-orchestration
 ```
 
-Start a new task after updating. Before downgrading to a version older than Planner support, run `/codex-orchestration disable` with the current version first.
+Version **0.5.1 or newer** is required for reliable Planner assignment. It has a distinct release identity so Codex replaces the affected Advisor-only `0.5.0` cache instead of reusing it. After the two update commands, confirm `codex plugin list --json` reports `0.5.1` or newer, then start a new task; a task that already loaded the old skill cannot refresh its instructions in place.
+
+If the version stays old or `marketplaceSource.sourceType` is `local`, Codex is pointed at a local checkout rather than the GitHub marketplace. Run `/codex-orchestration disable` first if a saved policy is active, then remove the plugin and that marketplace registration, add `Cjbuilds/Codex-Orchestration` again, and reinstall. This does not delete the local source checkout.
+
+Before downgrading to a version older than Planner support, run `/codex-orchestration disable` with the current version first.
 
 ## Uninstall
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,7 @@
 # Release process
 
 1. Replace `Unreleased` in `CHANGELOG.md` with the release date.
-2. Confirm `.codex-plugin/plugin.json`, the changelog, the installed package, and lifecycle fixture all use the same semantic version.
+2. Confirm `.codex-plugin/plugin.json`, the changelog, the installed package, and lifecycle fixture all use the same new semantic version. Never publish different plugin behavior under a version already used by another bundle; fix forward with a new version so Codex cannot reuse the old cache identity.
 3. Run:
 
    ```bash
@@ -17,7 +17,7 @@
 6. Merge only after every protected check passes.
 7. Create a signed annotated tag named `v<manifest-version>` at the reviewed merge commit.
 8. Re-run `python3 scripts/release_check.py --require-tag` and publish a GitHub release from that tag using the matching changelog section.
-9. Install from the public marketplace in a clean Codex home, start a new task, and verify setup, `status --require-effective`, and disable.
+9. Upgrade from the previous public version in a clean Codex home, reinstall the plugin, and verify the installed version and skill contents changed before starting a new task. Then verify setup, `status --require-effective`, and disable.
 
 Never move a published release tag. If a release is bad, fix forward with a new version and retain the old tag as provenance.
 

--- a/docs/production-readiness-audit.md
+++ b/docs/production-readiness-audit.md
@@ -4,7 +4,7 @@ Audit date: 2026-07-12. Baseline: `a674a81` (`0.4.0`).
 
 ## Release blockers found
 
-| Severity | Shortcoming | Resolution in 0.5.0 |
+| Severity | Shortcoming | Resolution |
 | --- | --- | --- |
 | High | The README led with internal routing details and did not explain the product's general multi-model role workflow. | Lead with a plain-language definition, a provider-neutral workflow diagram, the value proposition, and then installation and examples. |
 | High | Claude Fable 5 was developed separately, so the launch branch could not truthfully advertise the requested advisor workflow. | Integrate the opt-in, root-directed Fable bridge, disabled by default, with login checks, runtime-model confirmation, and fail-closed review decisions. |
@@ -13,12 +13,13 @@ Audit date: 2026-07-12. Baseline: `a674a81` (`0.4.0`).
 | Medium | Restore-state persistence failure ignored the config rollback status and could report false success. | Validate rollback status and report that managed fields may remain whenever rollback is not proven. |
 | Medium | Duplicated partial state validation accepted impossible schema/policy, nested restore, and scalar-conversion combinations that could make disable replace unrelated configuration. | Use one shared full-state validator for native and Fable paths, with exact schema-specific keys, snapshots, scalar/MCP relationships, routes, and marker-owned policy strings. |
 | Medium | Fable runtime confirmation accepted any extra model as long as `claude-fable-5` also appeared. | Require the pinned Fable primary and an exact allowlist of observed Claude Code helper models; reject every unknown additional model. |
+| Medium | Planner support reused the same `0.5.0` identity as an earlier Advisor-only bundle, allowing a stale marketplace/cache to keep role-obsolete instructions. | Release the complete Planner contract as `0.5.1`, treat explicit seat labels as authoritative, and lifecycle-test upgrade from the exact affected bundle into an installed Planner-capable package. |
 | Medium | Status always exited zero for conflicts, overrides, incomplete controls, or unavailable roles. | Add `--require-effective` and negative-path coverage. |
 | Medium | Cross-provider setup spans separate role-file and native-policy transactions. | Detect orphaned managed roles, require bounded cleanup on phase-two failure, and document interruption recovery. |
 | Medium | The skill explained only fixed advisor/executor seats, leaving arbitrary project roles, workflow ordering, Goal behavior, and permissions ambiguous. | Add native custom-role creation rules, project and personal scopes, user ownership, provider checks, bounded handoffs, and explicit Goal/permission boundaries. |
 | Medium | GitHub Actions used mutable major tags and the repository did not require SHA pinning. | Pin actions to full reviewed SHAs, restrict Actions, and add Dependabot updates. |
 | Medium | Windows support was claimed without CI or the custom-role update/removal limitation. | Add Windows/macOS portability checks and document the Windows fail-closed boundary. |
-| Medium | Released version `0.4.0` had no immutable tag or GitHub release. | Add a tag/version release gate; `0.5.0` must ship from a signed `v0.5.0` tag and matching GitHub release. |
+| Medium | Released version `0.4.0` had no immutable tag or GitHub release. | Add a tag/version release gate; `0.5.1` must ship from a signed `v0.5.1` tag and matching GitHub release. |
 | Low | Code scanning, dependency alerts, private vulnerability reporting, ownership, contribution, and release policies were absent. | Add CodeQL, Dependabot, `SECURITY.md`, `CODEOWNERS`, `CONTRIBUTING.md`, and `RELEASE.md`; enable repository security features. |
 | Low | CI had no static-quality baseline. | Add a pinned Ruff check and Dependabot updates for the development tool. |
 | Low | The documented fixed v2 concurrency count was stale. | Defer to the effective Codex/config limit instead of hard-coding a count. |

--- a/plugins/codex-orchestration/.codex-plugin/plugin.json
+++ b/plugins/codex-orchestration/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-orchestration",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Bring models like Claude Fable 5 into Codex as Planner, Advisor, or Executor.",
   "author": {
     "name": "CJ Zafir",

--- a/plugins/codex-orchestration/skills/codex-orchestration/SKILL.md
+++ b/plugins/codex-orchestration/skills/codex-orchestration/SKILL.md
@@ -29,6 +29,8 @@ Support these simple forms:
 
 `remove custom roles` cleans only verified plugin-managed advisor/executor files. Arbitrary native roles are user-owned. An invocation with seats and work but no control verb is a current-task override and must not rewrite config.
 
+Explicit seat labels are authoritative. `planner:` configures only Planner, `advisor:` configures only Advisor, and `executor:` configures only Executor. Never infer or change a seat from a model's historical use, default role, cached description, or provider; in particular, never reinterpret a supplied `planner:` model as an Advisor. Saved defaults may fill only omitted seats and never override a seat supplied in the current invocation.
+
 The executor is required for setup or a task-local override. It is not required for a custom-role creation request. Planner and advisor are optional: omitted planner means the current root model plans, while omitted advisor means `advisor: none`. Do not ask separate planner or advisor questions unless the user asks for help choosing them.
 
 For both persistent setup and task-local overrides, reject an identical Planner and Advisor route: the same direct model ID, the same custom-agent name, or Claude Fable 5 in both seats. Independent critique is required.
@@ -46,6 +48,8 @@ Because explicit skills may not reload from a bare reply, include a ready-to-cop
 ```
 
 For a task-local request, append `— <original task>`. Keep every supplied modifier. Do not lose the user's task while collecting a model choice.
+
+Before applying setup or starting task-local work, report the normalized mapping as `Planner`, `Advisor`, and `Executor` in that order. Compare it with the user's explicit labels. If an exact seat cannot run, report that seat as unavailable and stop under the required-route rules; never move its model to another seat. When the user supplies Planner and Executor but omits Advisor, report `Advisor: none`.
 
 If an old prompt contains `orchestrator:`, explain that the current task model already owns that role. Ignore that seat instead of switching or persisting it.
 
@@ -304,7 +308,7 @@ Do not persist a best-effort flag. An explicit task override applies only to tha
 
 Reject persistent setup or task-local activation when configured Planner and Advisor routes are identical: the same direct model ID, same custom-agent name, or Fable in both seats. Independent critique is the reason for the Advisor role.
 
-For Fable Planner calls, use the configured MCP server's `create_plan` and `revise_plan` tools. For Fable Advisor calls, use `review_plan`. The policy authorizes only the root to make these read-only calls; Executors must never use or direct them.
+Fable Planner uses `create_plan` and `revise_plan`; Fable Advisor uses `review_plan`. These operations are seat-bound: never send a supplied Fable Planner to `review_plan`, and never use an Advisor route to create or revise the plan. The policy authorizes only the root to make these read-only calls; Executors must never use or direct them.
 
 ## Executor handoff
 

--- a/plugins/codex-orchestration/skills/codex-orchestration/scripts/configure_native_routing.py
+++ b/plugins/codex-orchestration/skills/codex-orchestration/scripts/configure_native_routing.py
@@ -383,7 +383,7 @@ class AppServer:
                     "clientInfo": {
                         "name": "codex_orchestration_installer",
                         "title": "Codex Orchestration Installer",
-                        "version": "0.5.0",
+                        "version": "0.5.1",
                     },
                     "capabilities": {"experimentalApi": True},
                 },

--- a/tests/plugin_lifecycle_smoke.py
+++ b/tests/plugin_lifecycle_smoke.py
@@ -2,9 +2,10 @@
 """Exercise a real Codex plugin install, Git upgrade, and both setup routes.
 
 A disposable bare Git marketplace is served over loopback HTTP. The real Codex
-CLI installs 0.3.0, runs its documented marketplace-upgrade command after 0.5.0
-is pushed to that Git remote, installs the refreshed package, verifies its cache,
-and runs native-policy plus custom-agent setup/status/cleanup in isolation.
+CLI installs the affected Advisor-only 0.5.0 bundle, runs its documented
+marketplace-upgrade command after 0.5.1 is pushed to that Git remote, installs
+the refreshed package, verifies the new cache and Planner contract, and runs
+native-policy plus custom-agent setup/status/cleanup in isolation.
 """
 
 from __future__ import annotations
@@ -28,9 +29,9 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 PLUGIN_ROOT = REPO_ROOT / "plugins" / "codex-orchestration"
 PLUGIN_ID = "codex-orchestration@codex-orchestration"
 MARKETPLACE_NAME = "codex-orchestration"
-OLD_RELEASE = "d93b86e735a12a9fefcfd35b0b35199ce3e9a2a7"
-OLD_VERSION = "0.3.0"
-NEW_VERSION = "0.5.0"
+OLD_RELEASE = "a1d9c546665c3253cdcaa8fe5c0c060199a6126c"
+OLD_VERSION = "0.5.0"
+NEW_VERSION = "0.5.1"
 COMMAND_TIMEOUT_SECONDS = 60
 
 
@@ -371,6 +372,17 @@ def main() -> int:
             assert_equal(
                 old_install.get("version"), OLD_VERSION, "initial install version"
             )
+            old_installed_root = Path(old_install["installedPath"]).resolve()
+            old_skill = (
+                old_installed_root
+                / "skills"
+                / "codex-orchestration"
+                / "SKILL.md"
+            ).read_text(encoding="utf-8")
+            if "setup planner: Claude Fable 5 High" in old_skill:
+                raise SmokeFailure("old Advisor-only cache unexpectedly supports Planner")
+            if "built-in advisor label" not in old_skill:
+                raise SmokeFailure("old release fixture is not the affected Advisor-only cache")
 
             old_discovery = run_json(
                 [codex, "plugin", "list", "--json"], cwd=project, env=env
@@ -475,13 +487,40 @@ def main() -> int:
                 entry.get("version"), current_version, "discovered new version"
             )
             assert_equal(entry.get("enabled"), True, "new plugin enabled state")
+            refreshed_source = entry.get("marketplaceSource") or {}
+            assert_equal(
+                refreshed_source.get("sourceType"),
+                "git",
+                "refreshed marketplace source type",
+            )
+            assert_equal(
+                refreshed_source.get("source"),
+                marketplace_url,
+                "refreshed marketplace URL",
+            )
 
             installed_root = Path(new_install["installedPath"]).resolve()
+            if installed_root == old_installed_root:
+                raise SmokeFailure(
+                    "0.5.1 reused the Advisor-only 0.5.0 cache directory"
+                )
             assert_equal(
                 file_tree(installed_root),
                 file_tree(PLUGIN_ROOT),
                 "installed package contents",
             )
+            installed_skill = (
+                installed_root / "skills" / "codex-orchestration" / "SKILL.md"
+            ).read_text(encoding="utf-8")
+            for expected in (
+                "Explicit seat labels are authoritative",
+                "never reinterpret a supplied `planner:` model as an Advisor",
+                "Fable Planner uses `create_plan` and `revise_plan`",
+            ):
+                if expected not in installed_skill:
+                    raise SmokeFailure(
+                        f"Upgraded installed skill is missing Planner contract {expected!r}"
+                    )
 
             installed_fable_mcp = (
                 installed_root

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -24,7 +24,7 @@ class PackagingTests(unittest.TestCase):
 
         self.assertEqual(manifest["name"], "codex-orchestration")
         self.assertEqual(manifest["skills"], "./skills/")
-        self.assertEqual(manifest["version"], "0.5.0")
+        self.assertEqual(manifest["version"], "0.5.1")
         self.assertEqual(manifest["mcpServers"], "./.mcp.json")
         self.assertRegex(
             manifest["version"],
@@ -45,6 +45,7 @@ class PackagingTests(unittest.TestCase):
         self.assertTrue(custom.is_file())
         self.assertTrue(routing_state.is_file())
         self.assertIn("config/batchWrite", native.read_text(encoding="utf-8"))
+        self.assertIn('"version": "0.5.1"', native.read_text(encoding="utf-8"))
         self.assertIn("validate_routing_state", routing_state.read_text(encoding="utf-8"))
         self.assertIn("Standalone custom agent", custom.read_text(encoding="utf-8"))
 
@@ -108,8 +109,11 @@ class PackagingTests(unittest.TestCase):
         self.assertIn("@openai/codex@0.142.5", workflow)
         self.assertIn("@openai/codex@0.144.1", workflow)
         smoke_text = smoke.read_text(encoding="utf-8")
-        self.assertIn('OLD_VERSION = "0.3.0"', smoke_text)
-        self.assertIn('NEW_VERSION = "0.5.0"', smoke_text)
+        self.assertIn('OLD_VERSION = "0.5.0"', smoke_text)
+        self.assertIn('NEW_VERSION = "0.5.1"', smoke_text)
+        self.assertIn("old Advisor-only cache unexpectedly supports Planner", smoke_text)
+        self.assertIn("Upgraded installed skill is missing Planner contract", smoke_text)
+        self.assertIn("reused the Advisor-only 0.5.0 cache directory", smoke_text)
         self.assertIn("configure_native_routing.py", smoke_text)
         self.assertIn("configure_orchestration.py", smoke_text)
         self.assertIn("fable_advisor_mcp.py", smoke_text)
@@ -210,6 +214,8 @@ class PackagingTests(unittest.TestCase):
         readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
 
         self.assertIn("/codex-orchestration status", readme)
+        self.assertIn("Version **0.5.1 or newer**", readme)
+        self.assertIn("`marketplaceSource.sourceType` is `local`", readme)
         self.assertIn("`disable` restores the routing values", readme)
         self.assertIn("does not delete user-owned custom roles", readme)
         self.assertIn("Review and remove any user-owned custom roles separately", readme)

--- a/tests/test_release_check.py
+++ b/tests/test_release_check.py
@@ -15,7 +15,7 @@ SPEC.loader.exec_module(RELEASE)
 
 class ReleaseCheckTests(unittest.TestCase):
     def test_checkout_release_metadata_is_consistent(self) -> None:
-        self.assertEqual(RELEASE.run_check(REPO_ROOT, require_tag=False), "0.5.0")
+        self.assertEqual(RELEASE.run_check(REPO_ROOT, require_tag=False), "0.5.1")
 
     def test_unreleased_checkout_is_not_tag_ready(self) -> None:
         with self.assertRaisesRegex(RELEASE.ReleaseCheckError, "not tagged"):

--- a/tests/test_skill_contract.py
+++ b/tests/test_skill_contract.py
@@ -51,6 +51,18 @@ class SkillContractTests(unittest.TestCase):
         self.assertIn("Planner omission persists no Planner route", SKILL)
         self.assertIn("no Planner route is configured, so the root plans", SKILL)
 
+    def test_explicit_seat_labels_cannot_be_reinterpreted(self) -> None:
+        self.assertIn("Explicit seat labels are authoritative", SKILL)
+        self.assertIn(
+            "never reinterpret a supplied `planner:` model as an Advisor", SKILL
+        )
+        self.assertIn("`planner:` configures only Planner", SKILL)
+        self.assertIn("`advisor:` configures only Advisor", SKILL)
+        self.assertIn("`executor:` configures only Executor", SKILL)
+        self.assertIn("Fable Planner uses `create_plan` and `revise_plan`", SKILL)
+        self.assertIn("Fable Advisor uses `review_plan`", SKILL)
+        self.assertIn("Advisor: none", SKILL)
+
     def test_codex_still_decides_when_to_delegate(self) -> None:
         self.assertIn("Codex decides whether a plan helps", SKILL)
         self.assertIn("force a spawn or fixed worker count", SKILL)


### PR DESCRIPTION
## What changed

- Treat explicit planner, advisor, and executor labels as authoritative.
- Bind Fable Planner to create_plan/revise_plan and Fable Advisor to review_plan.
- Release the complete Planner contract as 0.5.1 so Codex does not reuse the affected Advisor-only 0.5.0 cache identity.
- Document detection and recovery for stale local marketplace installations.
- Lifecycle-test a real Git marketplace upgrade from Advisor-only 0.5.0 to a distinct 0.5.1 cache and verify the installed Planner contract.

## Root cause

The active installation came from an old local marketplace checkout whose skill supported Fable only as Advisor. Public main had Planner support but reused version 0.5.0, so the installed cache and the newer bundle did not have a reliable release boundary.

## Validation

- 189 unit/integration tests passed
- 0.5.0 to 0.5.1 plugin lifecycle and cache replacement passed
- Ruff, compileall, plugin validation, release metadata, and diff checks passed
- Independent final security/release review: CLEAN