### PR TITLE
Fix Kimi K3 Designer seat routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 # Changelog
 
-## 0.7.0 — Unreleased
+## 0.7.1 — Unreleased
+
+- Recognize a bare `Designer: Kimi K3` seat assignment as the audited task-local
+  External Model role `designer` instead of incorrectly reporting the route as
+  unexposed. The root now dispatches the existing status, preparation,
+  authentication, qualification, connection, restart, readiness, and resolution
+  states explicitly.
+- Preserve the no-secret and no-surprise-spend contract: the shorthand can authorize
+  clean provider preparation and role creation, but never credential entry, Gate 0
+  billing, probe retries, replacement, or deletion. Preparation may add the exact
+  audited OpenRouter provider entry when absent; it never modifies, replaces, or
+  removes existing provider entries or changes the root model, native GPT routes,
+  model picker, chats, or sessions.
+
+## 0.7.0 — 2026-07-18
 
 - Add `/codex-orchestration --update`, a canonical-source-checked orchestration of
   Codex's native plugin upgrade/install commands. It refuses disabled, local,

--- a/README.md
+++ b/README.md
@@ -182,8 +182,17 @@ Create a Codex Goal normally, then tell Codex to use the saved workflow until th
 /codex-orchestration repair
 /codex-orchestration --update
 /codex-orchestration setup planner: Claude Fable 5 High, advisor: GPT-5.6 Sol High, designer: GPT-5.6 Terra High, executor: GPT-5.6 Luna Extra High
+/codex-orchestration Planner: Claude Fable 5 High, Designer: Kimi K3
 /codex-orchestration disable
 ```
+
+`Designer: Kimi K3` selects the audited task-local External Model role without
+adding Kimi to the Desktop picker or replacing any GPT route. Kimi K3 supports only
+`max` reasoning (`auto` maps to `max`). If the exact role is already ready, the
+plugin resolves and uses it. Otherwise it walks the secure status, preparation,
+hidden authentication, separately authorized Gate 0, connection, restart, and
+readiness states and tells you the exact next action instead of calling the route
+unavailable. The seat label never authorizes credential entry or a paid probe.
 
 `disable` restores the routing values that existed before setup. It does not delete user-owned custom roles.
 
@@ -238,7 +247,9 @@ codex plugin add codex-orchestration@codex-orchestration
 ```
 
 Version **0.6.0 or newer** is required for External Model roles; version **0.7.0
-or newer** adds `--update`, routing repair, and Designer. Confirm with
+or newer** adds `--update`, routing repair, and Designer; version **0.7.1 or newer**
+lets the natural `Designer: Kimi K3` label enter the External Model lifecycle.
+Confirm with
 `codex plugin list --json`, then restart Codex Desktop and start a new task.
 
 If the version stays old or `marketplaceSource.sourceType` is `local`, Codex is pointed at a local checkout rather than the GitHub marketplace. Run `/codex-orchestration disable` first if a saved policy is active, then remove the plugin and that marketplace registration, add `Cjbuilds/Codex-Orchestration` again, and reinstall. This does not delete the local source checkout.

--- a/plugins/codex-orchestration/.codex-plugin/plugin.json
+++ b/plugins/codex-orchestration/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-orchestration",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Give Codex and audited external models safe, provider-pinned roles.",
   "author": {
     "name": "CJ Zafir",
@@ -38,7 +38,7 @@
     "defaultPrompt": [
       "/codex-orchestration setup designer: GPT-5.6 Sol High, executor: GPT-5.6 Luna Extra High",
       "/codex-orchestration --update",
-      "/codex-orchestration create project role: researcher"
+      "/codex-orchestration Planner: Claude Fable 5 High, Designer: Kimi K3"
     ]
   }
 }

--- a/plugins/codex-orchestration/skills/codex-orchestration/SKILL.md
+++ b/plugins/codex-orchestration/skills/codex-orchestration/SKILL.md
@@ -18,6 +18,7 @@ Support these simple forms:
 /codex-orchestration setup executor: GPT-5.6 Luna Extra High, advisor: Claude Fable 5 High
 /codex-orchestration setup planner: Claude Fable 5 High, advisor: GPT-5.6 Sol High, executor: GPT-5.6 Luna Extra High
 /codex-orchestration setup designer: GPT-5.6 Sol High, executor: GPT-5.6 Luna Extra High
+/codex-orchestration Planner: Claude Fable 5 High, Designer: Kimi K3
 /codex-orchestration --update
 /codex-orchestration create project role: researcher
 /codex-orchestration create personal roles: researcher, writer, reviewer
@@ -32,7 +33,7 @@ Support these simple forms:
 
 `--update` securely refreshes this plugin from its canonical Git marketplace. `setup` installs or updates the personal one-time routing policy. `create project role` or `create personal role` creates native Codex custom-agent files. `status` inspects built-in routing. `repair` restores only saved managed hint bytes after narrow drift validation. `disable` restores pre-setup values.
 
-`remove custom roles` cleans only verified plugin-managed advisor/executor files. Arbitrary native roles are user-owned. An invocation with seats and work but no control verb is a current-task override and must not rewrite config.
+`remove custom roles` cleans only verified plugin-managed advisor/executor files. Arbitrary native roles are user-owned. An invocation with native seats and work but no control verb is a current-task override and must not rewrite config. Explicit External Model seat labels are the exception: they may perform only the clean preparation, connection, and readiness writes authorized in the External Model lifecycle below.
 
 Explicit seat labels are authoritative. `planner:` configures only Planner, `advisor:` configures only Advisor, `designer:` configures only Designer, and `executor:` configures only Executor. Never infer or change a seat from a model's historical use, default role, cached description, or provider; in particular, never reinterpret a supplied `planner:` model as an Advisor or a supplied `designer:` model as an Executor. Saved defaults may fill only omitted seats and never override a seat supplied in the current invocation.
 
@@ -54,7 +55,7 @@ Because explicit skills may not reload from a bare reply, include a ready-to-cop
 
 For a task-local request, append `— <original task>`. Keep every supplied modifier. Do not lose the user's task while collecting a model choice.
 
-Before applying setup or starting task-local work, report the normalized mapping as `Planner`, `Advisor`, `Designer`, and `Executor` in that order. Compare it with the user's explicit labels. If an exact seat cannot run, report that seat as unavailable and stop under the required-route rules; never move its model to another seat. When the user omits Designer, report `Designer: none`; when the user supplies Planner and Executor but omits Advisor, report `Advisor: none`.
+Before applying setup or starting task-local work, report the normalized mapping as `Planner`, `Advisor`, `Designer`, and `Executor` in that order. Compare it with the user's explicit labels. If an exact native seat cannot run, report that seat as unavailable and stop under the required-route rules; never move its model to another seat. For an External Model seat still crossing a valid lifecycle boundary, report its exact lifecycle state and next action, not unavailable. When the user omits Designer, report `Designer: none`; when the user supplies Planner and Executor but omits Advisor, report `Advisor: none`.
 
 If an old prompt contains `orchestrator:`, explain that the current task model already owns that role. Ignore that seat instead of switching or persisting it.
 
@@ -132,6 +133,54 @@ Only bundled provider manifests are eligible. Do not turn an arbitrary URL, mode
 name, shell command, project file, or subscription CLI into a provider. Resolve the
 exact model and supported efforts from the manifest and its cited evidence. Reject
 all unsupported effort values; never clamp, alias, or silently fall back.
+
+### External models supplied as seat labels
+
+Treat a supplied built-in seat whose model unambiguously matches a bundled external
+model as an explicit External Model seat assignment. In particular, normalize
+`Designer: Kimi K3`, case-insensitively, to role `designer`, provider `openrouter`,
+model `moonshotai/kimi-k3`, and effort `max`; an omitted or `auto` effort also means
+`max`. Reject every other explicit Kimi K3 effort. This is a manifest-backed display
+name mapping, not permission to guess model IDs or accept fuzzy, dated, or `latest`
+aliases.
+
+An external Designer is not a native direct-model Designer: never pass it to `--designer-model`,
+the root-provider model catalog, or the persistent routing schema; always inspect `external status` first and compare the requested role, provider,
+model, and effort with the strict registry result. Then follow exactly one state:
+
+- If the exact role is `READY`, run read-only `resolve` and delegate only to the
+  returned agent name.
+- If the exact role is `RESTART_REQUIRED`, tell the user to fully quit and reopen
+  Codex and start a new task. In that new task, preview and apply `ready`; run `ready` and then `resolve`, and delegate only after both succeed.
+- If the provider is exact, authenticated, and `CAPABILITY_VERIFIED` or `READY`, but
+  role `designer` is absent, the explicit seat assignment authorizes clean role
+  creation: preview and apply `connect` with the bounded purpose "Produce a design
+  handoff for the root; do not edit implementation code, direct other roles, or
+  spawn descendants." Report the resulting `RESTART_REQUIRED` boundary. It does
+  not authorize replacing or disconnecting an existing role.
+- If the provider is absent, treat the explicit seat assignment like a literal
+  configure request: preview and apply only clean provider preparation, then follow
+  the existing hidden authentication flow. Preparation may add the exact audited
+  OpenRouter provider entry when absent, but never modifies or removes a pre-existing provider entry. If authentication is missing, print the required no-paste message
+  and enrollment command, then stop.
+- If the exact tuple is not qualified, request separate explicit billing approval
+  immediately before Gate 0. A seat assignment never authorizes Gate 0 billing,
+  credential entry, retries after a failed probe, or any other spend.
+- If the role exists with another provider/model, any file or helper drifts, a
+  project agent shadows it, or status is ambiguous, stop with the exact collision or
+  integrity blocker. Never overwrite, repair, disconnect, or substitute a route.
+
+At every non-ready state, describe the next exact action; do not report the requested external seat as unavailable merely because its personal agent has not been created
+or loaded yet; preserve the original task and every supplied seat while crossing an
+authentication, qualification, or restart boundary. A seat-only invocation is a
+role-provisioning request only when it contains only External Model seat labels; that
+form does not require Executor. If the invocation also supplies any native seat or
+contains task work, preserve every supplied seat and that work, then collect a missing Executor using the existing question and ready-to-copy invocation after reporting
+or progressing the external role state.
+
+External seat assignments remain task-local. The returned custom-agent name must not be persisted in native routing state because a project agent could shadow that
+unqualified name in a later workspace. This rule does not change native same-provider
+Designer setup or Claude Fable 5 Planner/Advisor routing.
 
 Native setup is preview-first and uses
 `scripts/external_configurator.py` from this skill's real installed directory. Its

--- a/plugins/codex-orchestration/skills/codex-orchestration/agents/openai.yaml
+++ b/plugins/codex-orchestration/skills/codex-orchestration/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "Codex Orchestration"
   short_description: "Plan, review, design, and build with multiple models"
-  default_prompt: "Use $codex-orchestration to configure Planner, Advisor, Designer, and Executor roles."
+  default_prompt: "Use $codex-orchestration to configure Planner, Advisor, Designer, Executor, and audited External Model roles."
 
 policy:
   allow_implicit_invocation: false

--- a/plugins/codex-orchestration/skills/codex-orchestration/references/external-models.md
+++ b/plugins/codex-orchestration/skills/codex-orchestration/references/external-models.md
@@ -33,6 +33,38 @@ UNCONFIGURED -> AUTH_REQUIRED -> AUTH_READY -> CAPABILITY_VERIFIED
 No state may skip an unlisted transition. Provider self-report or model-authored text
 never establishes `USED_CONFIRMED`.
 
+## Seat-label entry
+
+A built-in seat label may select a bundled External Model without putting that model
+in the Desktop picker. The currently bundled shorthand is case-insensitive
+`Designer: Kimi K3`, which means task-local role `designer`, provider `openrouter`,
+exact model `moonshotai/kimi-k3`, and effort `max`. Omitted effort or `auto` resolves
+to `max`; every other explicit effort is rejected. Similar labels are accepted only
+after a reviewed plugin release adds an unambiguous bundled mapping.
+
+Root must inspect external status before acting. Dispatch by exact state:
+
+| Exact state | Action |
+| --- | --- |
+| Provider absent | Preview and apply clean preparation, then stop for user-owned hidden authentication. |
+| Authentication missing | Print the no-paste enrollment guidance and stop. |
+| Tuple unqualified | Request separate billing approval immediately before one Gate 0; never infer approval from the seat label. |
+| Qualified provider, role absent | Preview and apply `connect` for role `designer` with the bounded Designer purpose. |
+| `RESTART_REQUIRED` | Require a full Desktop restart and new task; do not delegate. |
+| Exact role `READY` | Run `resolve`, then delegate only to its returned loaded agent name. |
+| Role mismatch, drift, shadow, or ambiguity | Stop with the exact blocker; never overwrite, disconnect, repair, or substitute. |
+
+The explicit seat label authorizes clean preparation and clean role creation, just as
+the equivalent literal configure request does. It never authorizes credential entry,
+Gate 0 billing, a failed-probe retry, replacement, or deletion. External seat routes
+remain task-local and are never stored in native routing state. Preserve any supplied
+seats and original task across authentication, qualification, or restart boundaries.
+Adding a role stages a new restart boundary and temporarily blocks other External
+Model roles on that provider until `ready` succeeds or the staged role is disconnected;
+native GPT routes, the root model, chats, and sessions remain untouched. Clean
+preparation may add the exact audited OpenRouter provider entry when absent, but it
+never modifies, replaces, or removes a pre-existing provider entry.
+
 ## Preview-first setup
 
 Run the packaged script from the installed skill directory with Python 3.11+ and the

--- a/plugins/codex-orchestration/skills/codex-orchestration/scripts/configure_native_routing.py
+++ b/plugins/codex-orchestration/skills/codex-orchestration/scripts/configure_native_routing.py
@@ -405,7 +405,7 @@ class AppServer:
                     "clientInfo": {
                         "name": "codex_orchestration_installer",
                         "title": "Codex Orchestration Installer",
-                        "version": "0.7.0",
+                        "version": "0.7.1",
                     },
                     "capabilities": {"experimentalApi": True},
                 },

--- a/tests/plugin_lifecycle_smoke.py
+++ b/tests/plugin_lifecycle_smoke.py
@@ -32,7 +32,7 @@ PLUGIN_ID = "codex-orchestration@codex-orchestration"
 MARKETPLACE_NAME = "codex-orchestration"
 OLD_RELEASE = "a1d9c546665c3253cdcaa8fe5c0c060199a6126c"
 OLD_VERSION = "0.5.0"
-NEW_VERSION = "0.7.0"
+NEW_VERSION = "0.7.1"
 COMMAND_TIMEOUT_SECONDS = 60
 
 

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -205,7 +205,7 @@ class PackagingTests(unittest.TestCase):
 
         self.assertEqual(manifest["name"], "codex-orchestration")
         self.assertEqual(manifest["skills"], "./skills/")
-        self.assertEqual(manifest["version"], "0.7.0")
+        self.assertEqual(manifest["version"], "0.7.1")
         self.assertEqual(manifest["mcpServers"], "./.mcp.json")
         self.assertRegex(
             manifest["version"],
@@ -228,7 +228,7 @@ class PackagingTests(unittest.TestCase):
         self.assertFalse((SKILL_ROOT / "scripts" / "update_plugin.py").exists())
         self.assertIn("config/batchWrite", native.read_text(encoding="utf-8"))
         self.assertIn('"--repair"', native.read_text(encoding="utf-8"))
-        self.assertIn('"version": "0.7.0"', native.read_text(encoding="utf-8"))
+        self.assertIn('"version": "0.7.1"', native.read_text(encoding="utf-8"))
         self.assertIn("validate_routing_state", routing_state.read_text(encoding="utf-8"))
         self.assertIn("Standalone custom agent", custom.read_text(encoding="utf-8"))
 
@@ -324,7 +324,7 @@ class PackagingTests(unittest.TestCase):
         self.assertIn("@openai/codex@0.144.1", workflow)
         smoke_text = smoke.read_text(encoding="utf-8")
         self.assertIn('OLD_VERSION = "0.5.0"', smoke_text)
-        self.assertIn('NEW_VERSION = "0.7.0"', smoke_text)
+        self.assertIn('NEW_VERSION = "0.7.1"', smoke_text)
         self.assertIn("old Advisor-only cache unexpectedly supports Planner", smoke_text)
         self.assertIn("Upgraded installed skill is missing Planner contract", smoke_text)
         self.assertIn("reused the Advisor-only 0.5.0 cache directory", smoke_text)

--- a/tests/test_release_check.py
+++ b/tests/test_release_check.py
@@ -69,7 +69,7 @@ class TempRepository:
 
 class ReleaseCheckTests(unittest.TestCase):
     def test_checkout_release_metadata_is_consistent(self) -> None:
-        self.assertEqual(RELEASE.run_check(REPO_ROOT, require_tag=False), "0.7.0")
+        self.assertEqual(RELEASE.run_check(REPO_ROOT, require_tag=False), "0.7.1")
 
     def test_unreleased_checkout_is_not_tag_ready(self) -> None:
         with self.assertRaisesRegex(RELEASE.ReleaseCheckError, "not tagged"):

--- a/tests/test_skill_contract.py
+++ b/tests/test_skill_contract.py
@@ -83,6 +83,28 @@ class SkillContractTests(unittest.TestCase):
         self.assertIn("Designer: none", SKILL)
         self.assertIn('"designer"', ROUTING_STATE)
 
+    def test_bare_external_designer_label_enters_secure_role_lifecycle(self) -> None:
+        self.assertIn("Designer: Kimi K3", SKILL)
+        self.assertIn("explicit External Model seat assignment", SKILL)
+        self.assertIn("Explicit External Model seat labels are the exception", SKILL)
+        self.assertIn("never pass it to `--designer-model`", SKILL)
+        self.assertIn("inspect `external status` first", SKILL)
+        self.assertIn("role `designer`", SKILL)
+        self.assertIn("preview and apply `connect`", SKILL)
+        self.assertIn("RESTART_REQUIRED", SKILL)
+        self.assertIn("run `ready` and then `resolve`", SKILL)
+        self.assertIn("do not report the requested external seat as unavailable", SKILL)
+        self.assertIn("never authorizes Gate 0 billing", SKILL)
+        self.assertIn("Never overwrite, repair, disconnect, or substitute", SKILL)
+        self.assertIn("preserve the original task", SKILL)
+        self.assertIn("must not be persisted in native routing state", SKILL)
+        self.assertIn("report its exact lifecycle state and next action, not unavailable", SKILL)
+        self.assertIn("only External Model seat labels", SKILL)
+        self.assertIn("also supplies any native seat", SKILL)
+        self.assertIn("collect a missing Executor", SKILL)
+        self.assertIn("never modifies or removes a pre-existing provider entry", SKILL)
+        self.assertIn("never modifies, replaces, or removes a pre-existing provider entry", EXTERNAL_REFERENCE)
+
     def test_plugin_update_is_canonical_non_destructive_and_restart_bound(self) -> None:
         self.assertIn("## Update the plugin", SKILL)
         self.assertIn("canonical Git marketplace", SKILL)


### PR DESCRIPTION
## What changed

- recognize the natural `Designer: Kimi K3` seat label as the audited task-local External Model role `designer`
- map it to OpenRouter `moonshotai/kimi-k3` at `max` reasoning (`auto` resolves to `max`; other explicit efforts reject)
- dispatch the existing secure status → prepare/auth/qualification → connect → restart → ready → resolve lifecycle instead of reporting the route as unexposed
- preserve supplied work and seats, including the mixed Fable Planner + Kimi Designer case; collect a missing Executor through the existing prompt
- publish the behavior as plugin version 0.7.1

## Root cause

The runtime lifecycle already supported qualified, provider-pinned External Model roles, but the skill contract recognized only explicit `configure external role ...` wording. A bare Designer seat was incorrectly sent toward native same-provider routing and then declared unavailable.

## Safety

- no API key or credential material is accepted, stored, logged, or committed
- no paid Gate 0 probe or retry is inferred from a seat label
- Kimi never enters the Desktop model picker or native persistent Designer route
- root/OpenAI models, GPT routes, chats, and sessions remain untouched
- clean preparation may add the exact audited OpenRouter provider entry only when absent; it never modifies, replaces, or removes an existing provider entry
- role mismatch, file/helper drift, project shadowing, and ambiguous state fail closed
- the OpenRouter provider manifest is unchanged, preserving existing per-install qualification

## Validation

- regression added first for the screenshot-style `Planner: Claude Fable 5 High, Designer: Kimi K3` contract
- focused suite: 93 tests passed
- `python3 scripts/preflight.py quick`: passed all available local gates
- `python3 scripts/preflight.py full`: diff check, compile, Ruff, focused tests, release identity, full tests, and Git-backed plugin lifecycle all passed
- secret-pattern scan: no OpenRouter key material
- exact-head independent security review: PASS on `4ce2c1fb963477f0588a8d8616bb823ad9ca30a5`; one provider-entry wording contradiction was repaired and re-reviewed with no new findings

Hosted Python matrix, Windows portability, and CodeQL are intentionally left to this PR's required GitHub checks.

## Review attestation

<!-- codex-review-attestation:start -->
{
  "schema": 1,
  "risk_tier": "security-state",
  "repository": "Cjbuilds/Codex-Orchestration",
  "base_branch": "main",
  "reviewed_head_sha": "4ce2c1fb963477f0588a8d8616bb823ad9ca30a5",
  "reviewer_identity": "Codex independent reviewer Zeno",
  "reviewer_route": "gpt-5.6-sol@high via sol_high_worker",
  "threat_model": {
    "assets": [
      "User credential secrecy and operating-system credential-store boundaries.",
      "Existing root OpenAI model, native GPT routes, provider entries, chats, and sessions.",
      "Exact Kimi provider, model, effort, role, and reviewed agent-file integrity."
    ],
    "threats": [
      "Seat shorthand could infer paid Gate 0 approval or expose credential material.",
      "Cross-provider Designer could be misrouted through native persistence or project-agent shadowing.",
      "Clean preparation wording could authorize replacing an existing provider entry."
    ],
    "mitigations": [
      "Gate 0, credential entry, retries, replacement, and deletion remain separately authorized and fail closed.",
      "External Designer stays task-local and resolve re-attests provider, role file, effort, and project-shadow state.",
      "Preparation adds only the absent audited OpenRouter entry and refuses any existing provider identifier."
    ]
  },
  "negative_test_evidence": [
    {
      "category": "regression",
      "evidence": "test_bare_external_designer_label_enters_secure_role_lifecycle covers the screenshot-style seat assignment and exact lifecycle dispatch."
    },
    {
      "category": "negative",
      "evidence": "The contract regression asserts no native Designer route, no inferred Gate 0 billing, no overwrite or disconnect, and no native persistence."
    },
    {
      "category": "malformed",
      "evidence": "External provider and configurator suites reject malformed schemas, unsupported efforts, drifted files, ambiguous roles, and project-agent shadowing."
    }
  ],
  "findings_disposition": "The independent reviewer found one provider-entry wording contradiction; it was repaired in the exact reviewed head and re-reviewed PASS with no new findings."
}
<!-- codex-review-attestation:end -->
