### PR TITLE
Harden Kimi external model invocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-## 0.7.2 — Unreleased
+## 0.8.0 — Unreleased
+
+- Replace READY External Model execution through Desktop native agents with a
+  sealed direct `codex exec` transport. Packets travel only on bounded stdin;
+  output is a bounded safe last-message artifact; model-facing tools, provider
+  streams, retries, fallback, and lifecycle writes are disabled.
+- Re-attest the explicit absolute active-host Codex executable before launch and
+  preserve exact schema-1 registries and managed role files without migration.
 
 - Enable implicit skill discovery for natural-language Kimi K3, External Model,
   and model-role availability questions. The previous metadata required an explicit

--- a/README.md
+++ b/README.md
@@ -213,7 +213,9 @@ Create a Codex Goal normally, then tell Codex to use the saved workflow until th
 `Designer: Kimi K3` selects the audited task-local External Model role without
 adding Kimi to the Desktop picker or replacing any GPT route. Kimi K3 supports only
 `max` reasoning (`auto` maps to `max`). If the exact role is already ready, the
-plugin resolves and uses it. Otherwise it walks the secure status, preparation,
+plugin invokes it through a sealed, tool-free `codex exec` transport with the task
+packet only on stdin; it never executes an External Model through native
+`agents.spawn_agent`. Otherwise it walks the secure status, preparation,
 hidden authentication, separately authorized Gate 0, connection, restart, and
 readiness states and tells you the exact next action instead of calling the route
 unavailable. The seat label never authorizes credential entry or a paid probe.
@@ -273,7 +275,9 @@ codex plugin add codex-orchestration@codex-orchestration
 Version **0.6.0 or newer** is required for External Model roles; version **0.7.0
 or newer** adds `--update`, routing repair, and Designer; version **0.7.1 or newer**
 lets the natural `Designer: Kimi K3` label enter the External Model lifecycle;
-version **0.7.2 or newer** uses the concise per-role activation confirmation.
+version **0.7.2 or newer** uses the concise per-role activation confirmation;
+version **0.8.0 or newer** uses sealed direct CLI invocation for READY External
+Model roles.
 Confirm with
 `codex plugin list --json`, then restart Codex Desktop and start a new task.
 

--- a/docs/production-readiness-audit.md
+++ b/docs/production-readiness-audit.md
@@ -26,6 +26,14 @@ Audit date: 2026-07-12. Baseline: `a674a81` (`0.4.0`).
 
 ## Deliberate boundaries that remain
 
+- External Model READY roles use a sealed direct CLI transport, not Desktop's
+  native spawn-agent server-tool path. Inputs and outputs are hard bounded, provider
+  streams are withheld, command-backed auth remains secret-free, tools are disabled,
+  and binary/config/role/shadow integrity fail closed. Windows process-group cleanup
+  can signal the group and hard-kill the child but cannot provide Unix-style
+  descendant enumeration; disabling model tools removes the supported descendant
+  creation path.
+
 - Codex currently exposes no global engine field that hard-wires one executor model. The native path installs durable routing policy on the spawn tool; the root still decides whether to delegate and supplies the route.
 - Setup-time config parsing cannot prove a future signed-in task will accept a route or expose its effective child identity. A live release check is required.
 - Direct model overrides inherit the root provider. Cross-provider use requires a provider-pinned custom agent that the user configured and authenticated separately.

--- a/plugins/codex-orchestration/.codex-plugin/plugin.json
+++ b/plugins/codex-orchestration/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-orchestration",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "Give Codex and audited external models safe, provider-pinned roles.",
   "author": {
     "name": "CJ Zafir",

--- a/plugins/codex-orchestration/skills/codex-orchestration/SKILL.md
+++ b/plugins/codex-orchestration/skills/codex-orchestration/SKILL.md
@@ -42,14 +42,19 @@ For a question such as `is Kimi available to use as Designer?`, enter this skill
 implicitly and run `external status` from the installed skill before answering.
 Never infer External Model availability from the currently exposed MCP or subagent
 tool list. A visible Fable tool is not an exhaustive provider or role inventory.
-Report the result in three separate terms:
+Report the result in four separate terms:
 
 - `supported`: the exact display name maps to a bundled audited manifest;
 - `configured`: the exact provider/model/effort and role exist without drift;
-- `callable now`: status is `READY` and read-only `resolve` succeeds for the exact
-  role and effort in the current workspace.
+- `locally ready`: status is `READY` and read-only `resolve` succeeds for the exact
+  role and effort in the current workspace;
+- `callable now`: a sealed `invoke` has successfully attested the active binary,
+  required CLI controls and feature catalog, unchanged registry, and accepted the
+  model call. Read-only discovery must report this as unconfirmed rather than make
+  a model call.
 
-Say Kimi K3 is available to use as Designer only when all three are true. Otherwise,
+Say Kimi K3 is available to use as Designer only when support, configuration, local
+readiness, and callability are all true. Otherwise,
 say it is supported but not yet callable, name the exact lifecycle state, and give
 the next action. Never answer that the plugin does not expose Kimi merely because a
 Kimi-specific tool is absent; the route is materialized through the External Model
@@ -109,8 +114,9 @@ Do not print omitted, `none`, or implicit-root seats. On a role-selection-only i
 activation lines are the entire successful response: do not add a heading,
 preamble, route internals, or delegation boilerplate.
 
-Use `Activated` only after that exact route is ready and callable in the current
-task. It means available for this task, not `used and confirmed` runtime identity.
+Use `Activated` only after that exact route is locally ready and its sealed invoke
+preflight succeeds for the active binary in the current task. It means available
+for this task, not `used and confirmed` runtime identity.
 If authentication, qualification, connection, restart, resolution, or another
 required boundary remains, report the exact lifecycle state and next action instead of `Activated`.
 Never mix a false activation line into a blocker response. For a
@@ -208,10 +214,13 @@ An external Designer is not a native direct-model Designer: never pass it to `--
 the root-provider model catalog, or the persistent routing schema; always inspect `external status` first and compare the requested role, provider,
 model, and effort with the strict registry result. Then follow exactly one state:
 
-- If the exact role is `READY`, run read-only `resolve` and delegate only to the
-  returned agent name.
+- If the exact role is `READY`, invoke it only with the configurator's sealed
+  `invoke` subcommand and an absolute active-host `--codex-bin`; pass the bounded
+  packet on stdin. Never execute an External Model role with `agents.spawn_agent`
+  (or any native spawn-agent namespace). `resolve` remains a read-only diagnostic.
 - If the exact role is `RESTART_REQUIRED`, tell the user to fully quit and reopen
-  Codex and start a new task. In that new task, preview and apply `ready`; run `ready` and then `resolve`, and delegate only after both succeed.
+  Codex and start a new task. In that new task, preview and apply `ready`; then use
+  sealed `invoke` only after readiness succeeds.
 - If the provider is exact, authenticated, and `CAPABILITY_VERIFIED` or `READY`, but
   role `designer` is absent, the explicit seat assignment authorizes clean role
   creation: preview and apply `connect` with the bounded purpose "Produce a design
@@ -275,9 +284,10 @@ or `latest` Kimi alias.
 
 `connect` creates one personal provider-pinned custom-agent variant for every
 manifest-validated effort. After a new task and exact integrity check, `resolve`
-maps the requested role and effort to one exact loaded agent name. Delegate only to
-that returned name. Report `route accepted` when the host accepts it. Report `used
-and confirmed` only from mechanical host/provider/rollout metadata; model self-identification is never evidence.
+maps the requested role and effort for diagnostics. Execute only with sealed
+`invoke`, never a native spawn-agent tool. Report `route accepted` when the direct
+CLI accepts it. Report `used and confirmed` only from mechanical
+host/provider/rollout metadata; model self-identification is never evidence.
 
 For an unavailable provider, effort, auth helper, role file, or readiness state,
 stop and report the exact blocker. `CLI_CHANGED`, `CONFIG_DRIFT`, `ROLE_COLLISION`,

--- a/plugins/codex-orchestration/skills/codex-orchestration/references/external-models.md
+++ b/plugins/codex-orchestration/skills/codex-orchestration/references/external-models.md
@@ -51,7 +51,7 @@ Root must inspect external status before acting. Dispatch by exact state:
 | Tuple unqualified | Request separate billing approval immediately before one Gate 0; never infer approval from the seat label. |
 | Qualified provider, role absent | Preview and apply `connect` for role `designer` with the bounded Designer purpose. |
 | `RESTART_REQUIRED` | Require a full Desktop restart and new task; do not delegate. |
-| Exact role `READY` | Run `resolve`, then delegate only to its returned loaded agent name. |
+| Exact role `READY` | Run sealed `invoke` with the bounded packet on stdin. Never use native `agents.spawn_agent` for an External Model. |
 | Role mismatch, drift, shadow, or ambiguity | Stop with the exact blocker; never overwrite, disconnect, repair, or substitute. |
 
 The explicit seat label authorizes clean preparation and clean role creation, just as
@@ -156,9 +156,9 @@ python3 <skill-dir>/scripts/external_configurator.py connect \
 
 The configurator creates one personal provider-pinned agent per manifest-validated
 effort. Start a new Codex task so Desktop loads those files, preview `ready`, then
-apply it. Read-only `resolve --role researcher --effort max` returns the exact
-loaded agent name root should delegate to. The agent file, not prompt text, binds
-provider, model, and effort.
+apply it. Read-only `resolve --role researcher --effort max` remains available for
+diagnostics. Execution uses the exact managed agent bytes as a sealed instruction;
+the agent file still binds provider, model, and effort.
 
 ## Calling a role
 
@@ -170,12 +170,36 @@ use reviewer@high for <bounded task>
 researcher: <bounded task> (effort max)
 ```
 
-Resolve the role and effort through `external_configurator.py resolve`. Reject an
-unknown role, unsupported effort, unready state, missing agent, digest drift, or
-provider drift. Delegate only to the exact returned agent. Report `route accepted`
-when the host accepts the spawn. Report `used and confirmed` only when mechanical
-host/provider metadata names the provider and model; never rely on the model saying
-its own name.
+Send the bounded UTF-8 packet only on stdin (maximum 1 MiB):
+
+```bash
+python3 <skill-dir>/scripts/external_configurator.py \
+  --codex-bin <absolute-active-host-codex-binary> \
+  invoke --role researcher --effort max < packet.txt
+```
+
+`invoke` repeats all `resolve` integrity, qualification, authentication, role-file,
+and workspace-shadow checks, then uses an isolated temporary `CODEX_HOME` and
+`codex exec` with a read-only sandbox, ignored repository rules, and all
+model-facing tools disabled. It first reads the exact binary's fail-closed feature
+catalog, requires every transport-critical control, and emits disable flags for
+every advertised targeted feature. The known cross-version optional `skill_search`
+feature is already absent when unadvertised and receives no incompatible flag.
+It accepts only a regular, single-link UTF-8 final
+message of at most 2 MiB and returns machine-readable JSON. It never truncates,
+retries, falls back, mutates lifecycle state, or exposes provider stdout/stderr.
+The active-host binary must be an explicit absolute regular executable (PATH lookup
+is forbidden), is fingerprinted and version-checked, and is re-fingerprinted before
+launch. A nonzero exit, timeout, changed binary, unsafe artifact, or drift returns a
+generic redacted failure. `READY` means only that the role, provider configuration,
+authentication helper, and managed agent satisfy local readiness checks. It does
+not attest the active binary, CLI flags, feature catalog, upstream uptime, or
+runtime model identity; those invocation controls are checked by sealed `invoke`.
+
+On POSIX, timeout cleanup kills the new process group. On Windows, invocation uses
+a new process group, requests a group break, then hard-kills the direct child if it
+does not exit. Because model tools are disabled, the design creates no model-facing
+long-lived descendants; Windows cannot promise Unix-style descendant enumeration.
 
 ## Status, disconnect, and removal
 
@@ -202,6 +226,9 @@ content.
 The bearer value crosses one unavoidable boundary: the OS credential helper prints
 it to the Codex provider process on stdout, as required by Codex command-backed
 authentication. Surrounding logs and errors withhold helper and provider output.
+The key is never copied into invocation argv, environment, temporary config, packet,
+registry, journal, output, or error text; the isolated config retains only the exact
+command-backed helper reference.
 
 ## Adding another provider
 

--- a/plugins/codex-orchestration/skills/codex-orchestration/scripts/configure_native_routing.py
+++ b/plugins/codex-orchestration/skills/codex-orchestration/scripts/configure_native_routing.py
@@ -367,8 +367,13 @@ def discover_compatibility_binaries(
 
 
 class AppServer:
-    def __init__(self, binary: Path, codex_home: Path | None) -> None:
-        env = os.environ.copy()
+    def __init__(
+        self,
+        binary: Path,
+        codex_home: Path | None,
+        environment: dict[str, str] | None = None,
+    ) -> None:
+        env = os.environ.copy() if environment is None else environment.copy()
         if codex_home is not None:
             resolved_home = codex_home.expanduser().absolute()
             resolved_home.mkdir(parents=True, exist_ok=True)
@@ -405,7 +410,7 @@ class AppServer:
                     "clientInfo": {
                         "name": "codex_orchestration_installer",
                         "title": "Codex Orchestration Installer",
-                        "version": "0.7.2",
+                        "version": "0.8.0",
                     },
                     "capabilities": {"experimentalApi": True},
                 },

--- a/plugins/codex-orchestration/skills/codex-orchestration/scripts/external_configurator.py
+++ b/plugins/codex-orchestration/skills/codex-orchestration/scripts/external_configurator.py
@@ -12,6 +12,7 @@ import os
 from pathlib import Path
 import re
 import secrets
+import signal
 import stat
 import subprocess
 import sys
@@ -40,6 +41,29 @@ GATE0_REQUIRED_FLAGS = (
     "--skip-git-repo-check",
     "--sandbox",
     "--output-last-message",
+)
+INVOKE_INPUT_MAX_BYTES = 1_048_576
+INVOKE_OUTPUT_MAX_BYTES = 2_097_152
+INVOKE_TIMEOUT_SECONDS = 180
+INVOKE_REQUIRED_FLAGS = GATE0_REQUIRED_FLAGS + ("--ignore-rules", "--disable")
+INVOKE_DISABLED_FEATURES = (
+    "multi_agent",
+    "multi_agent_v2",
+    "apps",
+    "browser_use",
+    "in_app_browser",
+    "computer_use",
+    "image_generation",
+    "shell_tool",
+    "unified_exec",
+    "skill_search",
+    "tool_suggest",
+)
+INVOKE_OPTIONAL_FEATURES = frozenset({"skill_search"})
+INVOKE_REQUIRED_FEATURES = tuple(
+    feature
+    for feature in INVOKE_DISABLED_FEATURES
+    if feature not in INVOKE_OPTIONAL_FEATURES
 )
 PURPOSE_MAX_CHARS = 2_000
 ROLE_RE = re.compile(r"^[a-z][a-z0-9_]{0,62}$")
@@ -576,6 +600,359 @@ def _read_gate0_last_message(path: Path) -> str:
         ) from exc
 
 
+def _read_invoke_last_message(path: Path) -> str:
+    flags = os.O_RDONLY
+    if hasattr(os, "O_BINARY"):
+        flags |= os.O_BINARY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        info = path.stat(follow_symlinks=False)
+        _require(
+            not path.is_symlink()
+            and stat.S_ISREG(info.st_mode)
+            and info.st_nlink == 1,
+            "external invocation result is unsafe; provider output withheld",
+        )
+        descriptor = os.open(path, flags)
+        try:
+            opened = os.fstat(descriptor)
+            _require(
+                (opened.st_dev, opened.st_ino) == (info.st_dev, info.st_ino),
+                "external invocation result changed before reading; output withheld",
+            )
+            _require(
+                opened.st_size <= INVOKE_OUTPUT_MAX_BYTES,
+                "external invocation result is oversized; provider output withheld",
+            )
+            chunks: list[bytes] = []
+            remaining = INVOKE_OUTPUT_MAX_BYTES + 1
+            while remaining:
+                chunk = os.read(descriptor, remaining)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+                remaining -= len(chunk)
+            raw = b"".join(chunks)
+            after = os.fstat(descriptor)
+        finally:
+            os.close(descriptor)
+    except OSError as exc:
+        raise ExternalConfigurationError(
+            "external invocation did not produce a safe result; provider output withheld"
+        ) from exc
+    _require(
+        (after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns, after.st_nlink)
+        == (opened.st_dev, opened.st_ino, opened.st_size, opened.st_mtime_ns, 1),
+        "external invocation result changed while reading; output withheld",
+    )
+    _require(
+        len(raw) <= INVOKE_OUTPUT_MAX_BYTES and len(raw) == after.st_size,
+        "external invocation result is oversized; provider output withheld",
+    )
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ExternalConfigurationError(
+            "external invocation result is unreadable; provider output withheld"
+        ) from exc
+
+
+def _verify_invoke_cli_contract(
+    codex_binary: Path, *, cwd: Path, environment: dict[str, str]
+) -> tuple[str, ...]:
+    try:
+        completed = subprocess.run(
+            [str(codex_binary), "exec", "--help"],
+            cwd=cwd,
+            env=environment,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+            timeout=GATE0_HELP_TIMEOUT_SECONDS,
+            shell=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise ExternalConfigurationError(
+            "external invocation CLI contract could not be verified; output withheld"
+        ) from exc
+    help_text = f"{completed.stdout}\n{completed.stderr}"
+    flags_present = all(
+        re.search(rf"(?m)^\s*(?:-[A-Za-z],\s*)?{re.escape(flag)}(?:\s|$)", help_text)
+        is not None
+        for flag in INVOKE_REQUIRED_FLAGS
+    )
+    read_only_present = re.search(
+        r"--sandbox\b[\s\S]{0,500}\bread-only\b", help_text
+    ) is not None
+    _require(
+        completed.returncode == 0 and flags_present and read_only_present,
+        "external invocation CLI contract is unsupported; no model call was started",
+    )
+    try:
+        catalog = subprocess.run(
+            [str(codex_binary), "features", "list"],
+            cwd=cwd,
+            env=environment,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+            timeout=GATE0_HELP_TIMEOUT_SECONDS,
+            shell=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise ExternalConfigurationError(
+            "external invocation feature catalog could not be verified; output withheld"
+        ) from exc
+    _require(
+        catalog.returncode == 0,
+        "external invocation feature catalog failed; no model call was started",
+    )
+    advertised: set[str] = set()
+    lines = [line for line in catalog.stdout.splitlines() if line.strip()]
+    _require(bool(lines), "external invocation feature catalog is invalid")
+    for line in lines:
+        match = re.fullmatch(
+            r"\s*([a-z][a-z0-9_]*)\s+.+?\s+(?:true|false)\s*", line
+        )
+        _require(match is not None, "external invocation feature catalog is invalid")
+        name = match.group(1)
+        _require(
+            name not in advertised,
+            "external invocation feature catalog is invalid",
+        )
+        advertised.add(name)
+    _require(
+        set(INVOKE_REQUIRED_FEATURES) <= advertised,
+        "external invocation required feature controls are unavailable; no model call was started",
+    )
+    return tuple(
+        feature for feature in INVOKE_DISABLED_FEATURES if feature in advertised
+    )
+
+
+def _terminate_invoke_process(process: subprocess.Popen[bytes]) -> None:
+    if process.poll() is not None:
+        return
+    try:
+        if os.name == "posix":
+            os.killpg(process.pid, signal.SIGKILL)
+        else:
+            if hasattr(signal, "CTRL_BREAK_EVENT"):
+                process.send_signal(signal.CTRL_BREAK_EVENT)
+                try:
+                    process.wait(timeout=2)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+            else:
+                process.kill()
+    except (OSError, ProcessLookupError):
+        process.kill()
+    try:
+        process.wait(timeout=5)
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+
+
+def _run_invoke_process(
+    command: list[str], *, cwd: Path, environment: dict[str, str], prompt: bytes
+) -> int:
+    creationflags = 0
+    popen_kwargs: dict[str, Any] = {}
+    if os.name == "posix":
+        popen_kwargs["start_new_session"] = True
+    else:
+        creationflags = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+    process: subprocess.Popen[bytes] | None = None
+    try:
+        process = subprocess.Popen(
+            command,
+            cwd=cwd,
+            env=environment,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            shell=False,
+            creationflags=creationflags,
+            **popen_kwargs,
+        )
+        process.communicate(input=prompt, timeout=INVOKE_TIMEOUT_SECONDS)
+    except subprocess.TimeoutExpired as exc:
+        raise ExternalConfigurationError(
+            "external invocation timed out; provider output withheld"
+        ) from exc
+    except (KeyboardInterrupt, SystemExit):
+        raise
+    except Exception as exc:
+        raise ExternalConfigurationError(
+            "external invocation could not complete; provider output withheld"
+        ) from exc
+    finally:
+        if process is not None and process.poll() is None:
+            _terminate_invoke_process(process)
+    return process.returncode
+
+
+def _read_exact_role_instruction(agent: dict[str, str]) -> str:
+    path = Path(agent["file"])
+    flags = os.O_RDONLY
+    if hasattr(os, "O_BINARY"):
+        flags |= os.O_BINARY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        path_info = path.stat(follow_symlinks=False)
+        _require(
+            not path.is_symlink()
+            and stat.S_ISREG(path_info.st_mode)
+            and path_info.st_nlink == 1,
+            "role agent is missing or unsafe",
+        )
+        descriptor = os.open(path, flags)
+        try:
+            before = os.fstat(descriptor)
+            _require(
+                (before.st_dev, before.st_ino) == (path_info.st_dev, path_info.st_ino),
+                "role agent changed before reading",
+            )
+            chunks: list[bytes] = []
+            while True:
+                chunk = os.read(descriptor, 1024 * 1024)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+            after = os.fstat(descriptor)
+        finally:
+            os.close(descriptor)
+    except OSError as exc:
+        raise ExternalConfigurationError("role agent is missing or unreadable") from exc
+    _require(
+        stat.S_ISREG(before.st_mode) and before.st_nlink == 1,
+        "role agent is missing or unsafe",
+    )
+    _require(
+        (after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns, after.st_nlink)
+        == (before.st_dev, before.st_ino, before.st_size, before.st_mtime_ns, 1),
+        "role agent changed while reading",
+    )
+    raw = b"".join(chunks)
+    _require(hashlib.sha256(raw).hexdigest() == agent["sha256"], "role agent drifted")
+    try:
+        parsed = tomllib.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, tomllib.TOMLDecodeError) as exc:
+        raise ExternalConfigurationError("role agent is unreadable") from exc
+    instruction = parsed.get("developer_instructions")
+    _require(
+        type(instruction) is str and bool(instruction.strip()),
+        "role instruction is invalid",
+    )
+    return instruction
+
+
+def _decode_invoke_packet(packet: bytes) -> str:
+    _require(0 < len(packet) <= INVOKE_INPUT_MAX_BYTES, "invoke packet size is invalid")
+    try:
+        return packet.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ExternalConfigurationError("invoke packet must be valid UTF-8") from exc
+
+
+def invoke_role(
+    home: Path,
+    role_id: str,
+    effort: str,
+    packet: bytes,
+    backend: ConfigBackend,
+    codex_binary: Path,
+    *,
+    workspace: Path | None = None,
+) -> dict[str, str]:
+    """Invoke one READY external role through a sealed, tool-free Codex exec."""
+
+    packet_text = _decode_invoke_packet(packet)
+
+    registry, registry_digest = load_registry(home)
+    _require(registry_digest is not None, "external registry is not configured")
+    route = resolve_role(
+        home,
+        role_id,
+        effort,
+        backend,
+        workspace,
+        registry_snapshot=(registry, registry_digest),
+    )
+    role = registry["roles"].get(role_id)
+    _require(
+        role is not None
+        and role["provider"] == route["provider"]
+        and role["model"] == route["model"]
+        and route["effort"] in role["effort_agents"],
+        "external route changed during invocation",
+    )
+    agent = role["effort_agents"][route["effort"]]
+    instruction = _read_exact_role_instruction(agent)
+
+    supplied_binary = codex_binary.expanduser()
+    _require(supplied_binary.is_absolute(), "invoke requires an absolute --codex-bin")
+    target, fingerprint = external_cli_trust.fingerprint(supplied_binary)
+    external_cli_trust.version(target)
+    provider = external_providers.load_provider(route["provider"])
+    record = registry["providers"][route["provider"]]
+    config = _expected_provider_config(home, provider, record, registry)
+    prompt = (
+        "<sealed_external_role_instruction>\n"
+        + instruction
+        + "\n</sealed_external_role_instruction>\n<bounded_task_packet>\n"
+        + packet_text
+        + "\n</bounded_task_packet>\n"
+    ).encode("utf-8")
+    with tempfile.TemporaryDirectory(prefix="codex-orchestration-invoke-") as raw:
+        isolated_home = Path(raw)
+        environment = _gate0_environment(isolated_home)
+        disabled_features = _verify_invoke_cli_contract(
+            target, cwd=isolated_home, environment=environment
+        )
+        config_path = isolated_home / "config.toml"
+        config_path.write_text(
+            _gate0_config(provider, config, route["model"], route["effort"]),
+            encoding="utf-8",
+        )
+        if os.name == "posix":
+            config_path.chmod(0o600)
+        output_path = isolated_home / "last-message.txt"
+        target_after, fingerprint_after = external_cli_trust.fingerprint(target)
+        _require(
+            target_after == target and fingerprint_after == fingerprint,
+            "CLI_CHANGED: executable changed before invocation",
+        )
+        _, current_registry_digest = load_registry(home)
+        _require(
+            current_registry_digest == registry_digest,
+            "external registry changed during invocation",
+        )
+        command = [
+            str(target), "exec", "--ephemeral", "--skip-git-repo-check",
+            "--sandbox", "read-only", "--ignore-rules", "--output-last-message",
+            os.fspath(output_path),
+        ]
+        for feature in disabled_features:
+            command.extend(("--disable", feature))
+        command.append("-")
+        returncode = _run_invoke_process(
+            command, cwd=isolated_home, environment=environment, prompt=prompt
+        )
+        _require(
+            returncode == 0,
+            f"external invocation failed with exit {returncode}; provider output withheld",
+        )
+        output = _read_invoke_last_message(output_path)
+    return {**route, "output": output}
+
+
 def run_gate0(
     home: Path,
     provider_id: str,
@@ -871,10 +1248,11 @@ def resolve_role(
     effort: str,
     backend: ConfigBackend,
     workspace: Path | None = None,
+    registry_snapshot: tuple[dict[str, Any], str | None] | None = None,
 ) -> dict[str, str]:
     """Resolve a role only after re-attesting every route-time trust boundary."""
 
-    registry, _ = load_registry(home)
+    registry, _ = registry_snapshot or load_registry(home)
     role = registry["roles"].get(role_id)
     _require(role is not None, f"role {role_id!r} is not configured")
     _require(
@@ -1188,8 +1566,16 @@ def inspect_status(home: Path, backend: ConfigBackend | None = None) -> dict[str
 
 
 class AppServerBackend:
-    def __init__(self, codex_binary: Path, home: Path, cwd: Path) -> None:
-        self._app = native_routing.AppServer(codex_binary, home)
+    def __init__(
+        self,
+        codex_binary: Path,
+        home: Path,
+        cwd: Path,
+        environment: dict[str, str] | None = None,
+    ) -> None:
+        self._app = native_routing.AppServer(
+            codex_binary, home, environment=environment
+        )
         self._cwd = cwd
 
     def close(self) -> None:
@@ -1269,6 +1655,9 @@ def main(argv: list[str] | None = None) -> int:
     resolve = subparsers.add_parser("resolve")
     resolve.add_argument("--role", required=True)
     resolve.add_argument("--effort", default="auto")
+    invoke = subparsers.add_parser("invoke")
+    invoke.add_argument("--role", required=True)
+    invoke.add_argument("--effort", default="auto")
     disconnect = subparsers.add_parser("disconnect")
     disconnect.add_argument("--role", required=True)
     disconnect.add_argument("--apply", action="store_true")
@@ -1284,6 +1673,13 @@ def main(argv: list[str] | None = None) -> int:
     recover.add_argument("--apply", action="store_true")
     args = parser.parse_args(argv)
     try:
+        invoke_packet = (
+            sys.stdin.buffer.read(INVOKE_INPUT_MAX_BYTES + 1)
+            if args.command == "invoke"
+            else None
+        )
+        if invoke_packet is not None:
+            _decode_invoke_packet(invoke_packet)
         home = _home(args.codex_home)
         if args.command == "prepare" and not args.apply:
             provider = external_providers.load_provider(args.provider)
@@ -1384,8 +1780,27 @@ def main(argv: list[str] | None = None) -> int:
                 "must pass again before role use."
             )
             return 0
-        codex_binary = native_routing.resolve_binary(args.codex_bin)
-        with AppServerBackend(codex_binary, home, Path.cwd().resolve()) as backend:
+        if args.command == "invoke":
+            codex_binary = Path(args.codex_bin).expanduser()
+            _require(
+                codex_binary.is_absolute(),
+                "invoke requires an absolute --codex-bin",
+            )
+            codex_binary, _ = external_cli_trust.fingerprint(codex_binary)
+            external_cli_trust.version(codex_binary)
+        else:
+            codex_binary = native_routing.resolve_binary(args.codex_bin)
+        app_environment = (
+            external_cli_trust.sanitized_environment()
+            if args.command == "invoke"
+            else None
+        )
+        with AppServerBackend(
+            codex_binary,
+            home,
+            Path.cwd().resolve(),
+            environment=app_environment,
+        ) as backend:
             if args.command == "prepare":
                 command = prepare_provider(
                     home,
@@ -1418,6 +1833,21 @@ def main(argv: list[str] | None = None) -> int:
                             args.effort,
                             backend,
                             Path.cwd().resolve(),
+                        ),
+                        sort_keys=True,
+                    )
+                )
+            elif args.command == "invoke":
+                print(
+                    json.dumps(
+                        invoke_role(
+                            home,
+                            args.role,
+                            args.effort,
+                            invoke_packet,
+                            backend,
+                            codex_binary,
+                            workspace=Path.cwd().resolve(),
                         ),
                         sort_keys=True,
                     )

--- a/plugins/codex-orchestration/skills/codex-orchestration/scripts/external_credentials.py
+++ b/plugins/codex-orchestration/skills/codex-orchestration/scripts/external_credentials.py
@@ -12,6 +12,8 @@ import subprocess
 import sys
 from typing import Any
 
+import external_cli_trust
+
 
 HELPER_NAME = "external_auth_helper.py"
 HELPER_MARKER = b"codex-orchestration-managed-external-auth-helper-v1"
@@ -213,6 +215,7 @@ def credential_ready(
             check=False,
             timeout=20,
             shell=False,
+            env=external_cli_trust.sanitized_environment(),
         )
     except (OSError, subprocess.TimeoutExpired):
         return False

--- a/tests/plugin_lifecycle_smoke.py
+++ b/tests/plugin_lifecycle_smoke.py
@@ -32,7 +32,7 @@ PLUGIN_ID = "codex-orchestration@codex-orchestration"
 MARKETPLACE_NAME = "codex-orchestration"
 OLD_RELEASE = "a1d9c546665c3253cdcaa8fe5c0c060199a6126c"
 OLD_VERSION = "0.5.0"
-NEW_VERSION = "0.7.2"
+NEW_VERSION = "0.8.0"
 COMMAND_TIMEOUT_SECONDS = 60
 
 

--- a/tests/test_external_configurator.py
+++ b/tests/test_external_configurator.py
@@ -24,6 +24,10 @@ assert SPEC and SPEC.loader
 CONFIG = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(CONFIG)
 
+FAKE_CODEX_DIR = Path(tempfile.gettempdir()).resolve() / "codex-orchestration-tests"
+FAKE_CODEX_BIN = FAKE_CODEX_DIR / "codex"
+FAKE_RESOLVED_CODEX_BIN = FAKE_CODEX_DIR / "resolved-codex"
+
 
 class FakeBackend:
     def __init__(self) -> None:
@@ -143,7 +147,7 @@ class ExternalConfiguratorTests(unittest.TestCase):
                 CONFIG.native_routing, "AppServer", FakeAppServer
             ), mock.patch.object(
                 CONFIG.external_cli_trust, "fingerprint",
-                return_value=(Path("/real/codex"), "same"),
+                return_value=(FAKE_RESOLVED_CODEX_BIN, "same"),
             ), mock.patch.object(
                 CONFIG.external_cli_trust, "version", return_value="codex 0.144.1"
             ), mock.patch.object(
@@ -156,12 +160,12 @@ class ExternalConfiguratorTests(unittest.TestCase):
                 os.environ, {"OPENROUTER_API_KEY": "sentinel-app-server-secret"}
             ):
                 result = CONFIG.main([
-                    "--codex-home", str(home), "--codex-bin", "/safe/codex",
+                    "--codex-home", str(home), "--codex-bin", str(FAKE_CODEX_BIN),
                     "invoke", "--role", "researcher", "--effort", "max",
                 ])
             self.assertEqual(result, 0)
-            self.assertEqual(observed["binary"], Path("/real/codex"))
-            self.assertEqual(invoke.call_args.args[5], Path("/real/codex"))
+            self.assertEqual(observed["binary"], FAKE_RESOLVED_CODEX_BIN)
+            self.assertEqual(invoke.call_args.args[5], FAKE_RESOLVED_CODEX_BIN)
             self.assertEqual(
                 observed["environment"], {"PATH": "/safe/bin", "KEEP": "yes"}
             )
@@ -181,7 +185,7 @@ class ExternalConfiguratorTests(unittest.TestCase):
             ],
         ):
             advertised = CONFIG._verify_invoke_cli_contract(
-                Path("/safe/codex"), cwd=Path("/safe"), environment={}
+                FAKE_CODEX_BIN, cwd=FAKE_CODEX_DIR, environment={}
             )
         self.assertEqual(
             advertised,
@@ -201,7 +205,7 @@ class ExternalConfiguratorTests(unittest.TestCase):
             ],
         ):
             advertised = CONFIG._verify_invoke_cli_contract(
-                Path("/safe/codex"), cwd=Path("/safe"), environment={}
+                FAKE_CODEX_BIN, cwd=FAKE_CODEX_DIR, environment={}
             )
         self.assertEqual(advertised, CONFIG.INVOKE_DISABLED_FEATURES)
 
@@ -220,7 +224,7 @@ class ExternalConfiguratorTests(unittest.TestCase):
             ):
                 with self.assertRaises(CONFIG.ExternalConfigurationError) as failure:
                     CONFIG._verify_invoke_cli_contract(
-                        Path("/safe/codex"), cwd=Path("/safe"), environment={}
+                        FAKE_CODEX_BIN, cwd=FAKE_CODEX_DIR, environment={}
                     )
                 self.assertNotIn("provider-secret", str(failure.exception))
 
@@ -243,7 +247,7 @@ class ExternalConfiguratorTests(unittest.TestCase):
                     "required feature controls are unavailable",
                 ):
                     CONFIG._verify_invoke_cli_contract(
-                        Path("/safe/codex"), cwd=Path("/safe"), environment={}
+                        FAKE_CODEX_BIN, cwd=FAKE_CODEX_DIR, environment={}
                     )
 
     def test_invoke_rejects_packet_boundaries_before_resolution(self) -> None:
@@ -312,7 +316,7 @@ class ExternalConfiguratorTests(unittest.TestCase):
 
             with mock.patch.object(
                 CONFIG.external_cli_trust, "fingerprint",
-                side_effect=[(Path("/safe/codex"), "same"), (Path("/safe/codex"), "same")],
+                side_effect=[(FAKE_CODEX_BIN, "same"), (FAKE_CODEX_BIN, "same")],
             ), mock.patch.object(
                 CONFIG.external_cli_trust, "version", return_value="codex 1.0"
             ), mock.patch.object(
@@ -322,7 +326,7 @@ class ExternalConfiguratorTests(unittest.TestCase):
             ):
                 result = CONFIG.invoke_role(
                     home, "researcher", "max", packet, backend,
-                    Path("/safe/codex"), workspace=home,
+                    FAKE_CODEX_BIN, workspace=home,
                 )
             self.assertEqual(result["output"], "safe result")
             command = observed["command"]
@@ -366,7 +370,7 @@ class ExternalConfiguratorTests(unittest.TestCase):
         ) as popen, mock.patch.object(CONFIG.os, "killpg") as killpg:
             with self.assertRaisesRegex(CONFIG.ExternalConfigurationError, "timed out"):
                 CONFIG._run_invoke_process(
-                    ["/safe/codex"], cwd=Path("/safe"), environment={}, prompt=b"packet"
+                    [str(FAKE_CODEX_BIN)], cwd=FAKE_CODEX_DIR, environment={}, prompt=b"packet"
                 )
         self.assertTrue(popen.call_args.kwargs["start_new_session"])
         killpg.assert_called_once_with(4242, CONFIG.signal.SIGKILL)
@@ -394,7 +398,7 @@ class ExternalConfiguratorTests(unittest.TestCase):
         ), mock.patch.object(CONFIG.os, "killpg") as killpg:
             with self.assertRaises(KeyboardInterrupt):
                 CONFIG._run_invoke_process(
-                    ["/safe/codex"], cwd=Path("/safe"), environment={}, prompt=b"packet"
+                    [str(FAKE_CODEX_BIN)], cwd=FAKE_CODEX_DIR, environment={}, prompt=b"packet"
                 )
         killpg.assert_called_once_with(4343, CONFIG.signal.SIGKILL)
         process.wait.assert_called_once_with(timeout=5)
@@ -423,7 +427,7 @@ class ExternalConfiguratorTests(unittest.TestCase):
                 CONFIG.external_credentials, "credential_ready", return_value=True
             ), mock.patch.object(
                 CONFIG.external_cli_trust, "fingerprint",
-                side_effect=[(Path("/safe/codex"), "before"), (Path("/safe/codex"), "after")],
+                side_effect=[(FAKE_CODEX_BIN, "before"), (FAKE_CODEX_BIN, "after")],
             ), mock.patch.object(
                 CONFIG.external_cli_trust, "version", return_value="codex 1.0"
             ), mock.patch.object(
@@ -435,7 +439,7 @@ class ExternalConfiguratorTests(unittest.TestCase):
                 with self.assertRaisesRegex(CONFIG.ExternalConfigurationError, "CLI_CHANGED"):
                     CONFIG.invoke_role(
                         home, "researcher", "max", b"packet", backend,
-                        Path("/safe/codex"), workspace=home,
+                        FAKE_CODEX_BIN, workspace=home,
                     )
             popen.assert_not_called()
 
@@ -454,7 +458,7 @@ class ExternalConfiguratorTests(unittest.TestCase):
                 CONFIG.external_credentials, "credential_ready", return_value=True
             ), mock.patch.object(
                 CONFIG.external_cli_trust, "fingerprint",
-                side_effect=[(Path("/safe/codex"), "same"), (Path("/safe/codex"), "same")],
+                side_effect=[(FAKE_CODEX_BIN, "same"), (FAKE_CODEX_BIN, "same")],
             ), mock.patch.object(
                 CONFIG.external_cli_trust, "version", return_value="codex 1.0"
             ), mock.patch.object(
@@ -465,7 +469,7 @@ class ExternalConfiguratorTests(unittest.TestCase):
                 with self.assertRaises(CONFIG.ExternalConfigurationError) as failure:
                     CONFIG.invoke_role(
                         home, "researcher", "max", b"sentinel-provider-output",
-                        backend, Path("/safe/codex"), workspace=home,
+                        backend, FAKE_CODEX_BIN, workspace=home,
                     )
             self.assertIn("exit 9", str(failure.exception))
             self.assertNotIn("sentinel-provider-output", str(failure.exception))
@@ -503,7 +507,7 @@ class ExternalConfiguratorTests(unittest.TestCase):
                 CONFIG.external_credentials, "credential_ready", return_value=True
             ), mock.patch.object(
                 CONFIG.external_cli_trust, "fingerprint",
-                side_effect=[(Path("/safe/codex"), "same"), (Path("/safe/codex"), "same")],
+                side_effect=[(FAKE_CODEX_BIN, "same"), (FAKE_CODEX_BIN, "same")],
             ), mock.patch.object(
                 CONFIG.external_cli_trust, "version", return_value="codex 0.144.1"
             ), mock.patch.object(
@@ -514,7 +518,7 @@ class ExternalConfiguratorTests(unittest.TestCase):
                 ):
                     CONFIG.invoke_role(
                         home, "researcher", "max", b"packet", backend,
-                        Path("/safe/codex"), workspace=home,
+                        FAKE_CODEX_BIN, workspace=home,
                     )
             run.assert_not_called()
 
@@ -1121,7 +1125,7 @@ class ExternalConfiguratorTests(unittest.TestCase):
                     "openrouter",
                     "moonshotai/kimi-k3",
                     "max",
-                    Path("/safe/codex"),
+                    FAKE_CODEX_BIN,
                     acknowledge_billing=False,
                 )
             completed = mock.Mock(
@@ -1157,14 +1161,14 @@ class ExternalConfiguratorTests(unittest.TestCase):
                         "openrouter",
                         "moonshotai/kimi-k3",
                         "max",
-                        Path("/safe/codex"),
+                        FAKE_CODEX_BIN,
                         acknowledge_billing=True,
                     )
             self.assertNotIn("sensitive-test-value", str(failure.exception))
             sanitized.assert_called_once_with()
             self.assertEqual(run.call_count, 2)
             command = run.call_args.args[0]
-            self.assertEqual(command[:2], [str(Path("/safe/codex")), "exec"])
+            self.assertEqual(command[:2], [str(FAKE_CODEX_BIN), "exec"])
             self.assertIn("--ephemeral", command)
             self.assertIn("--skip-git-repo-check", command)
             self.assertEqual(command[command.index("--sandbox") + 1], "read-only")
@@ -1227,7 +1231,7 @@ class ExternalConfiguratorTests(unittest.TestCase):
                     "openrouter",
                     "moonshotai/kimi-k3",
                     "max",
-                    Path("/safe/codex"),
+                    FAKE_CODEX_BIN,
                     acknowledge_billing=True,
                 )
             self.assertIn(
@@ -1262,7 +1266,7 @@ class ExternalConfiguratorTests(unittest.TestCase):
                     "openrouter",
                     "moonshotai/kimi-k3",
                     "max",
-                    Path("/safe/codex"),
+                    FAKE_CODEX_BIN,
                     acknowledge_billing=True,
                 )
 
@@ -1292,7 +1296,7 @@ class ExternalConfiguratorTests(unittest.TestCase):
                         "openrouter",
                         "moonshotai/kimi-k3",
                         "max",
-                        Path("/safe/codex"),
+                        FAKE_CODEX_BIN,
                         acknowledge_billing=True,
                     )
             self.assertEqual(run.call_count, 1)
@@ -1380,7 +1384,7 @@ class ExternalConfiguratorTests(unittest.TestCase):
                         "openrouter",
                         "moonshotai/kimi-k3",
                         "max",
-                        Path("/safe/codex"),
+                        FAKE_CODEX_BIN,
                         acknowledge_billing=True,
                     )
 
@@ -1429,7 +1433,7 @@ class ExternalConfiguratorTests(unittest.TestCase):
                             "openrouter",
                             "moonshotai/kimi-k3",
                             "max",
-                            Path("/safe/codex"),
+                            FAKE_CODEX_BIN,
                             acknowledge_billing=True,
                         )
 

--- a/tests/test_external_configurator.py
+++ b/tests/test_external_configurator.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 import importlib.util
+import io
 import json
 import os
 from pathlib import Path
@@ -75,6 +76,18 @@ GATE0_HELP = """Run Codex non-interactively
   -o, --output-last-message <FILE>
 """
 
+INVOKE_HELP = GATE0_HELP + """  --ignore-rules
+  --disable <FEATURE>
+"""
+
+INVOKE_FEATURES_0144 = "\n".join(
+    f"{name:<36} stable             true"
+    for name in CONFIG.INVOKE_DISABLED_FEATURES
+    if name != "skill_search"
+) + "\n"
+
+INVOKE_FEATURES_CURRENT = INVOKE_FEATURES_0144 + f"{'skill_search':<36} stable             true\n"
+
 
 def gate0_help_result():
     return mock.Mock(returncode=0, stdout=GATE0_HELP, stderr="")
@@ -109,6 +122,424 @@ def mutate_user_helper(helper: Path, marker: bytes) -> None:
 
 
 class ExternalConfiguratorTests(unittest.TestCase):
+    def test_main_sanitizes_invoke_app_server_environment(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            home = Path(directory)
+            backend = FakeBackend()
+            prepared(home, backend)
+            observed: dict[str, object] = {}
+
+            class FakeAppServer:
+                def __init__(self, binary, codex_home, environment=None):
+                    observed["binary"] = binary
+                    observed["home"] = codex_home
+                    observed["environment"] = environment
+
+                def close(self):
+                    observed["closed"] = True
+
+            stdin = io.TextIOWrapper(io.BytesIO(b"bounded packet"), encoding="utf-8")
+            with mock.patch.object(
+                CONFIG.native_routing, "AppServer", FakeAppServer
+            ), mock.patch.object(
+                CONFIG.external_cli_trust, "fingerprint",
+                return_value=(Path("/real/codex"), "same"),
+            ), mock.patch.object(
+                CONFIG.external_cli_trust, "version", return_value="codex 0.144.1"
+            ), mock.patch.object(
+                CONFIG.external_cli_trust, "sanitized_environment",
+                return_value={"PATH": "/safe/bin", "KEEP": "yes"},
+            ) as sanitized, mock.patch.object(
+                CONFIG, "invoke_role",
+                return_value={"role": "researcher", "output": "safe"},
+            ) as invoke, mock.patch.object(CONFIG.sys, "stdin", stdin), mock.patch.dict(
+                os.environ, {"OPENROUTER_API_KEY": "sentinel-app-server-secret"}
+            ):
+                result = CONFIG.main([
+                    "--codex-home", str(home), "--codex-bin", "/safe/codex",
+                    "invoke", "--role", "researcher", "--effort", "max",
+                ])
+            self.assertEqual(result, 0)
+            self.assertEqual(observed["binary"], Path("/real/codex"))
+            self.assertEqual(invoke.call_args.args[5], Path("/real/codex"))
+            self.assertEqual(
+                observed["environment"], {"PATH": "/safe/bin", "KEEP": "yes"}
+            )
+            self.assertNotIn(
+                "sentinel-app-server-secret", json.dumps(observed["environment"])
+            )
+            self.assertTrue(observed["closed"])
+            sanitized.assert_called_once_with()
+
+    def test_invoke_feature_catalog_omits_unadvertised_optional_control(self) -> None:
+        with mock.patch.object(
+            CONFIG.subprocess,
+            "run",
+            side_effect=[
+                mock.Mock(returncode=0, stdout=INVOKE_HELP, stderr=""),
+                mock.Mock(returncode=0, stdout=INVOKE_FEATURES_0144, stderr=""),
+            ],
+        ):
+            advertised = CONFIG._verify_invoke_cli_contract(
+                Path("/safe/codex"), cwd=Path("/safe"), environment={}
+            )
+        self.assertEqual(
+            advertised,
+            tuple(
+                name for name in CONFIG.INVOKE_DISABLED_FEATURES
+                if name != "skill_search"
+            ),
+        )
+
+    def test_invoke_feature_catalog_includes_current_control_and_fails_closed(self) -> None:
+        with mock.patch.object(
+            CONFIG.subprocess,
+            "run",
+            side_effect=[
+                mock.Mock(returncode=0, stdout=INVOKE_HELP, stderr=""),
+                mock.Mock(returncode=0, stdout=INVOKE_FEATURES_CURRENT, stderr=""),
+            ],
+        ):
+            advertised = CONFIG._verify_invoke_cli_contract(
+                Path("/safe/codex"), cwd=Path("/safe"), environment={}
+            )
+        self.assertEqual(advertised, CONFIG.INVOKE_DISABLED_FEATURES)
+
+        failures = (
+            mock.Mock(returncode=1, stdout="provider-secret", stderr="provider-secret"),
+            mock.Mock(returncode=0, stdout="malformed provider-secret", stderr=""),
+        )
+        for catalog in failures:
+            with self.subTest(returncode=catalog.returncode), mock.patch.object(
+                CONFIG.subprocess,
+                "run",
+                side_effect=[
+                    mock.Mock(returncode=0, stdout=INVOKE_HELP, stderr=""),
+                    catalog,
+                ],
+            ):
+                with self.assertRaises(CONFIG.ExternalConfigurationError) as failure:
+                    CONFIG._verify_invoke_cli_contract(
+                        Path("/safe/codex"), cwd=Path("/safe"), environment={}
+                    )
+                self.assertNotIn("provider-secret", str(failure.exception))
+
+        for missing in ("shell_tool", "multi_agent"):
+            incomplete = "\n".join(
+                line
+                for line in INVOKE_FEATURES_0144.splitlines()
+                if not line.startswith(missing)
+            ) + "\n"
+            with self.subTest(missing=missing), mock.patch.object(
+                CONFIG.subprocess,
+                "run",
+                side_effect=[
+                    mock.Mock(returncode=0, stdout=INVOKE_HELP, stderr=""),
+                    mock.Mock(returncode=0, stdout=incomplete, stderr=""),
+                ],
+            ):
+                with self.assertRaisesRegex(
+                    CONFIG.ExternalConfigurationError,
+                    "required feature controls are unavailable",
+                ):
+                    CONFIG._verify_invoke_cli_contract(
+                        Path("/safe/codex"), cwd=Path("/safe"), environment={}
+                    )
+
+    def test_invoke_rejects_packet_boundaries_before_resolution(self) -> None:
+        for packet in (b"", b"\xff", b"x" * (CONFIG.INVOKE_INPUT_MAX_BYTES + 1)):
+            with self.subTest(size=len(packet)), self.assertRaises(
+                CONFIG.ExternalConfigurationError
+            ):
+                CONFIG._decode_invoke_packet(packet)
+        exact = CONFIG._decode_invoke_packet(
+            b"x" * CONFIG.INVOKE_INPUT_MAX_BYTES
+        )
+        self.assertEqual(len(exact), CONFIG.INVOKE_INPUT_MAX_BYTES)
+
+    def test_v072_schema1_role_invokes_without_migration_and_seals_transport(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            home = Path(directory)
+            backend = FakeBackend()
+            prepared(home, backend)
+            qualify(home)
+            CONFIG.connect_role(
+                home, "researcher", "Review only the bounded packet.",
+                "openrouter", "moonshotai/kimi-k3", "max",
+            )
+            CONFIG.mark_role_ready(home, "researcher")
+            before = CONFIG.registry_path(home).read_bytes()
+            self.assertEqual(json.loads(before)["schema"], 1)
+            registry_before, _ = CONFIG.load_registry(home)
+            agent_path = Path(
+                registry_before["roles"]["researcher"]["effort_agents"]["max"]["file"]
+            )
+            agent_before = agent_path.read_bytes()
+            observed: dict[str, object] = {}
+
+            class FakeProcess:
+                returncode = 0
+                pid = 12345
+
+                def __init__(self, command, **kwargs):
+                    observed["command"] = command
+                    observed["kwargs"] = kwargs
+
+                def communicate(self, *, input, timeout):
+                    observed["prompt"] = input
+                    observed["timeout"] = timeout
+                    command = observed["command"]
+                    target = Path(command[command.index("--output-last-message") + 1])
+                    observed["config"] = (Path(observed["kwargs"]["cwd"]) / "config.toml").read_text()
+                    target.write_text("safe result", encoding="utf-8")
+                    return (None, None)
+
+                def poll(self):
+                    return self.returncode
+
+            packet = b"sentinel bounded packet"
+            def run_control(command, **kwargs):
+                if "status" in command:
+                    observed["auth_environment"] = kwargs["env"]
+                    return mock.Mock(returncode=0, stdout="configured\n", stderr="")
+                if command[-2:] == ["exec", "--help"]:
+                    return mock.Mock(returncode=0, stdout=INVOKE_HELP, stderr="")
+                if command[-2:] == ["features", "list"]:
+                    return mock.Mock(
+                        returncode=0, stdout=INVOKE_FEATURES_CURRENT, stderr=""
+                    )
+                raise AssertionError(f"unexpected subprocess: {command}")
+
+            with mock.patch.object(
+                CONFIG.external_cli_trust, "fingerprint",
+                side_effect=[(Path("/safe/codex"), "same"), (Path("/safe/codex"), "same")],
+            ), mock.patch.object(
+                CONFIG.external_cli_trust, "version", return_value="codex 1.0"
+            ), mock.patch.object(
+                CONFIG.subprocess, "run", side_effect=run_control
+            ), mock.patch.object(CONFIG.subprocess, "Popen", side_effect=FakeProcess), mock.patch.dict(
+                os.environ, {"OPENROUTER_API_KEY": "sentinel-secret-value"}
+            ):
+                result = CONFIG.invoke_role(
+                    home, "researcher", "max", packet, backend,
+                    Path("/safe/codex"), workspace=home,
+                )
+            self.assertEqual(result["output"], "safe result")
+            command = observed["command"]
+            self.assertNotIn(packet.decode(), command)
+            self.assertEqual(command[-1], "-")
+            for feature in CONFIG.INVOKE_DISABLED_FEATURES:
+                self.assertIn(["--disable", feature], [command[i:i + 2] for i in range(len(command) - 1)])
+            prompt = observed["prompt"]
+            self.assertIn(packet, prompt)
+            self.assertIn(b"Review only the bounded packet.", prompt)
+            self.assertEqual(observed["timeout"], 180)
+            kwargs = observed["kwargs"]
+            self.assertEqual(kwargs["stdout"], CONFIG.subprocess.DEVNULL)
+            self.assertEqual(kwargs["stderr"], CONFIG.subprocess.DEVNULL)
+            self.assertNotIn("OPENROUTER_API_KEY", kwargs["env"])
+            self.assertNotIn("OPENROUTER_API_KEY", observed["auth_environment"])
+            serialized = json.dumps(command) + str(observed["config"]) + json.dumps(kwargs["env"])
+            self.assertNotIn("sentinel-secret-value", serialized)
+            self.assertEqual(CONFIG.registry_path(home).read_bytes(), before)
+            self.assertEqual(agent_path.read_bytes(), agent_before)
+            self.assertFalse(CONFIG.journal_path(home).exists())
+
+    @unittest.skipUnless(os.name == "posix", "POSIX process-group cleanup")
+    def test_invoke_timeout_kills_process_group(self) -> None:
+        class TimedOutProcess:
+            returncode = None
+            pid = 4242
+
+            def communicate(self, **_kwargs):
+                raise CONFIG.subprocess.TimeoutExpired("codex", 180)
+
+            def poll(self):
+                return None
+
+            def wait(self, timeout):
+                self.returncode = -9
+                return self.returncode
+
+        with mock.patch.object(
+            CONFIG.subprocess, "Popen", return_value=TimedOutProcess()
+        ) as popen, mock.patch.object(CONFIG.os, "killpg") as killpg:
+            with self.assertRaisesRegex(CONFIG.ExternalConfigurationError, "timed out"):
+                CONFIG._run_invoke_process(
+                    ["/safe/codex"], cwd=Path("/safe"), environment={}, prompt=b"packet"
+                )
+        self.assertTrue(popen.call_args.kwargs["start_new_session"])
+        killpg.assert_called_once_with(4242, CONFIG.signal.SIGKILL)
+
+    def test_windows_cleanup_breaks_group_then_kills_direct_child(self) -> None:
+        process = mock.Mock()
+        process.poll.return_value = None
+        process.wait.side_effect = [CONFIG.subprocess.TimeoutExpired("codex", 2), 1]
+        with mock.patch.object(CONFIG.os, "name", "nt"), mock.patch.object(
+            CONFIG.signal, "CTRL_BREAK_EVENT", 999, create=True
+        ):
+            CONFIG._terminate_invoke_process(process)
+        process.send_signal.assert_called_once_with(999)
+        process.kill.assert_called_once_with()
+        self.assertEqual(process.wait.call_args_list, [mock.call(timeout=2), mock.call(timeout=5)])
+
+    @unittest.skipUnless(os.name == "posix", "POSIX process-group cleanup")
+    def test_invoke_keyboard_interrupt_always_cleans_up_and_propagates(self) -> None:
+        process = mock.Mock()
+        process.pid = 4343
+        process.poll.return_value = None
+        process.communicate.side_effect = KeyboardInterrupt()
+        with mock.patch.object(
+            CONFIG.subprocess, "Popen", return_value=process
+        ), mock.patch.object(CONFIG.os, "killpg") as killpg:
+            with self.assertRaises(KeyboardInterrupt):
+                CONFIG._run_invoke_process(
+                    ["/safe/codex"], cwd=Path("/safe"), environment={}, prompt=b"packet"
+                )
+        killpg.assert_called_once_with(4343, CONFIG.signal.SIGKILL)
+        process.wait.assert_called_once_with(timeout=5)
+
+    def test_invoke_rejects_binary_replacement_before_launch(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            home = Path(directory)
+            backend = FakeBackend()
+            prepared(home, backend)
+            qualify(home)
+            CONFIG.connect_role(
+                home, "researcher", "Review only the bounded packet.",
+                "openrouter", "moonshotai/kimi-k3", "max",
+            )
+            CONFIG.mark_role_ready(home, "researcher")
+            with mock.patch.object(
+                CONFIG.external_credentials, "credential_ready", return_value=True
+            ), self.assertRaisesRegex(
+                CONFIG.ExternalConfigurationError, "absolute --codex-bin"
+            ):
+                CONFIG.invoke_role(
+                    home, "researcher", "max", b"packet", backend,
+                    Path("codex"), workspace=home,
+                )
+            with mock.patch.object(
+                CONFIG.external_credentials, "credential_ready", return_value=True
+            ), mock.patch.object(
+                CONFIG.external_cli_trust, "fingerprint",
+                side_effect=[(Path("/safe/codex"), "before"), (Path("/safe/codex"), "after")],
+            ), mock.patch.object(
+                CONFIG.external_cli_trust, "version", return_value="codex 1.0"
+            ), mock.patch.object(
+                CONFIG.subprocess, "run", side_effect=[
+                    mock.Mock(returncode=0, stdout=INVOKE_HELP, stderr=""),
+                    mock.Mock(returncode=0, stdout=INVOKE_FEATURES_0144, stderr=""),
+                ]
+            ), mock.patch.object(CONFIG.subprocess, "Popen") as popen:
+                with self.assertRaisesRegex(CONFIG.ExternalConfigurationError, "CLI_CHANGED"):
+                    CONFIG.invoke_role(
+                        home, "researcher", "max", b"packet", backend,
+                        Path("/safe/codex"), workspace=home,
+                    )
+            popen.assert_not_called()
+
+    def test_invoke_nonzero_exit_redacts_provider_output(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            home = Path(directory)
+            backend = FakeBackend()
+            prepared(home, backend)
+            qualify(home)
+            CONFIG.connect_role(
+                home, "researcher", "Review only the bounded packet.",
+                "openrouter", "moonshotai/kimi-k3", "max",
+            )
+            CONFIG.mark_role_ready(home, "researcher")
+            with mock.patch.object(
+                CONFIG.external_credentials, "credential_ready", return_value=True
+            ), mock.patch.object(
+                CONFIG.external_cli_trust, "fingerprint",
+                side_effect=[(Path("/safe/codex"), "same"), (Path("/safe/codex"), "same")],
+            ), mock.patch.object(
+                CONFIG.external_cli_trust, "version", return_value="codex 1.0"
+            ), mock.patch.object(
+                CONFIG, "_verify_invoke_cli_contract"
+            ), mock.patch.object(
+                CONFIG, "_run_invoke_process", return_value=9
+            ):
+                with self.assertRaises(CONFIG.ExternalConfigurationError) as failure:
+                    CONFIG.invoke_role(
+                        home, "researcher", "max", b"sentinel-provider-output",
+                        backend, Path("/safe/codex"), workspace=home,
+                    )
+            self.assertIn("exit 9", str(failure.exception))
+            self.assertNotIn("sentinel-provider-output", str(failure.exception))
+
+    def test_invoke_rejects_registry_dequalification_race_before_model_call(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            home = Path(directory)
+            backend = FakeBackend()
+            prepared(home, backend)
+            qualify(home)
+            CONFIG.connect_role(
+                home, "researcher", "Review only the bounded packet.",
+                "openrouter", "moonshotai/kimi-k3", "max",
+            )
+            CONFIG.mark_role_ready(home, "researcher")
+            original_load = CONFIG.load_registry
+            calls = 0
+
+            def racing_load(selected_home):
+                nonlocal calls
+                calls += 1
+                if calls == 2:
+                    changed, digest = original_load(selected_home)
+                    changed["providers"]["openrouter"]["state"] = "AUTH_REQUIRED"
+                    changed["providers"]["openrouter"]["qualified"] = False
+                    CONFIG.external_registry.write_registry(
+                        CONFIG.registry_path(selected_home), changed,
+                        expected_sha256=digest,
+                    )
+                return original_load(selected_home)
+
+            with mock.patch.object(
+                CONFIG, "load_registry", side_effect=racing_load
+            ), mock.patch.object(
+                CONFIG.external_credentials, "credential_ready", return_value=True
+            ), mock.patch.object(
+                CONFIG.external_cli_trust, "fingerprint",
+                side_effect=[(Path("/safe/codex"), "same"), (Path("/safe/codex"), "same")],
+            ), mock.patch.object(
+                CONFIG.external_cli_trust, "version", return_value="codex 0.144.1"
+            ), mock.patch.object(
+                CONFIG, "_verify_invoke_cli_contract", return_value=()
+            ), mock.patch.object(CONFIG, "_run_invoke_process") as run:
+                with self.assertRaisesRegex(
+                    CONFIG.ExternalConfigurationError, "registry changed"
+                ):
+                    CONFIG.invoke_role(
+                        home, "researcher", "max", b"packet", backend,
+                        Path("/safe/codex"), workspace=home,
+                    )
+            run.assert_not_called()
+
+    def test_invoke_output_exact_limit_and_plus_one(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            exact = root / "exact"
+            exact.write_bytes(b"x" * CONFIG.INVOKE_OUTPUT_MAX_BYTES)
+            self.assertEqual(len(CONFIG._read_invoke_last_message(exact)), CONFIG.INVOKE_OUTPUT_MAX_BYTES)
+            oversized = root / "oversized"
+            oversized.write_bytes(b"x" * (CONFIG.INVOKE_OUTPUT_MAX_BYTES + 1))
+            with self.assertRaisesRegex(CONFIG.ExternalConfigurationError, "oversized"):
+                CONFIG._read_invoke_last_message(oversized)
+
+            invalid = root / "invalid"
+            invalid.write_bytes(b"\xff")
+            with self.assertRaises(CONFIG.ExternalConfigurationError) as failure:
+                CONFIG._read_invoke_last_message(invalid)
+            self.assertNotIn("\\xff", str(failure.exception))
+
+            linked = root / "linked"
+            os.link(exact, linked)
+            with self.assertRaisesRegex(CONFIG.ExternalConfigurationError, "unsafe"):
+                CONFIG._read_invoke_last_message(linked)
+
     def test_prepare_is_additive_nonsecret_and_returns_external_auth_command(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             home = Path(directory)

--- a/tests/test_external_credentials.py
+++ b/tests/test_external_credentials.py
@@ -14,6 +14,7 @@ import uuid
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / "plugins/codex-orchestration/skills/codex-orchestration/scripts"
+sys.path.insert(0, str(SCRIPTS))
 
 
 def load(name: str):
@@ -120,6 +121,28 @@ class ExternalCredentialTests(unittest.TestCase):
         self.assertEqual(
             run.call_args.args[0],
             [*expected_prefix, "status", "--provider", "openrouter"],
+        )
+        with mock.patch.dict(
+            os.environ, {"OPENROUTER_API_KEY": "sentinel-auth-readiness-secret"}
+        ), mock.patch.object(
+            CREDENTIALS.external_cli_trust,
+            "sanitized_environment",
+            return_value={"PATH": "/safe/bin"},
+        ), mock.patch.object(
+            CREDENTIALS.subprocess, "run", return_value=completed
+        ) as sanitized_run:
+            self.assertTrue(
+                CREDENTIALS.credential_ready(
+                    helper,
+                    "openrouter",
+                    platform="win32",
+                    python_executable=interpreter,
+                )
+            )
+        self.assertEqual(sanitized_run.call_args.kwargs["env"], {"PATH": "/safe/bin"})
+        self.assertNotIn(
+            "sentinel-auth-readiness-secret",
+            repr(sanitized_run.call_args.kwargs["env"]),
         )
 
     def test_stable_helper_verification_detects_byte_drift(self) -> None:

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -205,7 +205,7 @@ class PackagingTests(unittest.TestCase):
 
         self.assertEqual(manifest["name"], "codex-orchestration")
         self.assertEqual(manifest["skills"], "./skills/")
-        self.assertEqual(manifest["version"], "0.7.2")
+        self.assertEqual(manifest["version"], "0.8.0")
         self.assertEqual(manifest["mcpServers"], "./.mcp.json")
         self.assertRegex(
             manifest["version"],
@@ -228,7 +228,7 @@ class PackagingTests(unittest.TestCase):
         self.assertFalse((SKILL_ROOT / "scripts" / "update_plugin.py").exists())
         self.assertIn("config/batchWrite", native.read_text(encoding="utf-8"))
         self.assertIn('"--repair"', native.read_text(encoding="utf-8"))
-        self.assertIn('"version": "0.7.2"', native.read_text(encoding="utf-8"))
+        self.assertIn('"version": "0.8.0"', native.read_text(encoding="utf-8"))
         self.assertIn("validate_routing_state", routing_state.read_text(encoding="utf-8"))
         self.assertIn("Standalone custom agent", custom.read_text(encoding="utf-8"))
 
@@ -332,7 +332,7 @@ class PackagingTests(unittest.TestCase):
         self.assertIn("@openai/codex@0.144.1", workflow)
         smoke_text = smoke.read_text(encoding="utf-8")
         self.assertIn('OLD_VERSION = "0.5.0"', smoke_text)
-        self.assertIn('NEW_VERSION = "0.7.2"', smoke_text)
+        self.assertIn('NEW_VERSION = "0.8.0"', smoke_text)
         self.assertIn("old Advisor-only cache unexpectedly supports Planner", smoke_text)
         self.assertIn("Upgraded installed skill is missing Planner contract", smoke_text)
         self.assertIn("reused the Advisor-only 0.5.0 cache directory", smoke_text)

--- a/tests/test_release_check.py
+++ b/tests/test_release_check.py
@@ -69,7 +69,7 @@ class TempRepository:
 
 class ReleaseCheckTests(unittest.TestCase):
     def test_checkout_release_metadata_is_consistent(self) -> None:
-        self.assertEqual(RELEASE.run_check(REPO_ROOT, require_tag=False), "0.7.2")
+        self.assertEqual(RELEASE.run_check(REPO_ROOT, require_tag=False), "0.8.0")
 
     def test_unreleased_checkout_is_not_tag_ready(self) -> None:
         with self.assertRaisesRegex(RELEASE.ReleaseCheckError, "not tagged"):

--- a/tests/test_skill_contract.py
+++ b/tests/test_skill_contract.py
@@ -82,7 +82,7 @@ Executor — GPT-5.6 Sol high: Activated
         self.assertIn("one plain line per explicitly supplied model-bearing seat", SKILL)
         self.assertIn("preserve the user's seat order", SKILL)
         self.assertIn("Do not print omitted, `none`, or implicit-root seats", SKILL)
-        self.assertIn("Use `Activated` only after that exact route is ready", SKILL)
+        self.assertIn("Use `Activated` only after that exact route is locally ready", SKILL)
         self.assertIn("lifecycle state and next action instead of `Activated`", SKILL)
         self.assertIn(
             "activation confirmation preserves the supplied `Fable 5` label", SKILL
@@ -110,7 +110,10 @@ Executor — GPT-5.6 Sol high: Activated
         self.assertIn("role `designer`", SKILL)
         self.assertIn("preview and apply `connect`", SKILL)
         self.assertIn("RESTART_REQUIRED", SKILL)
-        self.assertIn("run `ready` and then `resolve`", SKILL)
+        self.assertIn("then use\n  sealed `invoke`", SKILL)
+        self.assertIn("Never execute an External Model role with `agents.spawn_agent`", SKILL)
+        self.assertIn("`resolve` remains a read-only diagnostic", SKILL)
+        self.assertNotIn("delegate only to the returned agent name", SKILL)
         self.assertIn("do not report the requested external seat as unavailable", SKILL)
         self.assertIn("never authorizes Gate 0 billing", SKILL)
         self.assertIn("Never overwrite, repair, disconnect, or substitute", SKILL)
@@ -135,7 +138,10 @@ Executor — GPT-5.6 Sol high: Activated
         self.assertIn("`supported`", SKILL)
         self.assertIn("`configured`", SKILL)
         self.assertIn("`callable now`", SKILL)
+        self.assertIn("`locally ready`", SKILL)
         self.assertIn("read-only `resolve` succeeds", SKILL)
+        self.assertIn("a sealed `invoke` has successfully attested", SKILL)
+        self.assertIn("Read-only discovery must report this as unconfirmed", SKILL)
         self.assertIn("never authorizes configuration, credentials, or spend", README)
 
     def test_plugin_update_is_canonical_non_destructive_and_restart_bound(self) -> None:


### PR DESCRIPTION
## Change summary

Kimi K3 Designer could be locally READY and resolve exactly while Desktop native subagent calls failed with provider HTTP 400 (`Server tool request failed`). The incompatible layer was the native spawn-agent/server-tool transport, not the OpenRouter tuple or stored authentication.

This release routes audited External Model roles through a sealed direct `codex exec` invocation. It pins and re-attests the active binary, feature catalog, registry snapshot, provider configuration, helper, and managed agent bytes; sanitizes inherited environments; disables model-facing tools; bounds stdin and output; and cleans up process groups on timeout or interruption. Native GPT routing, root selection, chat/session state, and unrelated provider configuration are unchanged.

## Validation

- `python3 scripts/preflight.py full`: compile, Ruff, focused tests, release identity, full test suite, and lifecycle smoke passed; hosted Python 3.11/3.13, Windows portability, and CodeQL remain required CI gates.
- Independent final-tree verification passed all nine acceptance criteria; 355 tests passed with five platform skips.
- Hosted Windows CI exposed POSIX-only fake test paths; a62d3ce replaces them with OS-native absolute tempdir paths. All 35 focused tests and the full local preflight pass, and a fresh independent exact-SHA review found no findings.
- Live bounded Kimi route marker returned `KIMI_ROUTE_OK`.
- Live representative synthetic Designer brief returned the required eight-section handoff through the direct route.
- Final installed-state audit reported provider READY, authentication ready, exact provider config, qualified tuple, exact role integrity, and exact Designer/OpenRouter/Kimi/max resolution.

## Review attestation

<!-- codex-review-attestation:start -->
{
  "schema": 1,
  "risk_tier": "security-state",
  "repository": "Cjbuilds/Codex-Orchestration",
  "base_branch": "main",
  "reviewed_head_sha": "a62d3ce7d371bf351aec35395d6c68c5bc9dc090",
  "reviewer_identity": "Independent verification worker Halley",
  "reviewer_route": "gpt-5.6-sol high verification_worker",
  "threat_model": {
    "assets": [
      "OpenRouter bearer confidentiality and command-backed helper integrity",
      "Exact managed registry, provider configuration, and agent role bytes",
      "Bounded Designer packets and final-message output artifacts"
    ],
    "threats": [
      "Ambient credentials or provider output could leak across the invocation boundary",
      "Binary, registry, helper, or agent files could change between validation and launch",
      "Malformed artifacts, timeouts, or interrupts could bypass checks or leave provider processes running"
    ],
    "mitigations": [
      "Sanitized App Server, credential-helper, and invocation environments preserve only required non-secret context",
      "Exact binary fingerprints, feature catalogs, registry digests, and managed file hashes are rechecked before launch",
      "Packets travel only on bounded stdin and provider stdout and stderr remain suppressed",
      "Only regular single-link bounded UTF-8 final-message artifacts are accepted",
      "Process groups are terminated on timeout and BaseException cleanup covers interruption paths"
    ]
  },
  "negative_test_evidence": [
    {
      "category": "regression",
      "evidence": "Live native spawn-agent HTTP 400 reproduction is replaced by successful sealed marker and representative Designer handoff checks"
    },
    {
      "category": "negative",
      "evidence": "Tests reject missing mandatory CLI features, changed binaries and registries, unsafe output artifacts, oversized packets, nonzero exits, and timeouts"
    },
    {
      "category": "malformed",
      "evidence": "Tests reject malformed feature catalogs, registry data, credential results, symlinks, hardlinks, invalid UTF-8, and unexpected final-message shapes"
    }
  ],
  "findings_disposition": "All material verifier findings were incorporated and independently reverified; no unresolved security or routing findings remain"
}
<!-- codex-review-attestation:end -->