### PR TITLE
Isolate Fable from inherited Anthropic routing

### DIFF
--- a/plugins/codex-orchestration/skills/codex-orchestration/scripts/fable_advisor_mcp.py
+++ b/plugins/codex-orchestration/skills/codex-orchestration/scripts/fable_advisor_mcp.py
@@ -39,6 +39,10 @@ MAX_INPUT_CHARS = 200_000
 SENSITIVE_ENV = {
     "ANTHROPIC_API_KEY",
     "ANTHROPIC_AUTH_TOKEN",
+    "ANTHROPIC_BASE_URL",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL",
     "CLAUDE_CODE_USE_BEDROCK",
     "CLAUDE_CODE_USE_VERTEX",
     "CLAUDE_CODE_USE_FOUNDRY",
@@ -598,6 +602,10 @@ def handle_request(request: dict[str, Any]) -> dict[str, Any] | None:
 
 
 def main() -> int:
+    for stream in (sys.stdin, sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if callable(reconfigure):
+            reconfigure(encoding="utf-8", errors="strict")
     for line in sys.stdin:
         try:
             request = json.loads(line)

--- a/tests/test_fable_advisor_mcp.py
+++ b/tests/test_fable_advisor_mcp.py
@@ -164,6 +164,10 @@ class FableAdvisorMcpTests(unittest.TestCase):
             "CODEX_HOME": str(self.home),
             "ANTHROPIC_API_KEY": "must-not-leak",
             "ANTHROPIC_AUTH_TOKEN": "must-not-leak",
+            "ANTHROPIC_BASE_URL": "https://must-not-be-used.invalid",
+            "ANTHROPIC_DEFAULT_HAIKU_MODEL": "must-not-be-used",
+            "ANTHROPIC_DEFAULT_OPUS_MODEL": "must-not-be-used",
+            "ANTHROPIC_DEFAULT_SONNET_MODEL": "must-not-be-used",
             "CLAUDE_CODE_USE_BEDROCK": "1",
         }
         calls: list[tuple[list[str], dict[str, object]]] = []
@@ -696,6 +700,31 @@ class FableAdvisorMcpTests(unittest.TestCase):
             with self.subTest(effort=effort):
                 self.write_state(advisor=self.route(effort))
                 self.assertEqual(FABLE.load_fable_route(self.home)["effort"], effort)
+
+    def test_main_forces_utf8_on_mcp_stdio(self) -> None:
+        class EmptyStream:
+            def __init__(self) -> None:
+                self.reconfigure_calls: list[dict[str, str]] = []
+
+            def reconfigure(self, **kwargs: str) -> None:
+                self.reconfigure_calls.append(kwargs)
+
+            def __iter__(self) -> object:
+                return iter(())
+
+        streams = [EmptyStream(), EmptyStream(), EmptyStream()]
+        with (
+            mock.patch.object(FABLE.sys, "stdin", streams[0]),
+            mock.patch.object(FABLE.sys, "stdout", streams[1]),
+            mock.patch.object(FABLE.sys, "stderr", streams[2]),
+        ):
+            self.assertEqual(FABLE.main(), 0)
+
+        for stream in streams:
+            self.assertEqual(
+                stream.reconfigure_calls,
+                [{"encoding": "utf-8", "errors": "strict"}],
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- remove inherited Anthropic endpoint and default-model overrides from the sealed first-party Fable subprocess environment
- force UTF-8 on the MCP server's stdin, stdout, and stderr streams
- add regression coverage for environment isolation and MCP stdio configuration

## Relationship to #11

This PR complements #11 and intentionally does not duplicate its subprocess encoding changes. PR #11 owns UTF-8 decoding for Claude/Codex subprocess calls across the plugin. This PR covers two separate gaps found while reproducing the same user-visible failure:

1. inherited routing variables could redirect the nominal first-party Fable call even though authentication status remained healthy;
2. the MCP server's own JSON-RPC stdio streams still inherited the Windows locale.

## Root cause

Codex can inherit `ANTHROPIC_BASE_URL` and `ANTHROPIC_DEFAULT_*_MODEL` variables. The Fable bridge removed authentication and cloud-provider overrides but preserved these routing variables. As a result, `claude auth status` reported a ready first-party login while the actual Planner call exited through an unintended route.

Separately, Python starts with CP932 stdio on a Japanese Windows locale unless UTF-8 mode is enabled. Explicitly reconfiguring the MCP streams protects JSON-RPC requests and responses independently of how the launcher was started.

## Validation

- `python3 -X utf8 -m unittest tests.test_fable_advisor_mcp tests.test_packaging` — 39 tests passed
- plugin validation passed with `validate_plugin.py`
- live Claude Fable 5 Japanese round-trip succeeded with inherited routing variables present, returned `PLAN_DRAFT`, confirmed the pinned model, and preserved the complete sentinel string

The complete test suite is not used as a Windows gate because existing unrelated tests depend on Unix-style fake executables, symlink privileges, and filesystem metadata behavior.

Related: #11
