### PR TITLE
Add ordered backup routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## 0.5.1 — Unreleased
+## 0.6.0 — Unreleased
+
+- Add ordered backup routes with policy-directed, fail-closed candidate chains for Executor, Planner, and Advisor seats.
+- Persist exact schema/policy 4 state with up to two backups per seat, migrate schemas 1–3 on the next successful setup, and preserve restore snapshots.
+- Add repeatable backup CLI specs, canonical provider/model identity checks, Fable candidate authorization, exhaustive failure classification, and per-candidate readiness status.
+
+## 0.5.1 — Historical
 
 - Preserve explicit role labels exactly: a model supplied as `planner:` can never be reinterpreted as an Advisor, and Fable Planner uses only the Planner operations.
 - Give Planner support a new plugin version so marketplace upgrade and reinstall replace the affected Advisor-only `0.5.0` cache instead of reusing it.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,21 @@ Fable 5 uses the official Claude Code CLI and a compatible first-party Claude lo
 - `executor` is required.
 - Planner and Advisor must use different configured model routes so the review is independent.
 
+Each seat may also have up to two ordered backups. Backups are policy-directed
+failover, never an engine-level automatic scheduler. Use the exact CLI grammar
+`model:<id>@<effort>`, `agent:<name>`, and (Planner/Advisor only)
+`fable:<effort>`:
+
+```text
+/codex-orchestration setup executor: GPT-5.6 Luna High, executor-backup: model:gpt-5.6-sol@high, executor-backup: agent:recovery_worker
+```
+
+An explicit task-local primary replaces that seat's saved chain; an omitted seat
+retains its saved chain, and backup-only task overrides are invalid. A candidate
+is eligible only when the root can mechanically prove the required pre-start or
+no-tools failure. Started or ambiguous Executor attempts freeze the chain; valid
+planning output, disagreement, refusal, or perceived quality never advances it.
+
 Role labels are literal. A model after `planner:` plans; a model after `advisor:` reviews; a model after `executor:` implements. Codex must never move a model to a different role because that model was used differently in an older plugin version. If you specify Planner and Executor but omit Advisor, the workflow has no Advisor.
 
 Examples:
@@ -162,11 +177,14 @@ codex plugin marketplace upgrade codex-orchestration
 codex plugin add codex-orchestration@codex-orchestration
 ```
 
-Version **0.5.1 or newer** is required for reliable Planner assignment. It has a distinct release identity so Codex replaces the affected Advisor-only `0.5.0` cache instead of reusing it. After the two update commands, confirm `codex plugin list --json` reports `0.5.1` or newer, then start a new task; a task that already loaded the old skill cannot refresh its instructions in place.
+Version **0.6.0 or newer** is required for ordered backup routes and schema-4 state. After the two update commands, confirm `codex plugin list --json` reports `0.6.0` or newer, then start a new task; a task that already loaded the old skill cannot refresh its instructions in place.
 
 If the version stays old or `marketplaceSource.sourceType` is `local`, Codex is pointed at a local checkout rather than the GitHub marketplace. Run `/codex-orchestration disable` first if a saved policy is active, then remove the plugin and that marketplace registration, add `Cjbuilds/Codex-Orchestration` again, and reinstall. This does not delete the local source checkout.
 
-Before downgrading to a version older than Planner support, run `/codex-orchestration disable` with the current version first.
+Before downgrading to any version older than 0.6.0, run
+`/codex-orchestration disable` with the current version first. Older releases do
+not understand schema-4 backup chains and must fail closed rather than guessing
+how to restore them.
 
 ## Uninstall
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -21,4 +21,6 @@
 
 Never move a published release tag. If a release is bad, fix forward with a new version and retain the old tag as provenance.
 
-Before downgrading to a release that predates Planner/state-schema-3 support, run `disable` with the current release. Older versions must fail closed on the unknown state schema rather than guessing how to restore it.
+Before downgrading to any release older than 0.6.0, run `disable` with the current
+release. Older versions do not understand state-schema-4 backup chains and must
+fail closed on the unknown state schema rather than guessing how to restore it.

--- a/plugins/codex-orchestration/.codex-plugin/plugin.json
+++ b/plugins/codex-orchestration/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-orchestration",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Bring models like Claude Fable 5 into Codex as Planner, Advisor, or Executor.",
   "author": {
     "name": "CJ Zafir",

--- a/plugins/codex-orchestration/skills/codex-orchestration/SKILL.md
+++ b/plugins/codex-orchestration/skills/codex-orchestration/SKILL.md
@@ -29,6 +29,29 @@ Support these simple forms:
 
 `remove custom roles` cleans only verified plugin-managed advisor/executor files. Arbitrary native roles are user-owned. An invocation with seats and work but no control verb is a current-task override and must not rewrite config.
 
+### Ordered backup routes
+
+Persistent setup accepts repeatable `--executor-backup`, `--planner-backup`, and
+`--advisor-backup` options. Each value must be exactly `model:<exact-id>@<effort>`,
+`agent:<name>`, or `fable:<effort>` for Planner/Advisor only. There are at most
+two backups per seat; Fable is never an Executor and may occupy only one planning
+position across all chains. Setup previews and status render candidates in order.
+Primary-only setups retain the same behavior and now persist exact empty backup
+arrays in state schema/policy 4. Schemas 1–3 are accepted for status/disable and
+upgrade to schema 4 on the next successful setup while preserving restore data.
+
+Backups are policy-directed failover, never an engine-level automatic scheduler.
+Only a root prompt can advance a cursor after a mechanically classified failure.
+`ELIGIBLE_PRESTART` requires proven local unavailability or explicit spawn
+rejection with no child/agent/task ID. `STARTED` never advances Executor;
+`AMBIGUOUS` and `UNKNOWN` freeze. A valid deliverable, PLAN_REVISE,
+disagreement, refusal, or perceived quality never triggers fallback. A task-local
+primary replaces that seat's full saved chain; omitted seats retain their saved
+chain; backup-only task overrides are invalid. Every activation carries a
+versioned envelope with cursor, canonical identity, episode state, activation IDs,
+started child identities, and superseded attempts. Missing or inconsistent state
+is `STATE_UNKNOWN` and freezes further activation.
+
 Explicit seat labels are authoritative. `planner:` configures only Planner, `advisor:` configures only Advisor, and `executor:` configures only Executor. Never infer or change a seat from a model's historical use, default role, cached description, or provider; in particular, never reinterpret a supplied `planner:` model as an Advisor. Saved defaults may fill only omitted seats and never override a seat supplied in the current invocation.
 
 The executor is required for setup or a task-local override. It is not required for a custom-role creation request. Planner and advisor are optional: omitted planner means the current root model plans, while omitted advisor means `advisor: none`. Do not ask separate planner or advisor questions unless the user asks for help choosing them.
@@ -111,6 +134,26 @@ python3 <skill-dir>/scripts/configure_native_routing.py \
 Add `--advisor-model` and `--advisor-effort` for a same-provider Codex advisor. For Claude Fable 5, use `--advisor-fable`; add `--advisor-effort low|medium|high|xhigh|max` when the user chooses one. Omitting Fable effort defaults to `high`, while user-facing `ultra` is normalized to Claude Code's `max`. The configurator verifies that the installed Claude Code CLI advertises the selected effective effort. It also requires Claude Code to be logged in through a first-party Pro or Max account, chooses an available Python 3.11+ MCP launcher, and performs only an auth/capability check during setup. It never extracts a token, writes a credential, or makes a model call during setup or status. Omission persists `advisor: none`.
 
 Add `--planner-model` and `--planner-effort` for a same-provider Planner. For Claude Fable 5, use `--planner-fable`; add `--planner-effort low|medium|high|xhigh|max` when the user chooses one. Planner omission persists no Planner route and means the root plans. A configured Planner and Advisor must not resolve to the same model or agent route; independent review is required.
+
+For example, a durable ordered chain can be previewed with:
+
+```bash
+python3 <skill-dir>/scripts/configure_native_routing.py \
+  --executor-model gpt-5.6-luna \
+  --executor-backup model:gpt-5.6-sol@high \
+  --executor-backup agent:recovery_worker \
+  --planner-model gpt-5.6-sol \
+  --planner-backup fable:high \
+  --advisor-model gpt-5.6-terra
+```
+
+Direct route identity is `(provider_id, model_id)` and excludes effort. Custom
+agent aliases are resolved from their TOML `model` and `model_provider`; if an
+effective Planner/Advisor identity cannot be proven independent, setup fails
+closed. Direct routes inherit the root provider and must be revalidated at task
+runtime. Route grammar cannot add sandbox, approval, service-tier, Goal, or
+authority extensions; backup activation inherits the root authority cap unchanged
+or narrower.
 
 The configurator capability-tests the complete four-field preset on the active target, `codex` on PATH when different, the known macOS Desktop binary when present, and every explicit `--compat-bin`. A successful isolated config probe means that client can parse the preset; it is not a live child-model confirmation. Report `route accepted` or `used and confirmed` only from the exact live spawn evidence defined below. Ask about other Codex/IDE installations that share this config only when the environment suggests they exist, and pass their binaries explicitly. If the request or active host indicates a named `--profile`, explain that normal setup manages the default user layer and is not verified for that profile; do not add a routine question for users with no profile signal. If a checked client rejects any managed field, stop before apply. Recommend updating it or using the task-local fallback. `--allow-incompatible-client` requires a separate explicit user decision because it can make the shared config unreadable to that client.
 

--- a/plugins/codex-orchestration/skills/codex-orchestration/references/providers-and-models.md
+++ b/plugins/codex-orchestration/skills/codex-orchestration/references/providers-and-models.md
@@ -153,7 +153,7 @@ Restore state lives at:
 ~/.codex/.codex-orchestration-routing.json
 ```
 
-It contains the prior and managed values of the four routing fields, chosen Planner/Advisor/Executor routes, schema/version markers, scalar-conversion metadata when needed, and config path. When Claude Fable 5 is selected for either planning seat, it also records only the plugin-scoped MCP launcher overrides that setup touched. It never copies provider definitions, auth stores, account identifiers, or credentials. A normal clean setup contains generated policy text, the namespace value, seat IDs, and restoration metadata. Explicit replacement must retain the user's exact old hint text so disable can restore it; routing hints must never contain credentials. State is written with a same-directory atomic replacement and restrictive file mode where supported. If persistence fails after config apply, the configurator rolls the config back using the returned version.
+It contains the prior and managed values of the four routing fields, ordered Planner/Advisor/Executor primary and backup chains, schema/version markers, scalar-conversion metadata when needed, and config path. When Claude Fable 5 is selected for either planning seat, it also records only the plugin-scoped MCP launcher overrides that setup touched. It never copies provider definitions, auth stores, account identifiers, or credentials. A normal clean setup contains generated policy text, the namespace value, seat IDs, exact schema-4 backup arrays, and restoration metadata. Explicit replacement must retain the user's exact old hint text so disable can restore it; routing hints must never contain credentials. State is written with a same-directory atomic replacement and restrictive file mode where supported. If persistence fails after config apply, the configurator rolls the config back using the returned version.
 
 Disable compares every current managed value before restoration. If the user edited a managed field after setup, it stops instead of erasing that work. Without state, each surviving marker proves ownership only of that hint string. Disable may safely remove the marked string or strings, but it leaves metadata visibility and the tool namespace unchanged because their previous values are unknown.
 
@@ -221,7 +221,25 @@ The bridge removes `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, and Bedrock/Vert
 
 The saved policy authorizes the root to call these planning tools and prohibits children from doing so. Current MCP requests provide no caller identity to the server, so that specific caller boundary is instruction-enforced, not server-authenticated. The bridge mechanically uses the same full saved-state validator as native status/disable, restricts the operation surface, and runs Fable without tools or persistence.
 
-Saved state compatibility is explicit: schema 1 must carry policy version 1 and predates Fable and Planner; schema 2 must carry policy version 2 and may authorize only the historical Fable Advisor shape; schema 3 must carry policy version 3 and adds Planner. Schema and policy values must be actual JSON integers, not booleans or floats. Legacy state cannot contain fields introduced later; nested snapshots, scalar conversion, MCP launchers, and routes must match an emitted contract; and managed policy strings must carry the plugin marker before status, update, disable, or Fable trusts them. Unknown extensions intentionally fail closed.
+Saved state compatibility is explicit: schema 1 must carry policy version 1 and predates Fable and Planner; schema 2 must carry policy version 2 and may authorize only the historical Fable Advisor shape; schema 3 must carry policy version 3 and adds Planner; schema 4 carries policy version 4 and exact `backups={executor:[], planner:[], advisor:[]}` arrays. Schemas 1–3 are accepted for status/disable and upgrade to schema 4 on the next successful setup/change while preserving restore snapshots. Each chain has at most two backups, duplicate canonical `(provider_id, model_id)` identities are rejected, Planner and Advisor chains are disjoint across every candidate, and Fable can occur at one planning position only. Schema and policy values must be actual JSON integers, not booleans or floats. Legacy state cannot contain fields introduced later; nested snapshots, scalar conversion, MCP launchers, and routes must match an emitted contract; and managed policy strings must carry the plugin marker before status, update, disable, or Fable trusts them. Unknown extensions intentionally fail closed.
+
+### Ordered backup failure boundary
+
+Backups are root policy, not engine-level automatic failover. A pre-start
+candidate is eligible only for bridge-attested `AUTH_UNAVAILABLE` or
+`MODEL_UNAVAILABLE` with no child/agent/task ID. A started attempt never advances
+an Executor. Post-start planning fallback is limited to a mechanically no-tools
+launcher with authenticated, identity-matched execution and no valid deliverable.
+`IDENTITY_MISMATCH`, `STATE_INVALID`, impossible combinations, and missing or
+truncated task envelopes produce `STATE_UNKNOWN` and freeze. Valid deliverables,
+`PLAN_REVISE`, disagreement, refusal, and perceived quality never trigger a
+backup. Schema-4 Fable calls must supply the exact candidate ordinal and
+bridge-derived activation ID printed in the managed policy. Success and failure
+tool results include the redacted activation, ordinal, authentication/identity/
+no-tools/start/deliverable flags, outcome code, and eligibility state; generic or
+inconsistent failures remain `STATE_UNKNOWN`. The prompt-governed task envelope carries each seat's active identity and
+cursor, episode state, activation IDs, started child identities, and superseded
+attempts; this is an honest policy contract, not engine enforcement.
 
 Fable setup defaults to `high`. It accepts the Claude Code effort values `low`, `medium`, `high`, `xhigh`, and `max`; the user-facing label `ultra` normalizes to the effective Claude Code value `max` because the CLI has no separate Ultra setting. Setup checks the installed CLI's advertised choices before persisting the route. The bridge reads only the normalized saved value, so tool callers cannot raise the effort at review time. Existing saved `max` routes remain compatible.
 

--- a/plugins/codex-orchestration/skills/codex-orchestration/scripts/configure_native_routing.py
+++ b/plugins/codex-orchestration/skills/codex-orchestration/scripts/configure_native_routing.py
@@ -30,6 +30,9 @@ from routing_state import (
     MANAGED_MARKER,
     ROUTING_TOOL_NAMESPACE,
     RoutingStateError,
+    candidate_activation_id,
+    route_chain,
+    route_identity,
     validate_routing_state,
 )
 
@@ -39,8 +42,8 @@ except ModuleNotFoundError as exc:  # pragma: no cover - Python < 3.11
     raise SystemExit("Python 3.11 or newer is required (missing tomllib).") from exc
 
 
-POLICY_VERSION = 3
-STATE_SCHEMA = 3
+POLICY_VERSION = 4
+STATE_SCHEMA = 4
 STATE_FILENAME = ".codex-orchestration-routing.json"
 PROBE_VALUE = "CODEX_ORCHESTRATION_CAPABILITY_PROBE"
 PLUGIN_ID = "codex-orchestration@codex-orchestration"
@@ -64,6 +67,149 @@ CUSTOM_AGENT_MANAGED_MARKER = (
     "# Managed by codex-orchestration. Standalone custom agent v2."
 )
 MISSING = object()
+
+
+def parse_backup_spec(spec: str, seat: str) -> dict[str, Any]:
+    """Parse one exact ordered-backup route specification.
+
+    Backup syntax is intentionally narrower than persisted state: Fable's
+    launcher is selected during setup, while model and custom-agent routes are
+    fully self-describing. No whitespace or implicit normalization is accepted.
+    """
+
+    if seat not in {"executor", "planner", "advisor"}:
+        raise ConfigurationError(f"Unknown route seat: {seat!r}.")
+    if not isinstance(spec, str) or not spec or spec.strip() != spec:
+        raise ConfigurationError(f"Invalid {seat} backup route: {spec!r}.")
+    prefix, separator, value = spec.partition(":")
+    if not separator or not value:
+        raise ConfigurationError(
+            f"Invalid {seat} backup route {spec!r}; use model:<id>@<effort>, "
+            "agent:<name>, or fable:<effort>."
+        )
+    if prefix == "model":
+        model, marker, effort = value.partition("@")
+        if not marker or not model or not effort or "@" in effort:
+            raise ConfigurationError(f"Invalid {seat} model backup route: {spec!r}.")
+        if (
+            MODEL_RE.fullmatch(model) is None
+            or EFFORT_RE.fullmatch(effort) is None
+            or effort == "auto"
+        ):
+            raise ConfigurationError(f"Invalid {seat} model backup route: {spec!r}.")
+        return {"kind": "model", "model": model, "effort": effort}
+    if prefix == "agent":
+        if AGENT_RE.fullmatch(value) is None:
+            raise ConfigurationError(f"Invalid {seat} agent backup route: {spec!r}.")
+        return {"kind": "agent", "agent": value}
+    if prefix == "fable":
+        if seat == "executor":
+            raise ConfigurationError("Fable is not permitted as an Executor route.")
+        if EFFORT_RE.fullmatch(value) is None:
+            raise ConfigurationError(f"Invalid {seat} Fable backup route: {spec!r}.")
+        return {
+            "kind": "fable",
+            "model": FABLE_MODEL,
+            "effort": normalize_fable_effort(value),
+        }
+    raise ConfigurationError(f"Unsupported {seat} backup route kind: {prefix!r}.")
+
+
+def _route_ids(
+    routes: list[dict[str, Any]],
+    *,
+    agent_identities: dict[str, tuple[str, str]] | None,
+    seat: str,
+) -> list[tuple[str, str]]:
+    identities: list[tuple[str, str]] = []
+    for route in routes:
+        identity = route_identity(route, agent_identities=agent_identities)
+        if identity is None:
+            raise ConfigurationError(f"{seat} route has no canonical identity.")
+        if route.get("kind") == "agent" and agent_identities is not None:
+            name = route.get("agent")
+            if name not in agent_identities:
+                raise ConfigurationError(
+                    f"{seat} custom agent {name!r} has no resolvable model identity."
+                )
+        if any(_identities_overlap(identity, prior) for prior in identities):
+            raise ConfigurationError(f"{seat} route chain contains duplicate identities.")
+        identities.append(identity)
+    return identities
+
+
+def _identities_overlap(
+    left: tuple[str, str],
+    right: tuple[str, str],
+) -> bool:
+    """Treat the unresolved root provider as a wildcard for the same model."""
+
+    left_provider, left_model = left
+    right_provider, right_model = right
+    return left_model == right_model and (
+        left_provider == right_provider
+        or "__root_provider__" in {left_provider, right_provider}
+    )
+
+
+def validate_route_chains(
+    executor: dict[str, Any],
+    executor_backups: list[dict[str, Any]],
+    planner: dict[str, Any] | None,
+    planner_backups: list[dict[str, Any]],
+    advisor: dict[str, Any] | None,
+    advisor_backups: list[dict[str, Any]],
+    agent_identities: dict[str, tuple[str, str]] | None = None,
+) -> None:
+    """Validate backup counts, duplicate identities, and planning separation."""
+
+    all_routes: list[dict[str, Any]] = []
+    for seat, primary, backups in (
+        ("executor", executor, executor_backups),
+        ("planner", planner, planner_backups),
+        ("advisor", advisor, advisor_backups),
+    ):
+        if primary is None:
+            if backups:
+                raise ConfigurationError(f"{seat.title()} backups require a primary route.")
+            continue
+        if len(backups) > 2:
+            raise ConfigurationError(f"{seat.title()} cannot have more than two backups.")
+        all_routes.extend(route_chain(primary, backups))
+        _route_ids(
+            route_chain(primary, backups),
+            agent_identities=agent_identities,
+            seat=seat,
+        )
+
+    fable_count = sum(route.get("kind") == "fable" for route in all_routes)
+    if fable_count > 1:
+        raise ConfigurationError("Fable may occur at exactly one planning position across all chains.")
+
+    if planner is not None and advisor is not None:
+        if agent_identities is None and any(
+            route.get("kind") == "agent"
+            for route in route_chain(planner, planner_backups) + route_chain(advisor, advisor_backups)
+        ):
+            raise ConfigurationError(
+                "Planner and Advisor custom-agent identities cannot be proven independent."
+            )
+        planner_ids = _route_ids(
+            route_chain(planner, planner_backups),
+            agent_identities=agent_identities,
+            seat="planner",
+        )
+        advisor_ids = _route_ids(
+            route_chain(advisor, advisor_backups),
+            agent_identities=agent_identities,
+            seat="advisor",
+        )
+        if any(
+            _identities_overlap(planner_id, advisor_id)
+            for planner_id in planner_ids
+            for advisor_id in advisor_ids
+        ):
+            raise ConfigurationError("Planner and Advisor routes must be distinct across every candidate.")
 
 
 class ConfigurationError(RuntimeError):
@@ -96,6 +242,13 @@ def parse_args() -> argparse.Namespace:
         help="Loaded custom-agent name for durable or cross-provider routing.",
     )
     parser.add_argument(
+        "--executor-backup",
+        action="append",
+        default=[],
+        metavar="SPEC",
+        help="Ordered backup route: model:<id>@<effort> or agent:<name>.",
+    )
+    parser.add_argument(
         "--executor-effort",
         default="auto",
         help="Exact supported effort, or auto (resolved to the catalog default).",
@@ -114,6 +267,13 @@ def parse_args() -> argparse.Namespace:
         default="auto",
         help="Exact supported planner effort, or auto.",
     )
+    parser.add_argument(
+        "--planner-backup",
+        action="append",
+        default=[],
+        metavar="SPEC",
+        help="Ordered backup route: model:<id>@<effort>, agent:<name>, or fable:<effort>.",
+    )
 
     advisor = parser.add_mutually_exclusive_group()
     advisor.add_argument("--advisor-model", help="Optional exact advisor model ID.")
@@ -127,6 +287,13 @@ def parse_args() -> argparse.Namespace:
         "--advisor-effort",
         default="auto",
         help="Exact supported advisor effort, or auto.",
+    )
+    parser.add_argument(
+        "--advisor-backup",
+        action="append",
+        default=[],
+        metavar="SPEC",
+        help="Ordered backup route: model:<id>@<effort>, agent:<name>, or fable:<effort>.",
     )
 
     parser.add_argument("--codex-bin", default="codex")
@@ -175,6 +342,9 @@ def _validate_args(args: argparse.Namespace) -> None:
             args.advisor_model,
             args.advisor_agent,
             args.advisor_fable,
+            args.executor_backup,
+            args.planner_backup,
+            args.advisor_backup,
         )
     ):
         raise ConfigurationError("--status does not accept seat settings.")
@@ -188,6 +358,9 @@ def _validate_args(args: argparse.Namespace) -> None:
             args.advisor_model,
             args.advisor_agent,
             args.advisor_fable,
+            args.executor_backup,
+            args.planner_backup,
+            args.advisor_backup,
         )
     ):
         raise ConfigurationError("--disable does not accept seat settings.")
@@ -197,6 +370,15 @@ def _validate_args(args: argparse.Namespace) -> None:
         raise ConfigurationError(
             "Setup requires --executor-model or --executor-agent. Advisor omission means none."
         )
+    for seat, specs in (
+        ("executor", args.executor_backup),
+        ("planner", args.planner_backup),
+        ("advisor", args.advisor_backup),
+    ):
+        if len(specs) > 2:
+            raise ConfigurationError(f"{seat.title()} cannot have more than two backups.")
+        for spec in specs:
+            parse_backup_spec(spec, seat)
     if args.executor_agent and args.executor_effort != "auto":
         raise ConfigurationError(
             "A custom executor agent owns its effort; omit --executor-effort."
@@ -383,7 +565,7 @@ class AppServer:
                     "clientInfo": {
                         "name": "codex_orchestration_installer",
                         "title": "Codex Orchestration Installer",
-                        "version": "0.5.1",
+                        "version": "0.6.0",
                     },
                     "capabilities": {"experimentalApi": True},
                 },
@@ -711,23 +893,25 @@ def verify_agent_routes(
     codex_home: Path,
     workspace: Path,
     executor: dict[str, Any],
+    executor_backups: list[dict[str, Any]],
     planner: dict[str, Any] | None,
+    planner_backups: list[dict[str, Any]],
     advisor: dict[str, Any] | None,
+    advisor_backups: list[dict[str, Any]],
 ) -> list[Path]:
     """Require personal role files and reject current-project shadowing."""
 
     verified: list[Path] = []
     personal_agents = codex_home / "agents"
     for label, route in (
-        ("Executor", executor),
-        ("Planner", planner),
-        ("Advisor", advisor),
+        ("Executor", route)
+        for route in route_chain(executor, executor_backups)
     ):
-        if route is None or route.get("kind") != "agent":
+        if route is None:
             continue
         name = route.get("agent")
-        if not isinstance(name, str):
-            raise ConfigurationError(f"{label} custom-agent route has an invalid name.")
+        if route.get("kind") != "agent" or not isinstance(name, str):
+            continue
         personal = _agent_files_with_name(personal_agents, name)
         if len(personal) != 1:
             raise ConfigurationError(
@@ -743,7 +927,70 @@ def verify_agent_routes(
                 "the project collision."
             )
         verified.append(personal[0])
+    for label, primary, backups in (
+        ("Planner", planner, planner_backups),
+        ("Advisor", advisor, advisor_backups),
+    ):
+        if primary is None:
+            continue
+        for route in route_chain(primary, backups):
+            if route.get("kind") != "agent":
+                continue
+            name = route.get("agent")
+            if not isinstance(name, str):
+                raise ConfigurationError(f"{label} custom-agent route has an invalid name.")
+            personal = _agent_files_with_name(personal_agents, name)
+            if len(personal) != 1:
+                raise ConfigurationError(
+                    f"{label} custom-agent route {name!r} must resolve to exactly one "
+                    f"personal file under {personal_agents}; found {len(personal)}."
+                )
+            project = _project_agent_matches(workspace, personal_agents, name)
+            if project:
+                locations = ", ".join(str(path) for path in project)
+                raise ConfigurationError(
+                    f"{label} personal agent {name!r} is shadowed by a project role: "
+                    f"{locations}. Use collision-resistant personal route names or remove "
+                    "the project collision."
+                )
+            verified.append(personal[0])
     return verified
+
+
+def agent_route_identities(
+    codex_home: Path,
+    routes: list[dict[str, Any]],
+) -> dict[str, tuple[str, str]]:
+    """Resolve custom-agent aliases to their effective provider/model identity."""
+
+    identities: dict[str, tuple[str, str]] = {}
+    for route in routes:
+        if route.get("kind") != "agent":
+            continue
+        name = route.get("agent")
+        if not isinstance(name, str):
+            raise ConfigurationError("Custom-agent route has an invalid name.")
+        matches = _agent_files_with_name(codex_home / "agents", name)
+        if len(matches) != 1:
+            raise ConfigurationError(
+                f"Custom-agent route {name!r} has no single effective identity."
+            )
+        try:
+            parsed = tomllib.loads(matches[0].read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError) as exc:
+            raise ConfigurationError(f"Could not resolve custom-agent {name!r}: {exc}") from exc
+        model = parsed.get("model")
+        if not isinstance(model, str) or not model:
+            raise ConfigurationError(f"Custom-agent {name!r} does not pin a model identity.")
+        provider = parsed.get("model_provider")
+        if not isinstance(provider, str) or not provider:
+            provider = "__root_provider__"
+        identity = (provider, model)
+        prior = identities.get(name)
+        if prior is not None and prior != identity:
+            raise ConfigurationError(f"Custom-agent {name!r} resolves inconsistently.")
+        identities[name] = identity
+    return identities
 
 
 def load_models(app: AppServer) -> dict[str, dict[str, Any]]:
@@ -885,6 +1132,88 @@ def _route_summary(route: dict[str, Any]) -> str:
     return f"{route['model']}@{route['effort']}"
 
 
+def _chain_summary(
+    primary: dict[str, Any] | None,
+    backups: list[dict[str, Any]],
+    *,
+    empty: str,
+) -> str:
+    if primary is None:
+        return empty
+    return " -> ".join(_route_summary(route) for route in route_chain(primary, backups))
+
+
+def _fable_activation_manifest(
+    planner: dict[str, Any] | None,
+    planner_backups: list[dict[str, Any]],
+    advisor: dict[str, Any] | None,
+    advisor_backups: list[dict[str, Any]],
+) -> str:
+    entries: list[str] = []
+    for seat, primary, backups in (
+        ("planner", planner, planner_backups),
+        ("advisor", advisor, advisor_backups),
+    ):
+        if primary is None:
+            continue
+        for index, route in enumerate(route_chain(primary, backups)):
+            if route.get("kind") != "fable":
+                continue
+            try:
+                activation_id = candidate_activation_id(seat, index, route)
+            except RoutingStateError as exc:
+                raise ConfigurationError(
+                    "Fable route has no canonical activation identity."
+                ) from exc
+            entries.append(
+                f"{seat} candidate {index} requires candidate_index={index} "
+                f"and activation_id={activation_id} on MCP server {route['server']}"
+            )
+    return "; ".join(entries) if entries else "none"
+
+
+def _candidate_tool_manifest(
+    executor: dict[str, Any],
+    executor_backups: list[dict[str, Any]],
+    planner: dict[str, Any] | None,
+    planner_backups: list[dict[str, Any]],
+    advisor: dict[str, Any] | None,
+    advisor_backups: list[dict[str, Any]],
+) -> str:
+    entries: list[str] = []
+    for seat, primary, backups in (
+        ("executor", executor, executor_backups),
+        ("planner", planner, planner_backups),
+        ("advisor", advisor, advisor_backups),
+    ):
+        if primary is None:
+            continue
+        for index, route in enumerate(route_chain(primary, backups)):
+            if route.get("kind") == "fable":
+                entries.append(f"{seat} candidate {index} => Fable MCP")
+            else:
+                entries.append(f"{seat} candidate {index} => {_spawn_route(route)}")
+    return "; ".join(entries)
+
+
+def _candidate_readiness(
+    route: dict[str, Any],
+    *,
+    fable_available: bool,
+    verified_agents: set[Path],
+    agent_paths: dict[str, Path] | None = None,
+) -> str:
+    if route.get("kind") == "fable":
+        return "READY" if fable_available else "UNAVAILABLE"
+    if route.get("kind") == "agent":
+        name = route.get("agent")
+        path = agent_paths.get(name) if agent_paths and isinstance(name, str) else None
+        return "READY" if path in verified_agents else "UNKNOWN"
+    if route.get("kind") == "model":
+        return "READY"
+    return "UNKNOWN"
+
+
 def _managed_personal_roles(codex_home: Path) -> tuple[dict[str, Path], list[str]]:
     """Find only collision-resistant v0.4 personal roles owned by this plugin."""
 
@@ -924,12 +1253,18 @@ def _referenced_agent_names(state: dict[str, Any] | None) -> set[str]:
     names: set[str] = set()
     if not isinstance(state, dict):
         return names
+    saved_backups = state.get("backups", {})
     for key in ("executor", "planner", "advisor"):
-        route = state.get(key)
-        if isinstance(route, dict) and route.get("kind") == "agent":
-            name = route.get("agent")
-            if isinstance(name, str):
-                names.add(name)
+        routes: list[Any] = [state.get(key)]
+        if isinstance(saved_backups, dict):
+            value = saved_backups.get(key, [])
+            if isinstance(value, list):
+                routes.extend(value)
+        for route in routes:
+            if isinstance(route, dict) and route.get("kind") == "agent":
+                name = route.get("agent")
+                if isinstance(name, str):
+                    names.add(name)
     return names
 
 
@@ -946,7 +1281,44 @@ def build_policy(
     executor: dict[str, Any],
     planner: dict[str, Any] | None,
     advisor: dict[str, Any] | None,
+    executor_backups: list[dict[str, Any]] | None = None,
+    planner_backups: list[dict[str, Any]] | None = None,
+    advisor_backups: list[dict[str, Any]] | None = None,
 ) -> tuple[str, str]:
+    executor_backups = executor_backups or []
+    planner_backups = planner_backups or []
+    advisor_backups = advisor_backups or []
+    fable_activations = _fable_activation_manifest(
+        planner,
+        planner_backups,
+        advisor,
+        advisor_backups,
+    )
+    candidate_tools = _candidate_tool_manifest(
+        executor,
+        executor_backups,
+        planner,
+        planner_backups,
+        advisor,
+        advisor_backups,
+    )
+    fable_guidance: list[str] = []
+    if any(
+        route.get("kind") == "fable"
+        for route in route_chain(planner, planner_backups)
+        if isinstance(route, dict)
+    ):
+        fable_guidance.append(
+            "At a Fable Planner position use create_plan for the initial draft "
+            "and revise_plan after PLAN_REVISE."
+        )
+    if any(
+        route.get("kind") == "fable"
+        for route in route_chain(advisor, advisor_backups)
+        if isinstance(route, dict)
+    ):
+        fable_guidance.append("At a Fable Advisor position use review_plan.")
+    fable_tool_guidance = " ".join(fable_guidance)
     has_direct_route = executor["kind"] == "model" or (
         planner is not None and planner["kind"] == "model"
     ) or (
@@ -998,7 +1370,13 @@ On PLAN_REVISE, record the latest finding IDs before revision. After the Planner
 
 When executor delegation materially improves speed, cost, quality, or context isolation, use only the configured executor route. Give each executor one bounded, self-contained packet with objective, relevant facts, constraints, owned files or read-only scope, dependencies, acceptance criteria, verification, and handoff format. Inspect every handoff, integrate it, and run final checks yourself.
 
-Explicit user instructions win, including no-subagents and task-local seat overrides. Persistent and task-local Planner and Advisor routes must remain distinct: reject the same direct model ID, the same custom-agent name, or Fable in both seats. This policy does not create or change a Goal, weaken approvals, alter permissions, or force a worker count.
+Ordered backup routes are policy-directed failover, never engine-level automatic failover. Executor candidates are tried only in this order: {_chain_summary(executor, executor_backups, empty="none")}. A primary or candidate that has started is never silently replaced. ELIGIBLE_PRESTART is limited to proven local unavailability or explicit spawn rejection with no child, agent, or task ID; STARTED means no automatic Executor advancement. AMBIGUOUS and UNKNOWN freeze the chain. Normal Codex children remain mutation-capable even when a packet says read-only. Post-start planning failover is limited to a mechanically no-tools launcher; valid PLAN_REVISE, disagreement, refusal, or perceived quality never triggers failover. Planning candidates are Planner: {_chain_summary(planner, planner_backups, empty="root")} and Advisor: {_chain_summary(advisor, advisor_backups, empty="none")}.
+
+The shared Fable classification is exhaustive: AUTH_UNAVAILABLE and MODEL_UNAVAILABLE are eligible pre-start only with bridge-attested provenance; TRANSPORT_FAILURE and INVALID_RESULT are eligible only after authenticated, identity-matched, mechanically no-tools execution with no valid deliverable; IDENTITY_MISMATCH and STATE_INVALID freeze as STATE_UNKNOWN; UNKNOWN or any impossible combination freezes. A valid deliverable never falls back.
+
+Before any routed activation, initialize and retain this prompt-governed envelope shape: routing_envelope_version=1; seats={{executor|planner|advisor: {{cursor, active_identity, episode_state, activation_ids, started_child_ids, superseded_attempts}}}}. Update it after every creation response and before considering the next candidate. A missing, truncated, inconsistent, or unknown field/version is STATE_UNKNOWN: freeze backup activation and never issue another Executor when prior creation cannot be disproved. The envelope is policy text, not engine enforcement.
+
+Explicit user instructions win, including no-subagents and task-local seat overrides. Persistent and task-local Planner and Advisor routes, including every backup candidate, must remain distinct: resolve custom-agent TOML provider/model identities, treat an unresolved root provider as a wildcard for the same model ID, and freeze when independence cannot be proven. Reject the same direct model identity, aliases of the same effective model route, or Fable in both chains. This policy does not create or change a Goal, weaken approvals, alter permissions, or force a worker count. Backup activation inherits the current root authority cap unchanged or narrower; unknown effective authority blocks failover. Route grammar rejects sandbox, approval, service-tier, Goal, and authority extensions.
 
 Planner and Advisor are policy-isolated, root-directed seats: they cannot contact each other or Executors, spawn descendants, edit files, execute work, or release Executor. They return only to the root. Fable MCP requests do not carry caller identity, so caller isolation is instruction-enforced even though the bridge itself disables tools and persistence. If you are a spawned child, stay inside the supplied packet, report only to the root, never call planning tools, and never spawn descendants. An Executor never redesigns the root plan or contacts Planner or Advisor.
 """
@@ -1039,7 +1417,11 @@ Planner and Advisor are policy-isolated, root-directed seats: they cannot contac
     usage = f"""{MANAGED_MARKER}
 If you are the root task model, you are the orchestrator. Apply these routes only to children you decide to create.
 
-For delegated executor work, call this tool with {_spawn_route(executor)}, fork_turns = "none". Send a self-contained task packet.
+The configured ordered backup chains are Executor: {_chain_summary(executor, executor_backups, empty="none")}; Planner: {_chain_summary(planner, planner_backups, empty="root")}; Advisor: {_chain_summary(advisor, advisor_backups, empty="none")}. The bridge never chooses a backup or moves a cursor. Only the root may advance a cursor after mechanically classified failure, and it must preserve the task envelope and activation IDs. Fable authorization: {fable_activations}. Every schema-4 Fable tool call must supply the exact listed candidate_index and activation_id; omission or mismatch freezes the chain. {fable_tool_guidance}
+
+Candidate tool routes: {candidate_tools}.
+
+For delegated executor work, begin with candidate 0 using {_spawn_route(executor)}, fork_turns = "none". Send a self-contained task packet. Use a later candidate's exact listed tool route only after the policy permits its cursor.
 
 {planner_hint}
 
@@ -1047,7 +1429,7 @@ For delegated executor work, call this tool with {_spawn_route(executor)}, fork_
 
 {provider_guard}
 
-Never use fork_turns = "all" with model, reasoning_effort, or agent_type: a full-history fork inherits the root route and rejects those overrides. Never silently substitute the root model when an exact child route is unavailable. Report the unavailable route to the root. A user's explicit current-task model, effort, agent, or no-subagents instruction overrides this saved default, but a task-local Planner and Advisor must still be distinct: reject the same direct model ID, the same custom-agent name, or Fable in both seats.
+Never use fork_turns = "all" with model, reasoning_effort, or agent_type: a full-history fork inherits the root route and rejects those overrides. Never silently substitute the root model when an exact child route is unavailable. Report the unavailable route to the root. A user's explicit current-task model, effort, agent, or no-subagents instruction overrides this saved default, but task-local Planner and Advisor must still be distinct across their full chains and proven disjoint by effective provider/model identity; unknown identity freezes routing. At minimum, reject the same direct model ID, aliases of the same custom-agent model route, or Fable in both seats.
 
 If you are a spawned child, do not call this tool or create descendants. Finish only your assigned packet and return to the root.
 """
@@ -1214,14 +1596,18 @@ def _status(
         print(f"Config: {app.config_path}")
         fable_available = True
         if state_matches:
-            print(f"Executor: {_route_summary(state['executor'])}")
+            saved_backups = state.get("backups", {})
+            executor_backups = saved_backups.get("executor", []) if isinstance(saved_backups, dict) else []
+            planner_backups = saved_backups.get("planner", []) if isinstance(saved_backups, dict) else []
+            advisor_backups = saved_backups.get("advisor", []) if isinstance(saved_backups, dict) else []
+            print(f"Executor: {_chain_summary(state['executor'], executor_backups, empty='none')}")
             planner = state.get("planner")
             advisor = state.get("advisor")
-            print(f"Planner: {_route_summary(planner) if planner else 'root'}")
-            print(f"Advisor: {_route_summary(advisor) if advisor else 'none'}")
+            print(f"Planner: {_chain_summary(planner, planner_backups, empty='root')}")
+            print(f"Advisor: {_chain_summary(advisor, advisor_backups, empty='none')}")
             fable_routes = [
                 route
-                for route in (planner, advisor)
+                for route in (planner, advisor, *planner_backups, *advisor_backups)
                 if isinstance(route, dict) and route.get("kind") == "fable"
             ]
             for route in fable_routes:
@@ -1234,13 +1620,18 @@ def _status(
                     print(
                         "Claude Fable 5: ready — first-party login; no model call made"
                     )
+            verified: list[Path] = []
+            agent_paths: dict[str, Path] = {}
             try:
                 verified = verify_agent_routes(
                     app.codex_home,
                     workspace,
                     state["executor"],
+                    executor_backups,
                     planner,
+                    planner_backups,
                     advisor,
+                    advisor_backups,
                 )
             except (ConfigurationError, KeyError, TypeError) as exc:
                 print(f"Custom-agent route: unavailable — {exc}")
@@ -1252,6 +1643,38 @@ def _status(
                         "Custom-agent route: verified — "
                         + ", ".join(str(path) for path in verified)
                     )
+                for route in (
+                    state["executor"],
+                    *executor_backups,
+                    planner,
+                    *planner_backups,
+                    advisor,
+                    *advisor_backups,
+                ):
+                    if not isinstance(route, dict) or route.get("kind") != "agent":
+                        continue
+                    name = route.get("agent")
+                    if not isinstance(name, str):
+                        continue
+                    matches = _agent_files_with_name(app.codex_home / "agents", name)
+                    if len(matches) == 1:
+                        agent_paths[name] = matches[0]
+            verified_set = set(verified)
+            for label, primary, candidates in (
+                ("Executor", state["executor"], executor_backups),
+                ("Planner", planner, planner_backups),
+                ("Advisor", advisor, advisor_backups),
+            ):
+                if primary is None:
+                    continue
+                for index, route in enumerate(route_chain(primary, candidates)):
+                    readiness = _candidate_readiness(
+                        route,
+                        fable_available=fable_available,
+                        verified_agents=verified_set,
+                        agent_paths=agent_paths,
+                    )
+                    print(f"{label} candidate {index}: {_route_summary(route)} — {readiness}")
         elif routing_state.startswith("installed"):
             agent_routes_available = False
             print("Seats: managed policy found; local state is unavailable")
@@ -1307,8 +1730,11 @@ def _prepare_setup_state(
     mode: str,
     usage: str,
     executor: dict[str, Any],
+    executor_backups: list[dict[str, Any]],
     planner: dict[str, Any] | None,
+    planner_backups: list[dict[str, Any]],
     advisor: dict[str, Any] | None,
+    advisor_backups: list[dict[str, Any]],
     config_path: Path,
     replace_existing: bool,
 ) -> tuple[dict[str, Any], list[dict[str, Any]], list[dict[str, Any]]]:
@@ -1470,7 +1896,12 @@ def _prepare_setup_state(
     manage_mcp = (
         any(
             isinstance(route, dict) and route.get("kind") == "fable"
-            for route in (planner, advisor)
+            for route in (
+                planner,
+                advisor,
+                *planner_backups,
+                *advisor_backups,
+            )
         )
         or isinstance(existing_managed, dict)
         and isinstance(existing_managed.get("mcp"), dict)
@@ -1483,7 +1914,7 @@ def _prepare_setup_state(
         fable_route = next(
             (
                 route
-                for route in (planner, advisor)
+                for route in (planner, advisor, *planner_backups, *advisor_backups)
                 if isinstance(route, dict) and route.get("kind") == "fable"
             ),
             None,
@@ -1535,6 +1966,11 @@ def _prepare_setup_state(
         "managed_by": "codex-orchestration",
         "config_file": str(config_path),
         "executor": executor,
+        "backups": {
+            "executor": executor_backups,
+            "planner": planner_backups,
+            "advisor": advisor_backups,
+        },
         "planner": planner,
         "advisor": advisor,
         "managed": managed,
@@ -1689,7 +2125,15 @@ def main() -> int:
                 return _disable(app, config, version, state, args.apply)
 
             catalog: dict[str, dict[str, Any]] = {}
-            if args.executor_model or args.planner_model or args.advisor_model:
+            if (
+                args.executor_model
+                or args.planner_model
+                or args.advisor_model
+                or any(
+                    spec.startswith("model:")
+                    for spec in (*args.executor_backup, *args.planner_backup, *args.advisor_backup)
+                )
+            ):
                 try:
                     catalog = load_models(app)
                 except ConfigurationError:
@@ -1712,12 +2156,36 @@ def main() -> int:
             else:
                 executor = {"kind": "agent", "agent": args.executor_agent}
 
+            executor_backups = [
+                parse_backup_spec(spec, "executor") for spec in args.executor_backup
+            ]
+            planner_backups = [
+                parse_backup_spec(spec, "planner") for spec in args.planner_backup
+            ]
+            advisor_backups = [
+                parse_backup_spec(spec, "advisor") for spec in args.advisor_backup
+            ]
+
+            if planner_backups and not (
+                args.planner_model or args.planner_agent or args.planner_fable
+            ):
+                raise ConfigurationError("Planner backups require a Planner primary route.")
+            if advisor_backups and not (
+                args.advisor_model or args.advisor_agent or args.advisor_fable
+            ):
+                raise ConfigurationError("Advisor backups require an Advisor primary route.")
+
             planner: dict[str, Any] | None = None
             advisor: dict[str, Any] | None = None
             fable_auth: dict[str, str] | None = None
             fable_server = (
                 select_fable_server()
-                if args.planner_fable or args.advisor_fable
+                if args.planner_fable
+                or args.advisor_fable
+                or any(
+                    route.get("kind") == "fable"
+                    for route in (*planner_backups, *advisor_backups)
+                )
                 else None
             )
             if args.planner_model:
@@ -1743,6 +2211,9 @@ def main() -> int:
                     "server": fable_server,
                 }
 
+            if planner is None and planner_backups:
+                raise ConfigurationError("Planner backups require a Planner primary route.")
+
             if args.advisor_model:
                 advisor_effort = resolve_model_effort(
                     "Advisor",
@@ -1766,10 +2237,32 @@ def main() -> int:
                     "server": fable_server,
                 }
 
+            if advisor is None and advisor_backups:
+                raise ConfigurationError("Advisor backups require an Advisor primary route.")
+
+            for label, routes in (
+                ("Executor", executor_backups),
+                ("Planner", planner_backups),
+                ("Advisor", advisor_backups),
+            ):
+                for route in routes:
+                    if route.get("kind") == "model":
+                        route["effort"] = resolve_model_effort(
+                            label,
+                            route["model"],
+                            route["effort"],
+                            catalog,
+                            args.confirm_unlisted_models,
+                        )
+
+            for route in (*planner_backups, *advisor_backups):
+                if route.get("kind") == "fable":
+                    route["server"] = fable_server
+
             validate_planning_routes(planner, advisor)
             fable_efforts = {
                 route["effort"]
-                for route in (planner, advisor)
+                for route in (planner, advisor, *planner_backups, *advisor_backups)
                 if isinstance(route, dict) and route.get("kind") == "fable"
             }
             for effort in sorted(fable_efforts):
@@ -1779,26 +2272,61 @@ def main() -> int:
                 app.codex_home,
                 workspace,
                 executor,
+                executor_backups,
+                planner,
+                planner_backups,
+                advisor,
+                advisor_backups,
+            )
+            route_agents = [
+                route
+                for route in (
+                    executor,
+                    *executor_backups,
+                    planner,
+                    *planner_backups,
+                    advisor,
+                    *advisor_backups,
+                )
+                if isinstance(route, dict)
+            ]
+            agent_identities = agent_route_identities(app.codex_home, route_agents)
+            validate_route_chains(
+                executor,
+                executor_backups,
+                planner,
+                planner_backups,
+                advisor,
+                advisor_backups,
+                agent_identities,
+            )
+            mode, usage = build_policy(
+                executor,
                 planner,
                 advisor,
+                executor_backups,
+                planner_backups,
+                advisor_backups,
             )
-            mode, usage = build_policy(executor, planner, advisor)
             new_state, edits, rollback = _prepare_setup_state(
                 config,
                 state,
                 mode,
                 usage,
                 executor,
+                executor_backups,
                 planner,
+                planner_backups,
                 advisor,
+                advisor_backups,
                 app.config_path,
                 args.replace_existing_policy,
             )
             print(f"Config: {app.config_path}")
             print("Orchestrator: model selected when each Codex task starts")
-            print(f"Executor: {_route_summary(executor)}")
-            print(f"Planner: {_route_summary(planner) if planner else 'root'}")
-            print(f"Advisor: {_route_summary(advisor) if advisor else 'none'}")
+            print(f"Executor: {_chain_summary(executor, executor_backups, empty='none')}")
+            print(f"Planner: {_chain_summary(planner, planner_backups, empty='root')}")
+            print(f"Advisor: {_chain_summary(advisor, advisor_backups, empty='none')}")
             if args.planner_fable and args.planner_effort in FABLE_EFFORT_ALIASES:
                 print(
                     f"Planner effort alias: {args.planner_effort} -> "

--- a/plugins/codex-orchestration/skills/codex-orchestration/scripts/configure_native_routing.py
+++ b/plugins/codex-orchestration/skills/codex-orchestration/scripts/configure_native_routing.py
@@ -1319,10 +1319,16 @@ def build_policy(
     ):
         fable_guidance.append("At a Fable Advisor position use review_plan.")
     fable_tool_guidance = " ".join(fable_guidance)
-    has_direct_route = executor["kind"] == "model" or (
-        planner is not None and planner["kind"] == "model"
-    ) or (
-        advisor is not None and advisor["kind"] == "model"
+    has_direct_route = any(
+        isinstance(route, dict) and route.get("kind") == "model"
+        for route in (
+            executor,
+            *executor_backups,
+            planner,
+            *planner_backups,
+            advisor,
+            *advisor_backups,
+        )
     )
     provider_guard = (
         "Direct model overrides retain the root provider. Before using a direct "

--- a/plugins/codex-orchestration/skills/codex-orchestration/scripts/fable_advisor_mcp.py
+++ b/plugins/codex-orchestration/skills/codex-orchestration/scripts/fable_advisor_mcp.py
@@ -44,6 +44,20 @@ SENSITIVE_ENV = {
     "CLAUDE_CODE_USE_FOUNDRY",
 }
 
+FABLE_OUTCOME_CODES = frozenset(
+    {
+        "AUTH_UNAVAILABLE",
+        "MODEL_UNAVAILABLE",
+        "TRANSPORT_FAILURE",
+        "INVALID_RESULT",
+        "IDENTITY_MISMATCH",
+        "STATE_INVALID",
+        "UNKNOWN",
+        "DELIVERABLE_VALID",
+    }
+)
+_STARTED_ELIGIBLE_CODES = frozenset({"TRANSPORT_FAILURE", "INVALID_RESULT"})
+
 ADVISOR_SYSTEM_PROMPT = """You are Claude Fable 5 acting only as a plan advisor to Codex's root orchestrator.
 Review the supplied self-contained packet for material correctness, missing constraints, unsafe sequencing, ownership conflicts, and verification gaps. Do not edit files, call tools, spawn agents, contact the Planner or executors, or attempt implementation.
 
@@ -78,6 +92,139 @@ Seat = Literal["planner", "advisor"]
 class AdvisorError(RuntimeError):
     """Fail-closed error for any Fable bridge operation."""
 
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str = "UNKNOWN",
+        authenticated: bool = False,
+        identity_matched: bool = False,
+        mechanically_no_tools: bool = False,
+        invocation_started: bool = False,
+        deliverable_valid: bool = False,
+        activation_id: str | None = None,
+        candidate_index: int | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.outcome = classify_fable_outcome(
+            code=code,
+            authenticated=authenticated,
+            identity_matched=identity_matched,
+            mechanically_no_tools=mechanically_no_tools,
+            invocation_started=invocation_started,
+            deliverable_valid=deliverable_valid,
+        )
+        self.outcome.update(
+            {
+                "activation_id": activation_id,
+                "candidate_index": candidate_index,
+                "authenticated": authenticated,
+                "identity_matched": identity_matched,
+                "mechanically_no_tools": mechanically_no_tools,
+                "invocation_started": invocation_started,
+                "deliverable_valid": deliverable_valid,
+            }
+        )
+
+    def with_activation(self, activation_id: str, candidate_index: int) -> AdvisorError:
+        """Attach the bridge-derived activation provenance without echoing input."""
+
+        self.outcome["activation_id"] = activation_id
+        self.outcome["candidate_index"] = candidate_index
+        return self
+
+
+def candidate_activation_id(seat: Seat, candidate_index: int, route: dict[str, str]) -> str:
+    """Return the redacted deterministic activation identity for one candidate."""
+
+    try:
+        return routing_state.candidate_activation_id(seat, candidate_index, route)
+    except routing_state.RoutingStateError as exc:
+        raise AdvisorError(
+            "Invalid Fable candidate authorization.",
+            code="STATE_INVALID",
+            mechanically_no_tools=True,
+        ) from exc
+
+
+def classify_fable_outcome(
+    *,
+    code: str,
+    authenticated: bool,
+    identity_matched: bool,
+    mechanically_no_tools: bool,
+    invocation_started: bool,
+    deliverable_valid: bool,
+) -> dict[str, Any]:
+    """Apply the exhaustive bridge/policy failover classification matrix."""
+
+    valid_flags = all(
+        type(value) is bool
+        for value in (
+            authenticated,
+            identity_matched,
+            mechanically_no_tools,
+            invocation_started,
+            deliverable_valid,
+        )
+    )
+    if code not in FABLE_OUTCOME_CODES or not valid_flags:
+        return {"code": code, "eligible": False, "state": "STATE_UNKNOWN"}
+    if code == "DELIVERABLE_VALID":
+        valid = (
+            authenticated
+            and identity_matched
+            and mechanically_no_tools
+            and invocation_started
+            and deliverable_valid
+        )
+        return {
+            "code": code,
+            "eligible": False,
+            "state": "DELIVERABLE_VALID" if valid else "STATE_UNKNOWN",
+        }
+    if deliverable_valid:
+        return {"code": code, "eligible": False, "state": "STATE_UNKNOWN"}
+    if code in {"IDENTITY_MISMATCH", "STATE_INVALID"}:
+        return {"code": code, "eligible": False, "state": "STATE_UNKNOWN"}
+    if code == "AUTH_UNAVAILABLE":
+        eligible = (
+            not invocation_started
+            and not authenticated
+            and identity_matched
+            and mechanically_no_tools
+        )
+        return {
+            "code": code,
+            "eligible": eligible,
+            "state": "ELIGIBLE_PRESTART" if eligible else "STATE_UNKNOWN",
+        }
+    if code == "MODEL_UNAVAILABLE":
+        eligible = (
+            not invocation_started
+            and authenticated
+            and identity_matched
+            and mechanically_no_tools
+        )
+        return {
+            "code": code,
+            "eligible": eligible,
+            "state": "ELIGIBLE_PRESTART" if eligible else "STATE_UNKNOWN",
+        }
+    elif code in _STARTED_ELIGIBLE_CODES:
+        eligible = (
+            invocation_started
+            and authenticated
+            and identity_matched
+            and mechanically_no_tools
+        )
+        return {
+            "code": code,
+            "eligible": eligible,
+            "state": "ELIGIBLE_STARTED" if eligible else "STATE_UNKNOWN",
+        }
+    return {"code": code, "eligible": False, "state": "STATE_UNKNOWN"}
+
 
 def codex_home() -> Path:
     value = os.environ.get("CODEX_HOME")
@@ -103,7 +250,12 @@ def resolve_claude() -> Path:
     for candidate in candidates:
         if candidate.is_file():
             return candidate.resolve()
-    raise AdvisorError("Claude Code is not installed or `claude` is not on PATH.")
+    raise AdvisorError(
+        "Claude Code is not installed or `claude` is not on PATH.",
+        code="AUTH_UNAVAILABLE",
+        identity_matched=True,
+        mechanically_no_tools=True,
+    )
 
 
 def _run_json(command: list[str], *, timeout: int) -> dict[str, Any]:
@@ -118,19 +270,42 @@ def _run_json(command: list[str], *, timeout: int) -> dict[str, Any]:
             check=False,
         )
     except subprocess.TimeoutExpired as exc:
-        raise AdvisorError("Claude Code authentication check timed out.") from exc
+        raise AdvisorError(
+            "Claude Code authentication check timed out.",
+            code="AUTH_UNAVAILABLE",
+            identity_matched=True,
+            mechanically_no_tools=True,
+        ) from exc
     except OSError as exc:
-        raise AdvisorError("Could not run Claude Code authentication check.") from exc
+        raise AdvisorError(
+            "Could not run Claude Code authentication check.",
+            code="AUTH_UNAVAILABLE",
+            identity_matched=True,
+            mechanically_no_tools=True,
+        ) from exc
     if result.returncode != 0:
         raise AdvisorError(
-            f"Claude Code authentication check exited with {result.returncode}; output withheld."
+            f"Claude Code authentication check exited with {result.returncode}; output withheld.",
+            code="AUTH_UNAVAILABLE",
+            identity_matched=True,
+            mechanically_no_tools=True,
         )
     try:
         payload = json.loads(result.stdout)
     except json.JSONDecodeError as exc:
-        raise AdvisorError("Claude Code returned malformed JSON.") from exc
+        raise AdvisorError(
+            "Claude Code returned malformed JSON.",
+            code="AUTH_UNAVAILABLE",
+            identity_matched=True,
+            mechanically_no_tools=True,
+        ) from exc
     if not isinstance(payload, dict):
-        raise AdvisorError("Claude Code returned an unexpected JSON value.")
+        raise AdvisorError(
+            "Claude Code returned an unexpected JSON value.",
+            code="AUTH_UNAVAILABLE",
+            identity_matched=True,
+            mechanically_no_tools=True,
+        )
     return payload
 
 
@@ -146,7 +321,10 @@ def check_claude_auth(claude: Path | None = None) -> dict[str, str]:
     ):
         raise AdvisorError(
             "Claude Code must be logged in through a first-party Pro or Max account; "
-            "run `claude auth login` and try again."
+            "run `claude auth login` and try again.",
+            code="AUTH_UNAVAILABLE",
+            identity_matched=True,
+            mechanically_no_tools=True,
         )
     return {"auth_method": "claude.ai", "api_provider": "firstParty"}
 
@@ -157,18 +335,38 @@ def _read_routing_state(home: Path | None = None) -> dict[str, Any]:
     try:
         info = path.lstat()
         if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
-            raise AdvisorError("The saved routing state is not a regular file.")
+            raise AdvisorError(
+                "The saved routing state is not a regular file.",
+                code="STATE_INVALID",
+                mechanically_no_tools=True,
+            )
         if info.st_nlink != 1:
-            raise AdvisorError("The saved routing state has multiple hard links.")
+            raise AdvisorError(
+                "The saved routing state has multiple hard links.",
+                code="STATE_INVALID",
+                mechanically_no_tools=True,
+            )
         payload = json.loads(path.read_text(encoding="utf-8"))
     except FileNotFoundError as exc:
-        raise AdvisorError("Claude Fable 5 is not configured; run setup first.") from exc
+        raise AdvisorError(
+            "Claude Fable 5 is not configured; run setup first.",
+            code="STATE_INVALID",
+            mechanically_no_tools=True,
+        ) from exc
     except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
-        raise AdvisorError("Could not read valid routing state.") from exc
+        raise AdvisorError(
+            "Could not read valid routing state.",
+            code="STATE_INVALID",
+            mechanically_no_tools=True,
+        ) from exc
     try:
         state = routing_state.validate_routing_state(payload)
     except routing_state.RoutingStateError as exc:
-        raise AdvisorError("The saved routing state is invalid.") from exc
+        raise AdvisorError(
+            "The saved routing state is invalid.",
+            code="STATE_INVALID",
+            mechanically_no_tools=True,
+        ) from exc
     config_file = state["config_file"]
     try:
         belongs_to_home = (
@@ -176,26 +374,51 @@ def _read_routing_state(home: Path | None = None) -> dict[str, Any]:
             == (root / "config.toml").expanduser().resolve()
         )
     except (OSError, RuntimeError) as exc:
-        raise AdvisorError("The saved routing state belongs to another Codex home.") from exc
+        raise AdvisorError(
+            "The saved routing state belongs to another Codex home.",
+            code="STATE_INVALID",
+            mechanically_no_tools=True,
+        ) from exc
     if not belongs_to_home:
-        raise AdvisorError("The saved routing state belongs to another Codex home.")
+        raise AdvisorError(
+            "The saved routing state belongs to another Codex home.",
+            code="STATE_INVALID",
+            mechanically_no_tools=True,
+        )
     return state
 
 
 def _validate_seat(seat: str) -> Seat:
     if seat not in {"planner", "advisor"}:
-        raise AdvisorError("Fable seat must be `planner` or `advisor`.")
+        raise AdvisorError(
+            "Fable seat must be `planner` or `advisor`.",
+            code="STATE_INVALID",
+            mechanically_no_tools=True,
+        )
     return seat  # type: ignore[return-value]
 
 
 def _validate_fable_route(route: Any, *, seat: Seat) -> dict[str, str]:
     if not isinstance(route, dict) or route.get("kind") != "fable":
-        raise AdvisorError(f"Claude Fable 5 is not the configured {seat}.")
-    return {"model": route["model"], "effort": route["effort"]}
+        raise AdvisorError(
+            f"Claude Fable 5 is not the configured {seat}.",
+            code="STATE_INVALID",
+            mechanically_no_tools=True,
+        )
+    return {
+        "kind": "fable",
+        "model": route["model"],
+        "effort": route["effort"],
+        "server": route["server"],
+    }
 
 
 def load_fable_route(
-    home: Path | None = None, *, seat: str = "advisor"
+    home: Path | None = None,
+    *,
+    seat: str = "advisor",
+    candidate_index: int = 0,
+    activation_id: str | None = None,
 ) -> dict[str, str]:
     """Load and validate one explicitly authorized Fable seat.
 
@@ -205,7 +428,36 @@ def load_fable_route(
 
     selected = _validate_seat(seat)
     payload = _read_routing_state(home)
-    return _validate_fable_route(payload.get(selected), seat=selected)
+    if type(candidate_index) is not int or candidate_index < 0:
+        raise AdvisorError(
+            "Fable candidate index must be a non-negative integer.",
+            code="STATE_INVALID",
+            mechanically_no_tools=True,
+        )
+    backups = payload.get("backups", {})
+    candidates = [payload.get(selected)]
+    if isinstance(backups, dict):
+        saved = backups.get(selected, [])
+        if isinstance(saved, list):
+            candidates.extend(saved)
+    if candidate_index >= len(candidates):
+        raise AdvisorError(
+            "Fable candidate index is not configured for this seat.",
+            code="STATE_INVALID",
+            mechanically_no_tools=True,
+        )
+    route = _validate_fable_route(candidates[candidate_index], seat=selected)
+    expected_activation = candidate_activation_id(selected, candidate_index, route)
+    if (payload["schema"] >= 4 or activation_id is not None) and activation_id != expected_activation:
+        raise AdvisorError(
+            "Fable activation identity does not match the configured candidate.",
+            code="IDENTITY_MISMATCH",
+            mechanically_no_tools=True,
+            candidate_index=candidate_index,
+        )
+    route["activation_id"] = expected_activation
+    route["candidate_index"] = str(candidate_index)
+    return route
 
 
 def _validate_inputs(operation: str, **values: Any) -> dict[str, str]:
@@ -229,16 +481,28 @@ def _validate_runtime_models(usage: Any) -> list[str]:
     raw_models = list(usage) if isinstance(usage, dict) else []
     if not all(isinstance(model, str) for model in raw_models):
         raise AdvisorError(
-            "Runtime metadata reported a model outside the allowed Fable runtime policy."
+            "Runtime metadata reported a model outside the allowed Fable runtime policy.",
+            code="IDENTITY_MISMATCH",
+            authenticated=True,
+            mechanically_no_tools=True,
+            invocation_started=True,
         )
     used_models = sorted(raw_models)
     if FABLE_MODEL not in used_models:
         raise AdvisorError(
-            "Runtime metadata did not confirm the pinned Claude Fable 5 primary model."
+            "Runtime metadata did not confirm the pinned Claude Fable 5 primary model.",
+            code="IDENTITY_MISMATCH",
+            authenticated=True,
+            mechanically_no_tools=True,
+            invocation_started=True,
         )
     if not set(used_models).issubset(ALLOWED_RUNTIME_MODELS):
         raise AdvisorError(
-            "Runtime metadata reported a model outside the allowed Fable runtime policy."
+            "Runtime metadata reported a model outside the allowed Fable runtime policy.",
+            code="IDENTITY_MISMATCH",
+            authenticated=True,
+            mechanically_no_tools=True,
+            invocation_started=True,
         )
     return used_models
 
@@ -250,12 +514,21 @@ def _invoke_fable(
     prompt: str,
     system_prompt: str,
     allowed_signals: set[str],
+    activation_id: str | None = None,
+    candidate_index: int = 0,
 ) -> tuple[str, str, dict[str, str], dict[str, str], list[str]]:
     """Run one stateless, seat-authorized, no-tools Fable operation."""
 
-    route = load_fable_route(seat=seat)
-    claude = resolve_claude()
-    auth = check_claude_auth(claude)
+    route = load_fable_route(
+        seat=seat,
+        candidate_index=candidate_index,
+        activation_id=activation_id,
+    )
+    try:
+        claude = resolve_claude()
+        auth = check_claude_auth(claude)
+    except AdvisorError as exc:
+        raise exc.with_activation(route["activation_id"], candidate_index)
     command = [
         str(claude),
         "-p",
@@ -288,30 +561,91 @@ def _invoke_fable(
             check=False,
         )
     except subprocess.TimeoutExpired as exc:
-        raise AdvisorError(f"Claude Fable 5 {operation} timed out.") from exc
+        raise AdvisorError(
+            f"Claude Fable 5 {operation} timed out.",
+            code="TRANSPORT_FAILURE",
+            authenticated=True,
+            identity_matched=True,
+            mechanically_no_tools=True,
+            invocation_started=True,
+            activation_id=route["activation_id"],
+            candidate_index=candidate_index,
+        ) from exc
     except OSError as exc:
-        raise AdvisorError(f"Could not start Claude Fable 5 {operation}.") from exc
+        raise AdvisorError(
+            f"Could not start Claude Fable 5 {operation}.",
+            code="MODEL_UNAVAILABLE",
+            authenticated=True,
+            identity_matched=True,
+            mechanically_no_tools=True,
+            activation_id=route["activation_id"],
+            candidate_index=candidate_index,
+        ) from exc
     if result.returncode != 0:
         raise AdvisorError(
-            f"Claude Fable 5 {operation} exited with {result.returncode}; output withheld."
+            f"Claude Fable 5 {operation} exited with {result.returncode}; output withheld.",
+            code="TRANSPORT_FAILURE",
+            authenticated=True,
+            identity_matched=True,
+            mechanically_no_tools=True,
+            invocation_started=True,
+            activation_id=route["activation_id"],
+            candidate_index=candidate_index,
         )
     try:
         payload = json.loads(result.stdout)
     except json.JSONDecodeError as exc:
-        raise AdvisorError(f"Claude Fable 5 {operation} returned malformed JSON.") from exc
+        raise AdvisorError(
+            f"Claude Fable 5 {operation} returned malformed JSON.",
+            code="INVALID_RESULT",
+            authenticated=True,
+            identity_matched=True,
+            mechanically_no_tools=True,
+            invocation_started=True,
+            activation_id=route["activation_id"],
+            candidate_index=candidate_index,
+        ) from exc
     if not isinstance(payload, dict) or not isinstance(payload.get("result"), str):
-        raise AdvisorError(f"Claude Fable 5 {operation} returned an unexpected response.")
+        raise AdvisorError(
+            f"Claude Fable 5 {operation} returned an unexpected response.",
+            code="INVALID_RESULT",
+            authenticated=True,
+            identity_matched=True,
+            mechanically_no_tools=True,
+            invocation_started=True,
+            activation_id=route["activation_id"],
+            candidate_index=candidate_index,
+        )
     # Authorize the complete runtime identity set before interpreting or
     # returning any model-authored plan/review content.
-    used_models = _validate_runtime_models(payload.get("modelUsage"))
+    try:
+        used_models = _validate_runtime_models(payload.get("modelUsage"))
+    except AdvisorError as exc:
+        raise exc.with_activation(route["activation_id"], candidate_index)
     response = payload["result"].strip()
     signal = _first_non_empty_line(response)
     if signal not in allowed_signals:
         if operation == "plan review":
-            raise AdvisorError("Claude Fable 5 omitted the required plan decision.")
+            raise AdvisorError(
+                "Claude Fable 5 omitted the required plan decision.",
+                code="INVALID_RESULT",
+                authenticated=True,
+                identity_matched=True,
+                mechanically_no_tools=True,
+                invocation_started=True,
+                activation_id=route["activation_id"],
+                candidate_index=candidate_index,
+            )
         expected = " or ".join(sorted(allowed_signals))
         raise AdvisorError(
-            f"Claude Fable 5 {operation} omitted the required {expected} signal."
+            f"Claude Fable 5 {operation} omitted the required {expected} signal.",
+            code="INVALID_RESULT",
+            authenticated=True,
+            identity_matched=True,
+            mechanically_no_tools=True,
+            invocation_started=True,
+            activation_id=route["activation_id"],
+            candidate_index=candidate_index,
         )
     return signal, response, route, auth, used_models
 
@@ -326,10 +660,32 @@ def _base_result(
         "effort": route["effort"],
         "auth_method": auth["auth_method"],
         "used_models": used_models,
+        "outcome": {
+            **classify_fable_outcome(
+                code="DELIVERABLE_VALID",
+                authenticated=True,
+                identity_matched=True,
+                mechanically_no_tools=True,
+                invocation_started=True,
+                deliverable_valid=True,
+            ),
+            "activation_id": route.get("activation_id"),
+            "candidate_index": int(route.get("candidate_index", "0")),
+            "authenticated": True,
+            "identity_matched": True,
+            "mechanically_no_tools": True,
+            "invocation_started": True,
+            "deliverable_valid": bool(used_models),
+        },
     }
 
 
-def create_plan(packet: str) -> dict[str, Any]:
+def create_plan(
+    packet: str,
+    *,
+    activation_id: str | None = None,
+    candidate_index: int = 0,
+) -> dict[str, Any]:
     values = _validate_inputs("plan creation", packet=packet)
     signal, response, route, auth, used_models = _invoke_fable(
         operation="plan creation",
@@ -337,6 +693,8 @@ def create_plan(packet: str) -> dict[str, Any]:
         prompt=values["packet"],
         system_prompt=PLANNER_CREATE_SYSTEM_PROMPT,
         allowed_signals={"PLAN_DRAFT"},
+        activation_id=activation_id,
+        candidate_index=candidate_index,
     )
     return {
         "signal": signal,
@@ -373,7 +731,13 @@ def _validate_revision_structure(response: str) -> None:
 
 
 def revise_plan(
-    task: str, current_plan: str, critique: str, history: str
+    task: str,
+    current_plan: str,
+    critique: str,
+    history: str,
+    *,
+    activation_id: str | None = None,
+    candidate_index: int = 0,
 ) -> dict[str, Any]:
     values = _validate_inputs(
         "plan revision",
@@ -396,8 +760,22 @@ def revise_plan(
         prompt=prompt,
         system_prompt=PLANNER_REVISE_SYSTEM_PROMPT,
         allowed_signals={"PLAN_REVISION"},
+        activation_id=activation_id,
+        candidate_index=candidate_index,
     )
-    _validate_revision_structure(response)
+    try:
+        _validate_revision_structure(response)
+    except AdvisorError as exc:
+        raise AdvisorError(
+            str(exc),
+            code="INVALID_RESULT",
+            authenticated=True,
+            identity_matched=True,
+            mechanically_no_tools=True,
+            invocation_started=True,
+            activation_id=route["activation_id"],
+            candidate_index=candidate_index,
+        ) from exc
     return {
         "signal": signal,
         "revision": response,
@@ -405,7 +783,12 @@ def revise_plan(
     }
 
 
-def review_plan(packet: str) -> dict[str, Any]:
+def review_plan(
+    packet: str,
+    *,
+    activation_id: str | None = None,
+    candidate_index: int = 0,
+) -> dict[str, Any]:
     values = _validate_inputs("plan review", packet=packet)
     signal, response, route, auth, used_models = _invoke_fable(
         operation="plan review",
@@ -413,6 +796,8 @@ def review_plan(packet: str) -> dict[str, Any]:
         prompt=values["packet"],
         system_prompt=ADVISOR_SYSTEM_PROMPT,
         allowed_signals={"PLAN_APPROVED", "PLAN_REVISE"},
+        activation_id=activation_id,
+        candidate_index=candidate_index,
     )
     return {
         "decision": signal,
@@ -430,9 +815,23 @@ def _configured_fable_seats() -> dict[str, dict[str, str]]:
             continue
         if not isinstance(value, dict):
             raise AdvisorError(f"The saved {seat} route is invalid.")
-        if value.get("kind") != "fable":
-            continue
-        routes[seat] = _validate_fable_route(value, seat=_validate_seat(seat))
+        candidates = [value]
+        backups = payload.get("backups", {})
+        if isinstance(backups, dict) and isinstance(backups.get(seat), list):
+            candidates.extend(backups[seat])
+        for candidate_index, candidate in enumerate(candidates):
+            if isinstance(candidate, dict) and candidate.get("kind") == "fable":
+                activation_id = candidate_activation_id(
+                    _validate_seat(seat),
+                    candidate_index,
+                    candidate,
+                )
+                routes[seat] = load_fable_route(
+                    seat=seat,
+                    candidate_index=candidate_index,
+                    activation_id=activation_id,
+                )
+                break
     if not routes:
         raise AdvisorError("Claude Fable 5 is not configured for Planner or Advisor.")
     return routes
@@ -442,7 +841,12 @@ def status() -> dict[str, Any]:
     routes = _configured_fable_seats()
     auth = check_claude_auth()
     seats = {
-        seat: {"model": route["model"], "effort": route["effort"]}
+        seat: {
+            "model": route["model"],
+            "effort": route["effort"],
+            "candidate_index": route["candidate_index"],
+            "activation_id": route["activation_id"],
+        }
         for seat, route in routes.items()
     }
     result: dict[str, Any] = {
@@ -472,7 +876,11 @@ def tool_definitions() -> list[dict[str, Any]]:
             "description": "Create one stateless plan draft with the configured Fable Planner.",
             "inputSchema": {
                 "type": "object",
-                "properties": {"packet": {**string_property, "description": "Complete planning packet."}},
+                "properties": {
+                    "packet": {**string_property, "description": "Complete planning packet."},
+                    "activation_id": {"type": "string", "maxLength": 512},
+                    "candidate_index": {"type": "integer", "minimum": 0},
+                },
                 "required": ["packet"],
                 "additionalProperties": False,
             },
@@ -489,6 +897,8 @@ def tool_definitions() -> list[dict[str, Any]]:
                     "current_plan": {**string_property, "description": "Canonical current plan with source version."},
                     "critique": {**string_property, "description": "Latest Advisor critique with stable finding IDs."},
                     "history": {**string_property, "description": "Compact cumulative findings history."},
+                    "activation_id": {"type": "string", "maxLength": 512},
+                    "candidate_index": {"type": "integer", "minimum": 0},
                 },
                 "required": ["task", "current_plan", "critique", "history"],
                 "additionalProperties": False,
@@ -501,7 +911,11 @@ def tool_definitions() -> list[dict[str, Any]]:
             "description": "Review one self-contained packet with the configured Fable Advisor.",
             "inputSchema": {
                 "type": "object",
-                "properties": {"packet": {**string_property, "description": "Complete context, plan, risks, slices, and checks."}},
+                "properties": {
+                    "packet": {**string_property, "description": "Complete context, plan, risks, slices, and checks."},
+                    "activation_id": {"type": "string", "maxLength": 512},
+                    "candidate_index": {"type": "integer", "minimum": 0},
+                },
                 "required": ["packet"],
                 "additionalProperties": False,
             },
@@ -554,28 +968,49 @@ def handle_request(request: dict[str, Any]) -> dict[str, Any] | None:
         arguments = params.get("arguments", {}) if isinstance(params, dict) else {}
         try:
             if name == "create_plan":
-                args = _tool_arguments(arguments, {"packet"})
-                result = _tool_result(create_plan(args.get("packet")))
+                args = _tool_arguments(arguments, {"packet", "activation_id", "candidate_index"})
+                result = _tool_result(
+                    create_plan(
+                        args.get("packet"),
+                        activation_id=args.get("activation_id"),
+                        candidate_index=args.get("candidate_index", 0),
+                    )
+                )
             elif name == "revise_plan":
-                args = _tool_arguments(arguments, {"task", "current_plan", "critique", "history"})
+                args = _tool_arguments(arguments, {"task", "current_plan", "critique", "history", "activation_id", "candidate_index"})
                 result = _tool_result(
                     revise_plan(
                         args.get("task"),
                         args.get("current_plan"),
                         args.get("critique"),
                         args.get("history"),
+                        activation_id=args.get("activation_id"),
+                        candidate_index=args.get("candidate_index", 0),
                     )
                 )
             elif name == "review_plan":
-                args = _tool_arguments(arguments, {"packet"})
-                result = _tool_result(review_plan(args.get("packet")))
+                args = _tool_arguments(arguments, {"packet", "activation_id", "candidate_index"})
+                result = _tool_result(
+                    review_plan(
+                        args.get("packet"),
+                        activation_id=args.get("activation_id"),
+                        candidate_index=args.get("candidate_index", 0),
+                    )
+                )
             elif name == "status":
                 _tool_arguments(arguments, set())
                 result = _tool_result(status())
             else:
                 raise AdvisorError(f"Unknown tool: {name!r}.")
         except AdvisorError as exc:
-            result = _tool_result({"available": False, "error": str(exc)}, is_error=True)
+            result = _tool_result(
+                {
+                    "available": False,
+                    "error": str(exc),
+                    "outcome": exc.outcome,
+                },
+                is_error=True,
+            )
     else:
         return {
             "jsonrpc": "2.0",

--- a/plugins/codex-orchestration/skills/codex-orchestration/scripts/routing_state.py
+++ b/plugins/codex-orchestration/skills/codex-orchestration/scripts/routing_state.py
@@ -23,7 +23,7 @@ FABLE_SERVERS = frozenset(
     }
 )
 
-_SCHEMA_POLICY_PAIRS = {1: 1, 2: 2, 3: 3}
+_SCHEMA_POLICY_PAIRS = {1: 1, 2: 2, 3: 3, 4: 4}
 _MODEL_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:+/@-]{0,199}$")
 _AGENT_RE = re.compile(r"^[a-z][a-z0-9_]{0,62}$")
 _EFFORT_RE = re.compile(r"^[a-z][a-z0-9_-]{0,31}$")
@@ -41,6 +41,87 @@ _BASE_TOP_LEVEL_KEYS = frozenset(
         "managed_feature",
     }
 )
+
+
+def route_chain(primary: Any, backups: Any) -> list[Any]:
+    """Return a route's ordered primary-plus-backup chain.
+
+    The helper intentionally returns a new list so callers cannot mutate the
+    persisted primary or backup values while rendering or evaluating a chain.
+    Validation belongs to :func:`validate_routing_state`; this helper is also
+    useful for prompt/status rendering of a candidate route.
+    """
+
+    if backups is None:
+        return [primary]
+    if type(backups) is not list:
+        raise RoutingStateError("route backups must be an array")
+    return [primary, *backups]
+
+
+def route_identity(route: Any, *, agent_identities: dict[str, tuple[str, str]] | None = None) -> tuple[str, str] | None:
+    """Return the canonical provider/model identity for a route when known.
+
+    Effort is deliberately excluded.  Custom-agent identities are resolved by
+    the native configurator from their TOML ``model``/``model_provider`` fields;
+    when no resolver is supplied the synthetic agent identity keeps duplicate
+    names from evading static checks while callers that require effective
+    independence can fail closed before setup.
+    """
+
+    if not isinstance(route, dict):
+        return None
+    kind = route.get("kind")
+    if kind == "model" and isinstance(route.get("model"), str):
+        provider = route.get("model_provider")
+        if not isinstance(provider, str) or not provider:
+            provider = "__root_provider__"
+        return provider, route["model"]
+    if kind == "agent" and isinstance(route.get("agent"), str):
+        if agent_identities and route["agent"] in agent_identities:
+            return agent_identities[route["agent"]]
+        return "__custom_agent__", route["agent"]
+    if kind == "fable":
+        return "anthropic-claude-code", FABLE_MODEL
+    return None
+
+
+def candidate_activation_id(seat: str, candidate_index: int, route: Any) -> str:
+    """Return the stable, redacted activation identity for one planning route."""
+
+    _require(seat in {"planner", "advisor"}, "candidate seat is invalid")
+    _require(
+        type(candidate_index) is int and candidate_index >= 0,
+        "candidate index is invalid",
+    )
+    identity = route_identity(route)
+    _require(identity is not None, "candidate route has no canonical identity")
+    effort = route.get("effort") if isinstance(route, dict) else None
+    _require(isinstance(effort, str) and bool(effort), "candidate effort is invalid")
+    return f"{seat}:{candidate_index}:{identity[0]}/{identity[1]}@{effort}"
+
+
+def _validate_chain(backups: Any, *, seat: str, primary: Any, schema: int) -> list[Any]:
+    _require(type(backups) is list, f"{seat} backups must be an array")
+    _require(len(backups) <= 2, f"{seat} cannot have more than two backups")
+    for route in backups:
+        _validate_route(route, seat=seat, schema=schema)
+    chain = route_chain(primary, backups)
+    identities = [route_identity(route) for route in chain]
+    known = [identity for identity in identities if identity is not None]
+    _require(len(known) == len(set(known)), f"{seat} route chain contains duplicate identities")
+    return chain
+
+
+def _validate_planning_chains(state: dict[str, Any]) -> None:
+    """Reject every possible Planner/Advisor identity overlap."""
+
+    backups = state.get("backups") or {"executor": [], "planner": [], "advisor": []}
+    planner = route_chain(state.get("planner"), backups.get("planner", [])) if state.get("planner") is not None else []
+    advisor = route_chain(state.get("advisor"), backups.get("advisor", [])) if state.get("advisor") is not None else []
+    planner_ids = {identity for route in planner if (identity := route_identity(route)) is not None}
+    advisor_ids = {identity for route in advisor if (identity := route_identity(route)) is not None}
+    _require(not planner_ids.intersection(advisor_ids), "Planner and Advisor routes are not independent")
 _BASE_MANAGED_KEYS = frozenset({"mode", "usage", "metadata", "namespace"})
 _BASE_PREVIOUS_KEYS = frozenset({"mode", "usage", "metadata", "namespace"})
 
@@ -203,7 +284,7 @@ def _validate_scalar_conversion(state: dict[str, Any], managed: dict[str, Any]) 
 
 
 def validate_routing_state(value: Any) -> dict[str, Any]:
-    """Validate and return one exact, complete persisted schema 1, 2, or 3.
+    """Validate and return one exact, complete persisted schema 1 through 4.
 
     Unknown keys and future extensions are rejected intentionally. Callers must
     perform their own secure file read and any caller-specific path/seat checks.
@@ -223,8 +304,10 @@ def validate_routing_state(value: Any) -> dict[str, Any]:
     )
 
     expected_top = set(_BASE_TOP_LEVEL_KEYS)
-    if schema == 3:
+    if schema >= 3:
         expected_top.add("planner")
+    if schema >= 4:
+        expected_top.add("backups")
     _require(set(value) == expected_top, "top-level state shape is unsupported")
     _require(value["managed_by"] == "codex-orchestration", "state owner is invalid")
     _require(
@@ -242,6 +325,39 @@ def validate_routing_state(value: Any) -> dict[str, Any]:
     if advisor is not None:
         _validate_route(advisor, seat="advisor", schema=schema)
     _validate_route_separation(planner, advisor)
+
+    if schema >= 4:
+        backups = value["backups"]
+        _require(type(backups) is dict, "backups must be an object")
+        _require(
+            set(backups) == {"executor", "planner", "advisor"},
+            "backups must contain exactly executor, planner, and advisor",
+        )
+        _validate_chain(
+            backups["executor"],
+            seat="executor",
+            primary=value["executor"],
+            schema=schema,
+        )
+        if planner is None:
+            _require(backups["planner"] == [], "Planner backups require a Planner primary")
+        else:
+            _validate_chain(
+                backups["planner"],
+                seat="planner",
+                primary=planner,
+                schema=schema,
+            )
+        if advisor is None:
+            _require(backups["advisor"] == [], "Advisor backups require an Advisor primary")
+        else:
+            _validate_chain(
+                backups["advisor"],
+                seat="advisor",
+                primary=advisor,
+                schema=schema,
+            )
+        _validate_planning_chains(value)
 
     managed = value["managed"]
     previous = value["previous"]
@@ -277,7 +393,12 @@ def validate_routing_state(value: Any) -> dict[str, Any]:
 
     fable_routes = [
         route
-        for route in (planner, advisor)
+        for route in (
+            planner,
+            advisor,
+            *(value.get("backups", {}).get("planner", []) if schema >= 4 else []),
+            *(value.get("backups", {}).get("advisor", []) if schema >= 4 else []),
+        )
         if type(route) is dict and route.get("kind") == "fable"
     ]
     _require(len(fable_routes) <= 1, "more than one Fable seat is configured")

--- a/tests/plugin_lifecycle_smoke.py
+++ b/tests/plugin_lifecycle_smoke.py
@@ -3,7 +3,7 @@
 
 A disposable bare Git marketplace is served over loopback HTTP. The real Codex
 CLI installs the affected Advisor-only 0.5.0 bundle, runs its documented
-marketplace-upgrade command after 0.5.1 is pushed to that Git remote, installs
+marketplace-upgrade command after 0.6.0 is pushed to that Git remote, installs
 the refreshed package, verifies the new cache and Planner contract, and runs
 native-policy plus custom-agent setup/status/cleanup in isolation.
 """
@@ -31,7 +31,7 @@ PLUGIN_ID = "codex-orchestration@codex-orchestration"
 MARKETPLACE_NAME = "codex-orchestration"
 OLD_RELEASE = "a1d9c546665c3253cdcaa8fe5c0c060199a6126c"
 OLD_VERSION = "0.5.0"
-NEW_VERSION = "0.5.1"
+NEW_VERSION = "0.6.0"
 COMMAND_TIMEOUT_SECONDS = 60
 
 
@@ -502,7 +502,7 @@ def main() -> int:
             installed_root = Path(new_install["installedPath"]).resolve()
             if installed_root == old_installed_root:
                 raise SmokeFailure(
-                    "0.5.1 reused the Advisor-only 0.5.0 cache directory"
+                    "0.6.0 reused the Advisor-only 0.5.0 cache directory"
                 )
             assert_equal(
                 file_tree(installed_root),

--- a/tests/test_fable_advisor_mcp.py
+++ b/tests/test_fable_advisor_mcp.py
@@ -341,6 +341,119 @@ class FableAdvisorMcpTests(unittest.TestCase):
         with self.assertRaisesRegex(FABLE.AdvisorError, "state is invalid"):
             FABLE.load_fable_route(self.home)
 
+    def test_backup_candidate_requires_exact_activation_identity(self) -> None:
+        self.write_state(
+            schema=3,
+            planner={"kind": "model", "model": "gpt-5.6-sol", "effort": "high"},
+        )
+        state_path = self.home / FABLE.STATE_FILENAME
+        payload = json.loads(state_path.read_text(encoding="utf-8"))
+        payload["schema"] = 4
+        payload["policy_version"] = 4
+        payload["backups"] = {
+            "executor": [],
+            "planner": [
+                {
+                    "kind": "fable",
+                    "model": "claude-fable-5",
+                    "effort": "xhigh",
+                    "server": "fable-advisor-python3",
+                }
+            ],
+            "advisor": [],
+        }
+        payload["managed"]["mcp"] = {"fable-advisor-python3": True}
+        payload["previous"]["mcp"] = {
+            "fable-advisor-python3": {"known": True, "present": False}
+        }
+        state_path.write_text(json.dumps(payload), encoding="utf-8")
+        route = payload["backups"]["planner"][0]
+        activation = FABLE.candidate_activation_id("planner", 1, route)
+        with self.assertRaisesRegex(FABLE.AdvisorError, "activation identity"):
+            FABLE.load_fable_route(
+                self.home,
+                seat="planner",
+                candidate_index=1,
+            )
+        candidate = FABLE.load_fable_route(
+            self.home,
+            seat="planner",
+            candidate_index=1,
+            activation_id=activation,
+        )
+        self.assertEqual(candidate["effort"], "xhigh")
+        self.assertEqual(candidate["activation_id"], activation)
+        self.assertEqual(
+            FABLE.load_fable_route(
+                self.home,
+                seat="planner",
+                candidate_index=1,
+                activation_id=activation,
+            )["activation_id"],
+            activation,
+        )
+        with self.assertRaisesRegex(FABLE.AdvisorError, "activation identity"):
+            FABLE.load_fable_route(
+                self.home,
+                seat="planner",
+                candidate_index=1,
+                activation_id="planner:1:forged",
+            )
+        with (
+            mock.patch.dict(os.environ, {"CODEX_HOME": str(self.home)}),
+            mock.patch.object(
+                FABLE,
+                "check_claude_auth",
+                return_value={
+                    "auth_method": "claude.ai",
+                    "api_provider": "firstParty",
+                },
+            ),
+        ):
+            status = FABLE.status()
+        self.assertEqual(status["seats"]["planner"]["effort"], "xhigh")
+        self.assertEqual(status["seats"]["planner"]["candidate_index"], "1")
+
+    def test_tool_failure_returns_exhaustive_redacted_outcome_provenance(self) -> None:
+        expected_activation = FABLE.candidate_activation_id(
+            "advisor",
+            0,
+            self.route("high"),
+        )
+        timeout = subprocess.TimeoutExpired(["claude"], 600, output="SECRET", stderr="SECRET")
+        with (
+            mock.patch.dict(os.environ, {"CODEX_HOME": str(self.home)}),
+            mock.patch.object(FABLE, "resolve_claude", return_value=Path("/fake/claude")),
+            mock.patch.object(
+                FABLE.subprocess,
+                "run",
+                side_effect=[self.auth_result(), timeout],
+            ),
+        ):
+            response = FABLE.handle_request(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 9,
+                    "method": "tools/call",
+                    "params": {
+                        "name": "review_plan",
+                        "arguments": {
+                            "packet": "review packet",
+                            "activation_id": expected_activation,
+                            "candidate_index": 0,
+                        },
+                    },
+                }
+            )
+        self.assertTrue(response["result"]["isError"])
+        payload = json.loads(response["result"]["content"][0]["text"])
+        self.assertNotIn("SECRET", json.dumps(payload))
+        self.assertEqual(payload["outcome"]["code"], "TRANSPORT_FAILURE")
+        self.assertEqual(payload["outcome"]["state"], "ELIGIBLE_STARTED")
+        self.assertEqual(payload["outcome"]["activation_id"], expected_activation)
+        self.assertEqual(payload["outcome"]["candidate_index"], 0)
+
+
     def test_authorization_state_tampering_fails_before_any_subprocess(self) -> None:
         mutations = {
             "policy version": lambda payload: payload.update(policy_version=2),

--- a/tests/test_native_routing.py
+++ b/tests/test_native_routing.py
@@ -410,6 +410,26 @@ class NativeRoutingTests(unittest.TestCase):
         self.assertNotIn("tool_namespace", mode + usage)
         self.assertNotIn("enabled = true", mode + usage)
 
+    def test_direct_model_backup_retains_same_provider_guard(self) -> None:
+        executor = {"kind": "agent", "agent": "primary_worker"}
+        direct_backup = {
+            "kind": "model",
+            "model": "gpt-5.6-luna",
+            "effort": "high",
+        }
+        _, usage = NATIVE.build_policy(
+            executor,
+            None,
+            None,
+            executor_backups=[direct_backup],
+        )
+        self.assertIn("Direct model overrides retain the root provider", usage)
+        self.assertIn("verify that the target model is on the same provider", usage)
+        self.assertNotIn(
+            "Configured custom agents and MCP seats own their provider routes",
+            usage,
+        )
+
     def test_policy_root_fallback_planner_without_advisor_and_fable_hints(self) -> None:
         executor = {"kind": "model", "model": "gpt-5.6-luna", "effort": "high"}
         advisor = {"kind": "model", "model": "gpt-5.6-terra", "effort": "high"}

--- a/tests/test_native_routing.py
+++ b/tests/test_native_routing.py
@@ -343,6 +343,36 @@ class NativeRoutingTests(unittest.TestCase):
 
         self.assertIn("root task model, you are the orchestrator", mode)
         self.assertIn("Codex still decides whether a plan or subagent helps", mode)
+        self.assertIn("routing_envelope_version=1", mode)
+        self.assertIn("started_child_ids", mode)
+        fable_backup = {
+            "kind": "fable",
+            "model": NATIVE.FABLE_MODEL,
+            "effort": "high",
+            "server": "fable-advisor-python3",
+        }
+        _, backup_usage = NATIVE.build_policy(
+            executor,
+            planner,
+            advisor,
+            planner_backups=[fable_backup],
+        )
+        self.assertIn(
+            "planner:1:anthropic-claude-code/claude-fable-5@high",
+            backup_usage,
+        )
+        _, executor_backup_usage = NATIVE.build_policy(
+            executor,
+            planner,
+            advisor,
+            executor_backups=[
+                {"kind": "model", "model": "gpt-5.6-terra", "effort": "high"}
+            ],
+        )
+        self.assertIn(
+            "executor candidate 1 => model = \"gpt-5.6-terra\", reasoning_effort = \"high\"",
+            executor_backup_usage,
+        )
         self.assertIn("never spawn descendants", mode)
         self.assertIn("Explicit user instructions win", mode)
         self.assertIn("Persistent and task-local Planner and Advisor routes", mode)
@@ -531,15 +561,75 @@ class NativeRoutingTests(unittest.TestCase):
         state = json.loads(
             (self.home / NATIVE.STATE_FILENAME).read_text(encoding="utf-8")
         )
-        self.assertEqual(state["schema"], 3)
-        self.assertEqual(state["policy_version"], 3)
+        self.assertEqual(state["schema"], 4)
+        self.assertEqual(state["policy_version"], 4)
+        self.assertEqual(state["backups"], {"executor": [], "planner": [], "advisor": []})
         self.assertEqual(state["planner"]["effort"], "xhigh")
 
         status = self.run_script("--status", "--require-effective")
         self.assertIn("Planner: gpt-5.6-sol@xhigh", status.stdout)
         self.assertEqual(status.returncode, 0)
 
-    def test_legacy_state_schemas_upgrade_to_three_without_losing_restore(self) -> None:
+    def test_ordered_backup_setup_persists_and_renders_each_chain(self) -> None:
+        setup = self.run_script(
+            "--executor-model",
+            "gpt-5.6-luna",
+            "--executor-backup",
+            "model:gpt-5.6-sol@high",
+            "--planner-model",
+            "gpt-5.6-sol",
+            "--planner-backup",
+            "model:gpt-5.6-terra@high",
+            "--advisor-model",
+            "gpt-5.6-luna",
+            "--apply",
+        )
+        self.assertIn("Executor: gpt-5.6-luna@high -> gpt-5.6-sol@high", setup.stdout)
+        state = json.loads((self.home / NATIVE.STATE_FILENAME).read_text())
+        self.assertEqual(state["schema"], 4)
+        self.assertEqual(
+            state["backups"]["executor"],
+            [{"kind": "model", "model": "gpt-5.6-sol", "effort": "high"}],
+        )
+        status = self.run_script("--status")
+        self.assertIn("Executor candidate 1: gpt-5.6-sol@high — READY", status.stdout)
+
+    def test_status_marks_verified_custom_agent_backup_ready(self) -> None:
+        self.write_personal_agent("recovery_worker")
+        self.run_script(
+            "--executor-model",
+            "gpt-5.6-sol",
+            "--executor-backup",
+            "agent:recovery_worker",
+            "--apply",
+        )
+        status = self.run_script("--status", "--require-effective")
+        self.assertEqual(status.returncode, 0)
+        self.assertIn(
+            "Executor candidate 1: custom agent recovery_worker — READY",
+            status.stdout,
+        )
+
+    def test_backup_specs_are_rejected_for_status_disable_and_caps(self) -> None:
+        for action in (("--status",), ("--disable",)):
+            result = self.run_script(*action, "--executor-backup", "model:gpt-5.6-sol@high", check=False)
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("does not accept seat settings", result.stderr)
+        result = self.run_script(
+            "--executor-model",
+            "gpt-5.6-luna",
+            "--executor-backup",
+            "model:gpt-5.6-sol@high",
+            "--executor-backup",
+            "model:gpt-5.6-terra@high",
+            "--executor-backup",
+            "model:gpt-5.6-luna@low",
+            check=False,
+        )
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("more than two backups", result.stderr)
+
+    def test_legacy_state_schemas_upgrade_to_four_without_losing_restore(self) -> None:
         for legacy_schema in (1, 2):
             with self.subTest(schema=legacy_schema):
                 setup_arguments = ["--executor-model", "gpt-5.6-luna"]
@@ -553,6 +643,7 @@ class NativeRoutingTests(unittest.TestCase):
                 legacy["schema"] = legacy_schema
                 legacy["policy_version"] = legacy_schema
                 legacy.pop("planner", None)
+                legacy.pop("backups", None)
                 legacy["managed"]["mode"] = (
                     f"{NATIVE.MANAGED_MARKER}\nlegacy schema {legacy_schema} mode"
                 )
@@ -577,8 +668,9 @@ class NativeRoutingTests(unittest.TestCase):
                     "--apply",
                 )
                 upgraded = json.loads(state_path.read_text(encoding="utf-8"))
-                self.assertEqual(upgraded["schema"], 3)
-                self.assertEqual(upgraded["policy_version"], 3)
+                self.assertEqual(upgraded["schema"], 4)
+                self.assertEqual(upgraded["policy_version"], 4)
+                self.assertEqual(upgraded["backups"], {"executor": [], "planner": [], "advisor": []})
                 self.assertEqual(upgraded["previous"], original_previous)
                 self.assertEqual(upgraded["planner"]["model"], "gpt-5.6-sol")
                 if legacy_schema == 2:

--- a/tests/test_ordered_backup_routes.py
+++ b/tests/test_ordered_backup_routes.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "plugins/codex-orchestration/skills/codex-orchestration/scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import configure_native_routing as native  # noqa: E402
+import fable_advisor_mcp as fable  # noqa: E402
+
+
+class BackupSpecTests(unittest.TestCase):
+    def test_parse_backup_specs(self) -> None:
+        self.assertEqual(
+            native.parse_backup_spec("model:gpt-5.6-sol@xhigh", "executor"),
+            {"kind": "model", "model": "gpt-5.6-sol", "effort": "xhigh"},
+        )
+        self.assertEqual(
+            native.parse_backup_spec("agent:secondary_worker", "planner"),
+            {"kind": "agent", "agent": "secondary_worker"},
+        )
+        self.assertEqual(
+            native.parse_backup_spec("fable:high", "advisor"),
+            {"kind": "fable", "model": native.FABLE_MODEL, "effort": "high"},
+        )
+
+    def test_parse_backup_specs_reject_bad_grammar_and_fable_executor(self) -> None:
+        for seat, value in (
+            ("executor", "fable:high"),
+            ("executor", "model:gpt@high@extra"),
+            ("planner", "model:@high"),
+            ("planner", "agent:Bad-Name"),
+            ("planner", "fable:bogus"),
+            ("planner", "agent:foo "),
+        ):
+            with self.subTest(seat=seat, value=value), self.assertRaises(native.ConfigurationError):
+                native.parse_backup_spec(value, seat)
+
+    def test_validate_backup_cap_and_duplicate_identity(self) -> None:
+        primary = {"kind": "model", "model": "gpt-5.6-sol", "effort": "high"}
+        backups = [
+            {"kind": "model", "model": "backup-one", "effort": "high"},
+            {"kind": "model", "model": "backup-two", "effort": "high"},
+        ]
+        native.validate_route_chains(primary, [], primary, backups, None, [], None)
+        with self.assertRaises(native.ConfigurationError):
+            native.validate_route_chains(primary, [*backups, {"kind": "model", "model": "third", "effort": "high"}], None, [], None, [], None)
+        with self.assertRaises(native.ConfigurationError):
+            native.validate_route_chains(
+                primary,
+                [{"kind": "model", "model": "gpt-5.6-sol", "effort": "low"}],
+                None,
+                [],
+                None,
+                [],
+            )
+
+    def test_custom_agent_identity_resolution_catches_alias_overlap(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            home = Path(raw)
+            agents = home / "agents"
+            agents.mkdir()
+            for name in ("planner_alias", "advisor_alias"):
+                (agents / f"{name}.toml").write_text(
+                    f'name = "{name}"\ndescription = "alias"\nmodel = "gpt-5.6-sol"\nmodel_provider = "openai"\ndeveloper_instructions = "work"\n',
+                    encoding="utf-8",
+                )
+            identities = native.agent_route_identities(
+                home,
+                [
+                    {"kind": "agent", "agent": "planner_alias"},
+                    {"kind": "agent", "agent": "advisor_alias"},
+                ],
+            )
+            with self.assertRaises(native.ConfigurationError):
+                native.validate_route_chains(
+                    {"kind": "model", "model": "executor", "effort": "high"},
+                    [],
+                    {"kind": "agent", "agent": "planner_alias"},
+                    [],
+                    {"kind": "agent", "agent": "advisor_alias"},
+                    [],
+                    identities,
+                )
+
+    def test_unknown_root_provider_overlaps_matching_custom_agent_model(self) -> None:
+        with self.assertRaises(native.ConfigurationError):
+            native.validate_route_chains(
+                {"kind": "model", "model": "executor", "effort": "high"},
+                [],
+                {"kind": "model", "model": "gpt-5.6-sol", "effort": "high"},
+                [],
+                {"kind": "agent", "agent": "advisor_alias"},
+                [],
+                {"advisor_alias": ("openai", "gpt-5.6-sol")},
+            )
+
+
+class FableCandidateTests(unittest.TestCase):
+    def test_candidate_activation_id_and_exhaustive_classification(self) -> None:
+        route = {"kind": "fable", "model": "claude-fable-5", "effort": "high", "server": "fable-advisor-python3"}
+        activation = fable.candidate_activation_id("planner", 1, route)
+        self.assertEqual(activation, "planner:1:anthropic-claude-code/claude-fable-5@high")
+        outcome = fable.classify_fable_outcome(
+            code="TRANSPORT_FAILURE",
+            authenticated=True,
+            identity_matched=True,
+            mechanically_no_tools=True,
+            invocation_started=True,
+            deliverable_valid=False,
+        )
+        self.assertEqual(outcome["eligible"], True)
+        model_unavailable = fable.classify_fable_outcome(
+            code="MODEL_UNAVAILABLE",
+            authenticated=True,
+            identity_matched=True,
+            mechanically_no_tools=True,
+            invocation_started=False,
+            deliverable_valid=False,
+        )
+        self.assertEqual(model_unavailable["state"], "ELIGIBLE_PRESTART")
+        impossible = fable.classify_fable_outcome(
+            code="DELIVERABLE_VALID",
+            authenticated=True,
+            identity_matched=True,
+            mechanically_no_tools=True,
+            invocation_started=True,
+            deliverable_valid=False,
+        )
+        self.assertEqual(impossible["state"], "STATE_UNKNOWN")
+        frozen = fable.classify_fable_outcome(
+            code="UNKNOWN",
+            authenticated=False,
+            identity_matched=False,
+            mechanically_no_tools=False,
+            invocation_started=False,
+            deliverable_valid=False,
+        )
+        self.assertEqual(frozen["state"], "STATE_UNKNOWN")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -24,7 +24,7 @@ class PackagingTests(unittest.TestCase):
 
         self.assertEqual(manifest["name"], "codex-orchestration")
         self.assertEqual(manifest["skills"], "./skills/")
-        self.assertEqual(manifest["version"], "0.5.1")
+        self.assertEqual(manifest["version"], "0.6.0")
         self.assertEqual(manifest["mcpServers"], "./.mcp.json")
         self.assertRegex(
             manifest["version"],
@@ -45,7 +45,7 @@ class PackagingTests(unittest.TestCase):
         self.assertTrue(custom.is_file())
         self.assertTrue(routing_state.is_file())
         self.assertIn("config/batchWrite", native.read_text(encoding="utf-8"))
-        self.assertIn('"version": "0.5.1"', native.read_text(encoding="utf-8"))
+        self.assertIn('"version": "0.6.0"', native.read_text(encoding="utf-8"))
         self.assertIn("validate_routing_state", routing_state.read_text(encoding="utf-8"))
         self.assertIn("Standalone custom agent", custom.read_text(encoding="utf-8"))
 
@@ -110,7 +110,7 @@ class PackagingTests(unittest.TestCase):
         self.assertIn("@openai/codex@0.144.1", workflow)
         smoke_text = smoke.read_text(encoding="utf-8")
         self.assertIn('OLD_VERSION = "0.5.0"', smoke_text)
-        self.assertIn('NEW_VERSION = "0.5.1"', smoke_text)
+        self.assertIn('NEW_VERSION = "0.6.0"', smoke_text)
         self.assertIn("old Advisor-only cache unexpectedly supports Planner", smoke_text)
         self.assertIn("Upgraded installed skill is missing Planner contract", smoke_text)
         self.assertIn("reused the Advisor-only 0.5.0 cache directory", smoke_text)
@@ -214,11 +214,15 @@ class PackagingTests(unittest.TestCase):
         readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
 
         self.assertIn("/codex-orchestration status", readme)
-        self.assertIn("Version **0.5.1 or newer**", readme)
+        self.assertIn("Version **0.6.0 or newer**", readme)
+        self.assertIn("Before downgrading to any version older than 0.6.0", readme)
         self.assertIn("`marketplaceSource.sourceType` is `local`", readme)
         self.assertIn("`disable` restores the routing values", readme)
         self.assertIn("does not delete user-owned custom roles", readme)
         self.assertIn("Review and remove any user-owned custom roles separately", readme)
+
+        release = (REPO_ROOT / "RELEASE.md").read_text(encoding="utf-8")
+        self.assertIn("Before downgrading to any release older than 0.6.0", release)
 
 
 if __name__ == "__main__":

--- a/tests/test_release_check.py
+++ b/tests/test_release_check.py
@@ -15,7 +15,7 @@ SPEC.loader.exec_module(RELEASE)
 
 class ReleaseCheckTests(unittest.TestCase):
     def test_checkout_release_metadata_is_consistent(self) -> None:
-        self.assertEqual(RELEASE.run_check(REPO_ROOT, require_tag=False), "0.5.1")
+        self.assertEqual(RELEASE.run_check(REPO_ROOT, require_tag=False), "0.6.0")
 
     def test_unreleased_checkout_is_not_tag_ready(self) -> None:
         with self.assertRaisesRegex(RELEASE.ReleaseCheckError, "not tagged"):

--- a/tests/test_routing_state.py
+++ b/tests/test_routing_state.py
@@ -78,6 +78,60 @@ def genuine_state(schema: int) -> dict[str, object]:
 
 
 class RoutingStateTests(unittest.TestCase):
+    def test_schema_four_requires_ordered_backup_chains(self) -> None:
+        state = genuine_state(3)
+        state["schema"] = 4
+        state["policy_version"] = 4
+        state["backups"] = {"executor": [], "planner": [], "advisor": []}
+        STATE.validate_routing_state(state)
+
+        state["backups"]["executor"] = [
+            {"kind": "model", "model": "gpt-5.6-sol", "effort": "high"}
+        ]
+        STATE.validate_routing_state(state)
+
+        state["backups"]["executor"].append(
+            {"kind": "agent", "agent": "backup_executor"}
+        )
+        STATE.validate_routing_state(state)
+
+        state["backups"]["executor"].append(
+            {"kind": "model", "model": "third", "effort": "high"}
+        )
+        with self.assertRaises(STATE.RoutingStateError):
+            STATE.validate_routing_state(state)
+
+    def test_schema_four_rejects_missing_or_malformed_backup_surfaces(self) -> None:
+        baseline = genuine_state(3)
+        baseline["schema"] = 4
+        baseline["policy_version"] = 4
+        baseline["backups"] = {"executor": [], "planner": [], "advisor": []}
+        mutations = (
+            lambda state: state.pop("backups"),
+            lambda state: state["backups"].pop("advisor"),
+            lambda state: state["backups"].update(future=[]),
+            lambda state: state["backups"].update(executor={}),
+            lambda state: state["backups"].update(planner=[None]),
+            lambda state: state["backups"].update(advisor=[fable_route()]),
+            lambda state: state["backups"].update(
+                executor=[
+                    {"kind": "model", "model": "same", "effort": "high"},
+                    {"kind": "model", "model": "same", "effort": "low"},
+                ]
+            ),
+        )
+        for mutate in mutations:
+            with self.subTest(mutate=mutate):
+                state = deepcopy(baseline)
+                mutate(state)
+                with self.assertRaises(STATE.RoutingStateError):
+                    STATE.validate_routing_state(state)
+
+    def test_route_chain_helper_preserves_primary_then_backups(self) -> None:
+        primary = {"kind": "model", "model": "primary", "effort": "high"}
+        backup = {"kind": "agent", "agent": "backup"}
+        self.assertEqual(STATE.route_chain(primary, [backup]), [primary, backup])
+
     def test_genuine_schemas_one_two_and_three_are_accepted(self) -> None:
         for schema in (1, 2, 3):
             with self.subTest(schema=schema):


### PR DESCRIPTION
## Summary

- add up to two ordered backup routes for Executor, Planner, and Advisor seats
- introduce strict state schema/policy 4 while preserving schemas 1-3 for status, disable, and migration on the next setup
- add exact backup CLI grammar, all-candidate identity separation, provider guards, status rendering, and reversible lifecycle handling
- authorize Fable candidates by exact ordinal and activation ID, with structured redacted success/failure outcome provenance

## Safety model

Backups are policy-directed, not an engine-level automatic scheduler. Executor failover is pre-start only; started or ambiguous creation freezes the chain. Post-start planning failover is limited to the mechanically no-tools Fable bridge. Unknown identity, state, authority, or task-envelope data fails closed. Planner and Advisor chains must remain disjoint across every effective route.

## Verification

- `python3 -m compileall -q plugins tests scripts`
- `python3 -m ruff check plugins tests scripts` with pinned ruff 0.15.21
- 204 unit tests passed
- lifecycle smoke passed for install 0.5.0, upgrade to 0.6.0, setup/status/cleanup
- release metadata and `git diff --check` passed
- independent GPT-5.6 Sol High exact-SHA review: REVIEW_APPROVED after one provider-guard finding was fixed and regression-tested

## Compatibility note

Version 0.6.0 writes schema-4 state. Users must run `disable` before downgrading to an older release. The installed plugin and live user routing config were not modified while developing this PR.