### PR TITLE
feat: add Claude Opus 5 subscription routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.9.0 — Unreleased
+
+- Add Claude Opus 5 as a sealed first-party subscription Planner or Advisor
+  through Claude Code 2.1.219 or newer, with exact effort validation and
+  fail-closed runtime model identity checks.
+- Preserve Fable 5 and routing-state schemas 1–4 while adding schema/policy 5
+  for Opus. Existing compatibility launcher IDs remain disabled until selected.
+- Require a full managed-policy disable before replacing or moving an Opus
+  subscription seat, so setup never silently changes an existing Claude route.
+
 ## 0.8.0 — Unreleased
 
 - Replace READY External Model execution through Desktop native agents with a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
   for Opus. Existing compatibility launcher IDs remain disabled until selected.
 - Require a full managed-policy disable before replacing or moving an Opus
   subscription seat, so setup never silently changes an existing Claude route.
+- Harden both bundled Claude subprocesses to a minimal platform environment,
+  retain only canonical home discovery for first-party login, and exclude
+  credential, routing, endpoint, transport, and telemetry override families.
+- Add protected macOS/Windows portability coverage for native routing, saved
+  routing state, and the shared Fable/Opus bridge, plus mandatory live Opus
+  Planner and Advisor release qualification.
 
 ## 0.8.0 — Unreleased
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Codex Orchestration
 
-Bring models like Claude Fable 5 into Codex, give each model a role, and let Codex coordinate the work.
+Bring models like Claude Fable 5 and Claude Opus 5 into Codex, give each model a role, and let Codex coordinate the work.
 
 ## What is it?
 
@@ -53,7 +53,7 @@ Planner and Advisor can work through several revisions. Codex stops as soon as t
 
 ## Why use it?
 
-- Bring Fable 5 or another compatible model into Codex.
+- Bring Fable 5, Opus 5, or another compatible model into Codex.
 - Use different models for planning, review, design, and implementation.
 - Get a stronger plan before code changes begin.
 - Run independent implementation work in parallel—up to 2x faster on suitable tasks.
@@ -90,11 +90,21 @@ Or let your current Codex model plan and use Fable 5 only as Advisor:
 /codex-orchestration setup advisor: Claude Fable 5 High, executor: GPT-5.6 Luna Extra High
 ```
 
+Or use Claude Opus 5 as the Advisor:
+
+```text
+/codex-orchestration setup advisor: Claude Opus 5 XHigh, executor: GPT-5.6 Luna Extra High
+```
+
 After setup, start another new task and use Codex normally. The saved workflow applies automatically.
 
 Fable defaults to **High**. You can choose **Low**, **Medium**, **High**, **XHigh**, or **Max**. **Ultra** is accepted as an alias for Max because Claude Code does not expose a separate Ultra effort.
 
-Fable 5 uses the official Claude Code CLI and a compatible first-party Claude login. You do not need to add an Anthropic API key to Codex.
+Opus 5 also defaults to **High** and supports the same five exact effort values,
+but not the Fable-only **Ultra** alias. Opus requires Claude Code **2.1.219 or
+newer**.
+
+Fable 5 and Opus 5 use the official Claude Code CLI and a compatible first-party Claude login. You do not need to add an Anthropic API key to Codex.
 
 ## Choose your roles
 
@@ -180,10 +190,13 @@ the explicitly billable isolated Gate 0. New providers or subscription CLIs stil
 require a reviewed bundled manifest and adapter; arbitrary URLs and arbitrary local
 CLIs are not auto-trusted.
 
-Fable 5 remains the sealed subscription exception and can be used directly as
-Planner or Advisor through first-party Claude login. See the
+Fable 5 and Opus 5 are sealed subscription exceptions and can be used directly
+as Planner or Advisor through first-party Claude login. Only one bundled Claude
+subscription seat may be configured at a time. See the
 [External Models reference](plugins/codex-orchestration/skills/codex-orchestration/references/external-models.md)
 for commands, lifecycle states, extension rules, and threat boundaries.
+Fable 5 is the bundled cross-provider exception retained for compatibility;
+Opus 5 is the second sealed bundled exception added in version 0.9.0.
 
 Models already available through Codex can still become ordinary user-owned roles:
 
@@ -192,7 +205,7 @@ Models already available through Codex can still become ordinary user-owned role
 ```
 
 Project roles live in `.codex/agents/`; personal roles live in
-`~/.codex/agents/`. An unbundled cross-provider model still requires an existing authenticated, compatible provider. Fable 5 is the bundled cross-provider exception.
+`~/.codex/agents/`. An unbundled cross-provider model still requires an existing authenticated, compatible provider. Fable 5 and Opus 5 are the bundled cross-provider exceptions.
 
 ## Use it with Codex Goals
 
@@ -206,6 +219,7 @@ Create a Codex Goal normally, then tell Codex to use the saved workflow until th
 /codex-orchestration repair
 /codex-orchestration --update
 /codex-orchestration setup planner: Claude Fable 5 High, advisor: GPT-5.6 Sol High, designer: GPT-5.6 Terra High, executor: GPT-5.6 Luna Extra High
+/codex-orchestration setup advisor: Claude Opus 5 XHigh, executor: GPT-5.6 Luna Extra High
 /codex-orchestration Planner: Claude Fable 5 High, Designer: Kimi K3
 /codex-orchestration disable
 ```
@@ -222,6 +236,12 @@ unavailable. The seat label never authorizes credential entry or a paid probe.
 
 `disable` restores the routing values that existed before setup. It does not delete user-owned custom roles.
 
+An Opus seat can be updated in place on the same Planner or Advisor seat,
+including its effort. Replacing Opus with Fable, replacing Fable with Opus,
+moving Opus between Planner and Advisor, or removing Opus through another setup
+requires `/codex-orchestration disable` first, followed by one fresh complete
+setup. This prevents silent subscription route replacement.
+
 `repair` is narrower than setup or disable. When status reports that plugin-managed
 mode/usage hints conflict with otherwise intact saved state, it can restore only
 those saved hint bytes after a dry run. It refuses missing state, unmarked text,
@@ -234,7 +254,7 @@ credentials, chats, or sessions.
 - Codex remains the root orchestrator and final authority.
 - Planner, Advisor, and Designer report only to Codex; they do not contact one another or Executors directly.
 - Designer may edit only design artifacts explicitly delegated by Codex; it does not change implementation code or release Executor.
-- The workflow reserves Fable planning tools for the root Codex model by policy. Current MCP calls do not identify their caller, so this caller boundary is instruction-enforced; the bridge itself still disables tools, edits, and session persistence.
+- The workflow reserves bundled Claude planning tools for the root Codex model by policy. Current MCP calls do not identify their caller, so this caller boundary is instruction-enforced; the bridge itself still disables tools, edits, and session persistence.
 - Advisor approval is a planning gate, not a guarantee that implementation will succeed.
 - Direct model routes inherit the root provider. Audited external adapters use
   provider-pinned personal role agents and never enter the model picker.
@@ -277,7 +297,7 @@ or newer** adds `--update`, routing repair, and Designer; version **0.7.1 or new
 lets the natural `Designer: Kimi K3` label enter the External Model lifecycle;
 version **0.7.2 or newer** uses the concise per-role activation confirmation;
 version **0.8.0 or newer** uses sealed direct CLI invocation for READY External
-Model roles.
+Model roles; version **0.9.0 or newer** adds Claude Opus 5 subscription routing.
 Confirm with
 `codex plugin list --json`, then restart Codex Desktop and start a new task.
 

--- a/README.md
+++ b/README.md
@@ -190,13 +190,20 @@ the explicitly billable isolated Gate 0. New providers or subscription CLIs stil
 require a reviewed bundled manifest and adapter; arbitrary URLs and arbitrary local
 CLIs are not auto-trusted.
 
-Fable 5 and Opus 5 are sealed subscription exceptions and can be used directly
-as Planner or Advisor through first-party Claude login. Only one bundled Claude
-subscription seat may be configured at a time. See the
+Fable 5 and Opus 5 are sealed subscription exceptions available only as Planner
+or Advisor through first-party Claude login. Only one bundled Claude subscription
+seat may be configured at a time; neither model is a Designer, Executor, general
+custom role, or Desktop picker entry. See the
 [External Models reference](plugins/codex-orchestration/skills/codex-orchestration/references/external-models.md)
 for commands, lifecycle states, extension rules, and threat boundaries.
 Fable 5 is the bundled cross-provider exception retained for compatibility;
 Opus 5 is the second sealed bundled exception added in version 0.9.0.
+
+The bundled Claude bridge starts each authentication and model subprocess with
+only a minimal platform environment. It preserves canonical `HOME` on POSIX or
+`USERPROFILE` on Windows so the official CLI can find the user's first-party login,
+but it does not inherit credential, config-redirection, provider/model/effort,
+endpoint/gateway, proxy/CA/mTLS, or telemetry override families.
 
 Models already available through Codex can still become ordinary user-owned roles:
 
@@ -245,9 +252,9 @@ setup. This prevents silent subscription route replacement.
 `repair` is narrower than setup or disable. When status reports that plugin-managed
 mode/usage hints conflict with otherwise intact saved state, it can restore only
 those saved hint bytes after a dry run. It refuses missing state, unmarked text,
-namespace or spawn-metadata drift, Fable launcher drift, concurrent edits, and
-higher-layer overrides. It does not rewrite restore history or touch authentication,
-credentials, chats, or sessions.
+namespace or spawn-metadata drift, bundled Claude launcher drift, concurrent edits,
+and higher-layer overrides. It does not rewrite restore history or touch
+authentication, credentials, chats, or sessions.
 
 ## Important limits
 
@@ -280,10 +287,10 @@ the plugin or touch routing, credentials, chats, sessions, or the model picker.
 Restart Codex Desktop and start a new task after an update; the task that launched
 the updater keeps its already loaded instructions.
 
-If a Fable call fails in the task that performed an update but fresh status reports
-`first-party login ready`, the login is healthy and the already loaded MCP bridge is
-stale. Fully quit and reopen Codex, then start a new task; do not re-authenticate
-solely for that stale-bridge condition.
+If a bundled Claude call fails in the task that performed an update but fresh
+status reports `first-party login ready`, the login is healthy and the already
+loaded MCP bridge is stale. Fully quit and reopen Codex, then start a new task; do
+not re-authenticate solely for that stale-bridge condition.
 
 To move from version 0.6.x or older to 0.7.0, run the native Codex commands once:
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,10 +12,11 @@
 
 4. From a new Desktop task, verify one direct same-provider child route. Record `route accepted`; record `used and confirmed` only if the client exposes effective child model/provider/effort metadata.
 5. If Claude Fable 5 is included in the release, verify both supported seat paths from a first-party Claude login: Fable Planner `create_plan`/`revise_plan` with a different Advisor, and Fable Advisor `review_plan` with root planning. Confirm the pinned primary model, exact allowlisted helper set reported by runtime metadata, effort, status, the bounded approval loop, and disable/restore. An unknown helper model is a release failure, not an implicit allowlist expansion.
-6. Merge only after every protected check passes.
-7. Create a signed annotated tag named `v<manifest-version>` at the reviewed merge commit.
-8. Re-run `python3 scripts/preflight.py full` on the tagged tree, then run `python3 scripts/release_check.py --require-tag` and publish a GitHub release from that tag using the matching changelog section.
-9. Upgrade from the previous public version in a clean Codex home, reinstall the plugin, and verify the installed version and skill contents changed before starting a new task. Then verify setup, `status --require-effective`, and disable.
+6. If Claude Opus 5 is included in the release, separately qualify both live seat paths from a first-party Claude login. Run Opus Planner `create_plan` and force a reviewed `PLAN_REVISE` round through `revise_plan` with a distinct Advisor; then run Opus Advisor `review_plan` with root planning. For both paths confirm the pinned `claude-opus-5` primary, the primary-only allowed-runtime-model policy, the configured effort, no tools and no session persistence, `status --require-effective`, the five-review approval bound, and disable/restore. Any helper or other runtime model is a release failure. This is a manual release qualification; local preflight must never invoke Opus.
+7. Merge only after every protected check passes.
+8. Create a signed annotated tag named `v<manifest-version>` at the reviewed merge commit.
+9. Re-run `python3 scripts/preflight.py full` on the tagged tree, then run `python3 scripts/release_check.py --require-tag` and publish a GitHub release from that tag using the matching changelog section.
+10. Upgrade from the previous public version in a clean Codex home, reinstall the plugin, and verify the installed version and skill contents changed before starting a new task. Then verify setup, `status --require-effective`, and disable.
 
 Never move a published release tag. If a release is bad, fix forward with a new version and retain the old tag as provenance.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -72,25 +72,30 @@ identity. Native providers remain
 `ROUTE_ACCEPTED` unless the host exposes mechanical provider/model metadata; model
 self-report is never confirmation.
 
-Native setup/status/repair/disable and Fable authorization retain their full-state
+Native setup/status/repair/disable and bundled Claude authorization retain their full-state
 validators. Repair is allowed only when valid saved state exists, both live hint
-strings retain the ownership marker, and namespace, spawn metadata, Fable launcher
-enablement, scalar-conversion shape, and all other managed values still match. It
+strings retain the ownership marker, and namespace, spawn metadata, historical Fable
+launcher enablement, scalar-conversion shape, and all other managed values still match. It
 restores only drifted mode/usage bytes through App Server compare-and-swap, verifies
 user and effective readback, rolls back on an override, preserves a concurrent edit,
 detects concurrent saved-state replacement without overwriting it, and never changes
 restore state, authentication, credentials, chats, or sessions.
-The bundled Fable Planner/Advisor bridge disables tools and session
-persistence, strips provider override credentials, and requires runtime usage
-metadata to contain the pinned Fable primary plus only explicitly allowlisted Claude
-Code helpers. The managed workflow authorizes only root to call planning tools, but
-MCP does not provide caller identity; that caller boundary remains
-instruction-enforced rather than server-authenticated.
+The bundled Fable/Opus Planner-or-Advisor bridge gives authentication and model
+subprocesses only a minimal platform environment, preserving home discovery for the
+official CLI while excluding credential, config-redirection, provider/model/effort,
+endpoint/gateway, proxy/CA/mTLS, and telemetry override families. It disables tools
+and session persistence and requires structurally valid runtime usage metadata to
+contain the pinned primary plus only the exact helper allowlist for that model. The
+managed workflow authorizes only root to call planning tools, but MCP does not
+provide caller identity; that caller boundary remains instruction-enforced rather
+than server-authenticated.
 
-Routing schema/policy version 4 adds the optional Designer field while retaining
-strict validation for schemas 1–3. Legacy schemas cannot smuggle a Designer key,
-and persistent Designer accepts only a direct same-provider model, never the
-privileged Fable MCP route or a project-shadowable unqualified agent name.
+Routing schema/policy version 5 adds the sealed Opus subscription route while
+retaining strict validation for schemas 1–4. Legacy schemas cannot smuggle newer
+fields, generic model routes cannot encode either reserved bundled Claude model, and
+only one bundled Claude Planner-or-Advisor seat may exist. Persistent Designer
+accepts only a direct same-provider model, never a privileged bundled Claude MCP
+route or a project-shadowable unqualified agent name.
 Cross-provider/custom Designers remain task-local and require current-project
 validation immediately before use. Designer authority is
 policy-bounded: it reports only to root, cannot contact other seats or spawn

--- a/plugins/codex-orchestration/.codex-plugin/plugin.json
+++ b/plugins/codex-orchestration/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-orchestration",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Give Codex and audited external models safe, provider-pinned roles.",
   "author": {
     "name": "CJ Zafir",
@@ -21,7 +21,7 @@
   "interface": {
     "displayName": "Codex Orchestration",
     "shortDescription": "Plan, review, design, and build with multiple models",
-    "longDescription": "Bring Fable 5 and audited API models into Codex as bounded Planner, Advisor, Designer, Executor, or custom roles without changing the root model or Desktop model picker.",
+    "longDescription": "Bring Fable 5, Opus 5, and audited API models into Codex as bounded Planner, Advisor, Designer, Executor, or custom roles without changing the root model or Desktop model picker.",
     "developerName": "CJ Zafir",
     "category": "Productivity",
     "websiteURL": "https://github.com/Cjbuilds/Codex-Orchestration",

--- a/plugins/codex-orchestration/.codex-plugin/plugin.json
+++ b/plugins/codex-orchestration/.codex-plugin/plugin.json
@@ -21,7 +21,7 @@
   "interface": {
     "displayName": "Codex Orchestration",
     "shortDescription": "Plan, review, design, and build with multiple models",
-    "longDescription": "Bring Fable 5, Opus 5, and audited API models into Codex as bounded Planner, Advisor, Designer, Executor, or custom roles without changing the root model or Desktop model picker.",
+    "longDescription": "Use sealed Fable 5 or Opus 5 as one bundled Planner-or-Advisor subscription seat, and audited API models in supported bounded roles, without changing the root model or Desktop model picker.",
     "developerName": "CJ Zafir",
     "category": "Productivity",
     "websiteURL": "https://github.com/Cjbuilds/Codex-Orchestration",

--- a/plugins/codex-orchestration/skills/codex-orchestration/SKILL.md
+++ b/plugins/codex-orchestration/skills/codex-orchestration/SKILL.md
@@ -17,6 +17,7 @@ Support these simple forms:
 /codex-orchestration setup executor: GPT-5.6 Luna Extra High
 /codex-orchestration setup executor: GPT-5.6 Luna Extra High, advisor: Claude Fable 5 High
 /codex-orchestration setup planner: Claude Fable 5 High, advisor: GPT-5.6 Sol High, executor: GPT-5.6 Luna Extra High
+/codex-orchestration setup advisor: Claude Opus 5 XHigh, executor: GPT-5.6 Luna Extra High
 /codex-orchestration setup designer: GPT-5.6 Sol High, executor: GPT-5.6 Luna Extra High
 /codex-orchestration Planner: Claude Fable 5 High, Designer: Kimi K3
 /codex-orchestration --update
@@ -68,7 +69,7 @@ Explicit seat labels are authoritative. `planner:` configures only Planner, `adv
 
 The executor is required for setup or a task-local override. It is not required for a custom-role creation request. Planner, advisor, and designer are optional: omitted planner means the current root model plans, omitted advisor means `advisor: none`, and omitted designer means `designer: none`. Do not ask separate planner or advisor questions, or a separate designer question, unless the user asks for help choosing them.
 
-For both persistent setup and task-local overrides, reject an identical Planner and Advisor route: the same direct model ID, the same custom-agent name, or Claude Fable 5 in both seats. Independent critique is required.
+For both persistent setup and task-local overrides, reject an identical Planner and Advisor route: the same direct model ID, the same custom-agent name, or more than one bundled Claude subscription seat across Fable 5 and Opus 5. Independent critique is required.
 
 If the executor is missing, ask only:
 
@@ -125,7 +126,7 @@ continue that work.
 
 If an old prompt contains `orchestrator:`, explain that the current task model already owns that role. Ignore that seat instead of switching or persisting it.
 
-Normalize `Extra High` to `xhigh`. For Claude Fable 5, accept `Low`, `Medium`, `High`, `XHigh`, `Max`, or `Ultra`. Omission or `Auto` means `High`; `Ultra` is a user-facing alias for Claude Code's actual `max` setting and must be reported as that mapping. Route Fable with `--planner-fable --planner-effort <normalized-effort>` or `--advisor-fable --advisor-effort <normalized-effort>`, not through the Codex model catalog. Resolve every other display name to an exact ID only through the executing host's model catalog, picker, a loaded custom agent, or official provider documentation. Never invent an ID. For persistent direct routing, resolve `auto` to the catalog's concrete default.
+Normalize `Extra High` to `xhigh`. For Claude Fable 5, accept `Low`, `Medium`, `High`, `XHigh`, `Max`, or `Ultra`. Omission or `Auto` means `High`; `Ultra` is a user-facing alias for Claude Code's actual `max` setting and must be reported as that mapping. Route Fable with `--planner-fable --planner-effort <normalized-effort>` or `--advisor-fable --advisor-effort <normalized-effort>`, not through the Codex model catalog. For Claude Opus 5, accept exactly `Low`, `Medium`, `High`, `XHigh`, or `Max`; omission or `Auto` means `High`, and `Ultra` is not an alias. Route it with `--planner-opus` or `--advisor-opus` plus the normalized effort. Resolve every other display name to an exact ID only through the executing host's model catalog, picker, a loaded custom agent, or official provider documentation. Never invent an ID. For persistent direct routing, resolve `auto` to the catalog's concrete default.
 
 Persistent Designer accepts only a direct same-provider model, not a Fable MCP
 or unqualified custom-agent route. Route it with `--designer-model` plus
@@ -297,11 +298,11 @@ or ambiguous data for manual recovery. An intentionally replaced user helper may
 accepted only through preview/apply `trust-helper` at the same absolute path, which
 clears qualification and requires authentication plus Gate 0 again.
 
-Claude Fable 5 remains the sealed first-party subscription adapter. It continues to
-use only its Planner/Advisor MCP operations and existing first-party login,
-no-tools, no-session-persistence, runtime-model-metadata contract. Do not route it
-through the native External Model provider configurator and do not generalize its
-adapter to arbitrary CLIs.
+Claude Fable 5 and Claude Opus 5 are the sealed first-party subscription adapters.
+They use only the Planner/Advisor MCP operations and existing first-party login,
+no-tools, no-session-persistence, runtime-model-metadata contract. Do not route
+them through the native External Model provider configurator and do not generalize
+their adapter to arbitrary CLIs.
 
 ## Create arbitrary custom roles
 
@@ -331,7 +332,7 @@ If the user combines a workflow with a Codex Goal, leave Goal lifecycle and limi
 
 ## One-time native setup
 
-Use this path for a current same-provider setup such as Sol root to Luna or Terra children. Claude Fable 5 is the one built-in cross-provider Planner or Advisor exception because it runs through the bundled read-only MCP bridge and the user's authenticated Claude Code CLI.
+Use this path for a current same-provider setup such as Sol root to Luna or Terra children. Claude Fable 5 and Claude Opus 5 are the built-in cross-provider Planner or Advisor exceptions because they run through the bundled read-only MCP bridge and the user's authenticated Claude Code CLI.
 
 1. Identify the Codex binary used by the active host. Do not assume the shell `codex` is the Desktop binary.
 2. Resolve the exact executor and optional Planner, Advisor, and Designer IDs and efforts from that host.
@@ -356,7 +357,13 @@ python3 <skill-dir>/scripts/configure_native_routing.py \
 
 Add `--advisor-model` and `--advisor-effort` for a same-provider Codex advisor. For Claude Fable 5, use `--advisor-fable`; add `--advisor-effort low|medium|high|xhigh|max` when the user chooses one. Omitting Fable effort defaults to `high`, while user-facing `ultra` is normalized to Claude Code's `max`. The configurator verifies that the installed Claude Code CLI advertises the selected effective effort. It also requires Claude Code to be logged in through a first-party Pro or Max account, chooses an available Python 3.11+ MCP launcher, and performs only an auth/capability check during setup. It never extracts a token, writes a credential, or makes a model call during setup or status. Omission persists `advisor: none`.
 
-Add `--planner-model` and `--planner-effort` for a same-provider Planner. For Claude Fable 5, use `--planner-fable`; add `--planner-effort low|medium|high|xhigh|max` when the user chooses one. Planner omission persists no Planner route and means the root plans. A configured Planner and Advisor must not resolve to the same model or agent route; independent review is required.
+For Claude Opus 5 Advisor, use `--advisor-opus` with an optional exact
+`--advisor-effort low|medium|high|xhigh|max`. The default is `high`. Setup also
+requires Claude Code 2.1.219 or newer. It checks version, first-party login,
+required flags, and that the installed CLI advertises the selected effort; extra
+future CLI efforts remain unselectable.
+
+Add `--planner-model` and `--planner-effort` for a same-provider Planner. For Claude Fable 5, use `--planner-fable`; add `--planner-effort low|medium|high|xhigh|max` when the user chooses one. For Claude Opus 5, use `--planner-opus` with the same exact five values and the same 2.1.219 minimum. Planner omission persists no Planner route and means the root plans. A configured Planner and Advisor must not resolve to the same model or agent route; independent review is required.
 
 Add `--designer-model` and `--designer-effort` for a persistent same-provider
 Designer. Designer omission persists `designer: none`. Designer cannot use the
@@ -375,9 +382,9 @@ Do not add `enabled = true` for a Sol or Terra root. Their current model metadat
 - `features.multi_agent_v2.multi_agent_mode_hint_text`;
 - `features.multi_agent_v2.usage_hint_text`.
 
-When Claude Fable 5 is selected, it additionally manages only the plugin-scoped `enabled` override for the chosen bundled MCP launcher and any launcher variant already overridden by the user. All bundled variants are disabled by default. The original override values are stored and restored by `disable`. Codex's TOML editor may retain an inert empty table header after deleting the last override; never rewrite the file merely to remove that cosmetic header.
+When Claude Fable 5 or Claude Opus 5 is selected, it additionally manages only the plugin-scoped `enabled` override for the chosen bundled MCP launcher and any launcher variant already overridden by the user. The historical `fable-advisor-*` launcher IDs are retained as compatibility identifiers for both sealed models. All bundled variants are disabled by default. The original override values are stored and restored by `disable`. Codex's TOML editor may retain an inert empty table header after deleting the last override; never rewrite the file merely to remove that cosmetic header.
 
-It uses Codex App Server's `config/read` and `config/batchWrite` APIs, not a home-grown TOML rewrite. It preserves unrelated settings and comments, validates the whole effective config, and uses the user-layer version to detect races. Restore snapshots cover the four routing fields plus the narrowly scoped MCP overrides only when Fable is selected; the namespaced state also records schema/version markers, config path, selected seats, and scalar-conversion metadata when needed. If the user explicitly replaces existing hint text, the exact prior text is stored for restoration; warn them never to place credentials in routing hints.
+It uses Codex App Server's `config/read` and `config/batchWrite` APIs, not a home-grown TOML rewrite. It preserves unrelated settings and comments, validates the whole effective config, and uses the user-layer version to detect races. Restore snapshots cover the four routing fields plus the narrowly scoped MCP overrides only when either bundled Claude model is selected; the namespaced state also records schema/version markers, config path, selected seats, and scalar-conversion metadata when needed. If the user explicitly replaces existing hint text, the exact prior text is stored for restoration; warn them never to place credentials in routing hints.
 
 If a user-authored mode or usage hint already exists, do not replace it automatically. Show the conflict. Use `--replace-existing-policy` only after the user explicitly approves replacing and later restoring those exact values.
 
@@ -423,7 +430,7 @@ a concurrent config or saved-state edit instead of overwriting it. It never read
 changes authentication, credentials, chats, or sessions. After apply, run status with
 `--require-effective` and fully quit and reopen Codex before starting a new task.
 
-To change seats, run normal `setup` again. The configurator keeps the original restore snapshot rather than treating its own managed values as user settings.
+To change ordinary seats, run normal `setup` again. The configurator keeps the original restore snapshot rather than treating its own managed values as user settings. An Opus route may update effort in place only on the same seat. Replacing Fable with Opus, replacing Opus with Fable, moving Opus between planning seats, or removing Opus through setup must fail before writes and instruct the user to run the existing full-policy `--disable --apply`, then one fresh complete setup.
 
 For disable, dry-run and then apply. A literal `disable` request authorizes a clean restore:
 
@@ -441,9 +448,14 @@ Disable must remain available even if an older client is incompatible with the a
 
 For personal v0.4 custom roles, preview and apply removal with `configure_orchestration.py --scope personal --personal-route-names --remove-saved-roles`. For older fixed-name personal roles, run a separate preview without `--personal-route-names`. Project removal uses `--scope project --root <trusted-project> --remove-saved-roles`. Delete only files that the configurator fully validates as managed; edited or user-owned files require manual review.
 
-## Claude Fable 5 Planner or Advisor
+## Claude Fable 5 or Claude Opus 5 Planner or Advisor
 
 Use this built-in route when the user names Claude Fable 5. Do not create a custom provider or custom-agent file for it.
+Claude Fable 5 remains a built-in cross-provider Planner or Advisor exception.
+
+Use the same sealed bridge when the user names Claude Opus 5. Its exact model
+ID is `claude-opus-5`, and Claude Code 2.1.219 or newer is required. In
+user-facing diagnostics use the exact name `Claude Opus 5`.
 
 In user-facing diagnostic status or operation results, use the exact name `Claude Fable 5`.
 The concise activation confirmation preserves the supplied `Fable 5` label when that is what the user wrote, as shown in its exact example.
@@ -455,11 +467,19 @@ Prerequisites:
 - `claude auth status` reports a first-party Pro or Max login;
 - a Python 3.11+ launcher is available.
 
-The plugin packages three disabled MCP launcher variants for macOS, Linux, and Windows. Setup enables exactly one compatible variant through the plugin's namespaced config when either Fable seat is selected. At planning or review time the MCP server removes API-key and Bedrock/Vertex/Foundry override variables, re-checks first-party login, and invokes `claude -p --model claude-fable-5` with `--safe-mode`, no tools, no session persistence, prompt suggestions disabled, and JSON output. Each saved seat pins its model and effort; the root cannot replace them through tool arguments.
+The plugin packages three disabled MCP launcher variants for macOS, Linux, and Windows. Setup enables exactly one compatible variant through the plugin's namespaced config when either bundled Claude model is selected. At planning or review time the MCP server removes API credentials plus endpoint, header, provider, model, and effort overrides, re-checks first-party login, and invokes `claude --print --model <sealed-model-id>` with `--safe-mode`, no tools, no session persistence, prompt suggestions disabled, and JSON output. Each saved seat pins its model and effort; the root cannot replace them through tool arguments.
 
 Fable effort is configurable per setup. The default is `high`; supported Claude Code values are `low`, `medium`, `high`, `xhigh`, and `max`. Accept `ultra` as an alias for `max`, save the effective Claude Code value, and disclose the alias mapping in setup output. Existing saved `max` routes remain valid.
 
-The bridge exposes only bounded, read-only planning operations. `create_plan` accepts one self-contained packet and requires `PLAN_DRAFT`. `revise_plan` requires the task, canonical current plan, latest critique, and compact findings history, then requires `PLAN_REVISION` plus a findings ledger and revised plan. `review_plan` remains the Advisor operation and requires `PLAN_APPROVED` or `PLAN_REVISE`. Every call uses the same full saved-state validator as native status/repair/disable, then requires runtime `modelUsage` to contain the pinned `claude-fable-5` primary plus only the bridge's explicit exact helper allowlist. Return every observed ID in `used_models`; an unknown additional or missing primary model makes the seat unavailable. Any auth, transport, state, format, or model-confirmation failure makes that seat unavailable; it never counts as approval. The bridge returns no account identifier or credential.
+Opus effort is also configurable and defaults to `high`. Its sealed set is
+exactly `low`, `medium`, `high`, `xhigh`, and `max`; no alias is accepted.
+Setup requires only that the selected sealed effort appear in the installed
+CLI's advertised set. Extra advertised values do not expand the sealed set.
+
+The bridge exposes only bounded, read-only planning operations. `create_plan` accepts one self-contained packet and requires `PLAN_DRAFT`. `revise_plan` requires the task, canonical current plan, latest critique, and compact findings history, then requires `PLAN_REVISION` plus a findings ledger and revised plan. `review_plan` remains the Advisor operation and requires `PLAN_APPROVED` or `PLAN_REVISE`. Every call uses the same full saved-state validator as native status/repair/disable, then requires runtime `modelUsage` to contain the pinned primary plus only that model's explicit exact helper allowlist. Fable permits its independently observed `claude-haiku-4-5-20251001` helper. No Opus helper identity is independently established, so Opus currently permits only `claude-opus-5` and fails closed if any additional runtime model appears. Return every observed ID in `used_models`; an unknown additional or missing primary model makes the seat unavailable. Any auth, transport, state, format, or model-confirmation failure makes that seat unavailable; it never counts as approval. The bridge returns no account identifier or credential. Local mocked verification does not prove a positive live Opus invocation.
+
+The legacy Fable contract requires runtime `modelUsage` to contain the pinned `claude-fable-5`
+primary; Opus applies the same primary-presence rule to `claude-opus-5`.
 
 Plugin and policy updates cannot replace the MCP process already loaded into the
 current task. If a Fable call fails after an update or repair, run fresh native
@@ -595,9 +615,11 @@ A configured Planner or Advisor is required by default. Route failure, malformed
 
 Do not persist a best-effort flag. An explicit task override applies only to that task.
 
-Reject persistent setup or task-local activation when configured Planner and Advisor routes are identical: the same direct model ID, same custom-agent name, or Fable in both seats. Independent critique is the reason for the Advisor role.
+Reject persistent setup or task-local activation when configured Planner and Advisor routes are identical: the same direct model ID, same custom-agent name, or more than one bundled Claude subscription seat. Independent critique is the reason for the Advisor role.
 
-Fable Planner uses `create_plan` and `revise_plan`; Fable Advisor uses `review_plan`. These operations are seat-bound: never send a supplied Fable Planner to `review_plan`, and never use an Advisor route to create or revise the plan. The policy authorizes only the root to make these read-only calls; Executors must never use or direct them.
+Bundled Claude Planner routes use `create_plan` and `revise_plan`; bundled Claude Advisor routes use `review_plan`. These operations are seat-bound: never send a supplied Planner route to `review_plan`, and never use an Advisor route to create or revise the plan. The policy authorizes only the root to make these read-only calls; Executors must never use or direct them.
+
+For compatibility with the established seat contract: Fable Planner uses `create_plan` and `revise_plan`; Fable Advisor uses `review_plan`. Opus uses the same operation-to-seat mapping.
 
 ## Designer handoff
 
@@ -665,11 +687,11 @@ Never call that 65% fewer raw tokens, a guaranteed five-hour or weekly-limit sav
 ## Resources
 
 - `scripts/configure_native_routing.py`: one-time native setup, status, seat changes, and disable.
-- `scripts/fable_advisor_mcp.py`: fail-closed Claude Fable 5 planning and review bridge.
+- `scripts/fable_advisor_mcp.py`: fail-closed Fable 5 and Opus 5 planning and review bridge; the filename is retained for compatibility.
 - `scripts/configure_orchestration.py`: namespaced custom agents, provider pins, safe removal, and legacy migration.
 - `scripts/inspect_models.py`: fallible host-catalog diagnostics.
 - `scripts/external_configurator.py`: preview-first External Model provider, Gate 0, role, status, recovery, and removal lifecycle.
 - `scripts/external_auth_helper.py`: stable OS credential-store reader for documented command-backed provider auth.
-- `scripts/external_subscription.py`: sealed dispatch through the existing Claude Fable 5 bridge.
+- `scripts/external_subscription.py`: sealed dispatch through the bundled Claude subscription bridge.
 - [providers-and-models.md](references/providers-and-models.md): detailed capability, provider, compatibility, persistence, and usage boundaries.
 - [external-models.md](references/external-models.md): External Model trust lanes, lifecycle, commands, secret handling, Kimi status, and adapter-extension contract.

--- a/plugins/codex-orchestration/skills/codex-orchestration/SKILL.md
+++ b/plugins/codex-orchestration/skills/codex-orchestration/SKILL.md
@@ -128,14 +128,14 @@ If an old prompt contains `orchestrator:`, explain that the current task model a
 
 Normalize `Extra High` to `xhigh`. For Claude Fable 5, accept `Low`, `Medium`, `High`, `XHigh`, `Max`, or `Ultra`. Omission or `Auto` means `High`; `Ultra` is a user-facing alias for Claude Code's actual `max` setting and must be reported as that mapping. Route Fable with `--planner-fable --planner-effort <normalized-effort>` or `--advisor-fable --advisor-effort <normalized-effort>`, not through the Codex model catalog. For Claude Opus 5, accept exactly `Low`, `Medium`, `High`, `XHigh`, or `Max`; omission or `Auto` means `High`, and `Ultra` is not an alias. Route it with `--planner-opus` or `--advisor-opus` plus the normalized effort. Resolve every other display name to an exact ID only through the executing host's model catalog, picker, a loaded custom agent, or official provider documentation. Never invent an ID. For persistent direct routing, resolve `auto` to the catalog's concrete default.
 
-Persistent Designer accepts only a direct same-provider model, not a Fable MCP
-or unqualified custom-agent route. Route it with `--designer-model` plus
+Persistent Designer accepts only a direct same-provider model, not a bundled Claude
+MCP or unqualified custom-agent route. Route it with `--designer-model` plus
 `--designer-effort`. A Designer route may share a model with another seat; only
 Planner and Advisor require independent routes. For a cross-provider Designer,
 create and invoke a task-local External Model role named `designer`; `resolve` must
 reject matching project agents in the current workspace or any ancestor immediately
-before returning its route. Codex does not yet expose a scope-qualified agent identity,
-so persisting an agent name would let a later project's agent shadow it.
+before returning its route. Codex does not yet expose a scope-qualified agent
+identity, so persisting an agent name would let a later project's agent shadow it.
 
 Read [providers-and-models.md](references/providers-and-models.md) before setup, when clients disagree, when a model is absent, when providers differ, or when custom agents or legacy migration are involved.
 
@@ -367,9 +367,10 @@ Add `--planner-model` and `--planner-effort` for a same-provider Planner. For Cl
 
 Add `--designer-model` and `--designer-effort` for a persistent same-provider
 Designer. Designer omission persists `designer: none`. Designer cannot use the
-Fable MCP route or a persistent custom-agent name. Use a task-local External Model
-role named `designer` for cross-provider design work so the root can validate its
-personal file and reject project shadowing immediately before the bounded call.
+bundled Claude MCP route or a persistent custom-agent name. Use a task-local
+External Model role named `designer` for cross-provider design work so the root can
+validate its personal file and reject project shadowing immediately before the
+bounded call.
 
 The configurator capability-tests the complete four-field preset on the active target, `codex` on PATH when different, the known macOS Desktop binary when present, and every explicit `--compat-bin`. A successful isolated config probe means that client can parse the preset; it is not a live child-model confirmation. Report `route accepted` or `used and confirmed` only from the exact live spawn evidence defined below. Ask about other Codex/IDE installations that share this config only when the environment suggests they exist, and pass their binaries explicitly. If the request or active host indicates a named `--profile`, explain that normal setup manages the default user layer and is not verified for that profile; do not add a routine question for users with no profile signal. If a checked client rejects any managed field, stop before apply. Recommend updating it or using the task-local fallback. `--allow-incompatible-client` requires a separate explicit user decision because it can make the shared config unreadable to that client.
 
@@ -402,7 +403,7 @@ python3 <skill-dir>/scripts/configure_native_routing.py \
   --status --require-effective
 ```
 
-Run status from the target project. The first form is descriptive. Use `--require-effective` for automation and release gates; it returns nonzero for incompatible clients, conflicts, overrides, incomplete controls, an unavailable Fable or custom-agent route, or orphaned v0.4+ personal roles. Report the current task model as the orchestrator, Planner (`root` when omitted), configured Advisor, Designer, and Executor, whether the personal policy is installed and effective in that workspace, whether effective spawn controls are visible, whether the effective tool namespace is `agents`, the target config path, and checked-client compatibility. State that neither status form proves a live route or infers v2 activation for the model selected in a task; current Sol or Terra is the intended root.
+Run status from the target project. The first form is descriptive. Use `--require-effective` for automation and release gates; it returns nonzero for incompatible clients, conflicts, overrides, incomplete controls, an unavailable bundled Claude or custom-agent route, or orphaned v0.4+ personal roles. Report the current task model as the orchestrator, Planner (`root` when omitted), configured Advisor, Designer, and Executor, whether the personal policy is installed and effective in that workspace, whether effective spawn controls are visible, whether the effective tool namespace is `agents`, the target config path, and checked-client compatibility. State that neither status form proves a live route or infers v2 activation for the model selected in a task; current Sol or Terra is the intended root.
 
 When status reports `managed fields conflict with local restore state`, do not run
 setup or disable over the conflict and do not assume authentication failed. A literal
@@ -421,8 +422,9 @@ python3 <skill-dir>/scripts/configure_native_routing.py \
 ```
 
 Repair must require valid saved state and both live hints to retain the plugin
-ownership marker. It must refuse namespace, spawn-metadata, Fable launcher,
-scalar-shape, missing/unmarked hint, or other managed drift. It writes only the
+ownership marker. It must refuse namespace, spawn-metadata, drift in the historical
+Fable launcher IDs shared by both bundled Claude models, scalar-shape,
+missing/unmarked hint, or other managed drift. It writes only the
 different mode/usage fields through App Server compare-and-swap, leaves the original
 restore snapshot and seat records byte-for-byte unchanged, checks user and effective
 readback, rolls the two fields back when a higher layer overrides them, and preserves
@@ -467,7 +469,7 @@ Prerequisites:
 - `claude auth status` reports a first-party Pro or Max login;
 - a Python 3.11+ launcher is available.
 
-The plugin packages three disabled MCP launcher variants for macOS, Linux, and Windows. Setup enables exactly one compatible variant through the plugin's namespaced config when either bundled Claude model is selected. At planning or review time the MCP server removes API credentials plus endpoint, header, provider, model, and effort overrides, re-checks first-party login, and invokes `claude --print --model <sealed-model-id>` with `--safe-mode`, no tools, no session persistence, prompt suggestions disabled, and JSON output. Each saved seat pins its model and effort; the root cannot replace them through tool arguments.
+The plugin packages three disabled MCP launcher variants for macOS, Linux, and Windows. Setup enables exactly one compatible variant through the plugin's namespaced config when either bundled Claude model is selected. At planning or review time the MCP server gives authentication and model subprocesses only a minimal platform environment. It preserves canonical `HOME` on POSIX or `USERPROFILE` on Windows for first-party login discovery, but does not inherit credential, config-redirection, provider/model/effort, endpoint/gateway, proxy/CA/mTLS, or telemetry override families. It invokes `claude --print --model <sealed-model-id>` with `--safe-mode`, no tools, no session persistence, prompt suggestions disabled, and JSON output. Each saved seat pins its model and effort; the root cannot replace them through tool arguments.
 
 Fable effort is configurable per setup. The default is `high`; supported Claude Code values are `low`, `medium`, `high`, `xhigh`, and `max`. Accept `ultra` as an alias for `max`, save the effective Claude Code value, and disclose the alias mapping in setup output. Existing saved `max` routes remain valid.
 
@@ -482,9 +484,10 @@ The legacy Fable contract requires runtime `modelUsage` to contain the pinned `c
 primary; Opus applies the same primary-presence rule to `claude-opus-5`.
 
 Plugin and policy updates cannot replace the MCP process already loaded into the
-current task. If a Fable call fails after an update or repair, run fresh native
-status. When status reports Claude Fable 5 `ready — first-party login`, classify the
-current tool failure as a stale loaded bridge, not an authentication failure. Do not
+current task. If a bundled Claude call fails after an update or repair, run fresh
+native status. When status reports that configured bundled Claude seat
+`ready — first-party login`, classify the current tool failure as a stale loaded
+bridge, not an authentication failure. Do not
 request re-authentication. Fully quit and reopen Codex, then start a new task so the
 installed bridge, policy, and saved state load together. Ask for login only when the
 fresh status check itself reports authentication unavailable.

--- a/plugins/codex-orchestration/skills/codex-orchestration/providers/claude-opus.json
+++ b/plugins/codex-orchestration/skills/codex-orchestration/providers/claude-opus.json
@@ -1,0 +1,41 @@
+{
+  "schema": 1,
+  "id": "claude-opus",
+  "version": 1,
+  "name": "Claude Opus 5",
+  "lane": "subscription",
+  "experimental": false,
+  "qualified": true,
+  "base_url": null,
+  "wire_api": null,
+  "auth": "first_party_cli",
+  "models": {
+    "claude-opus-5": {
+      "default_effort": "high",
+      "supported_efforts": [
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max"
+      ],
+      "context_window": null,
+      "auto_compact_token_limit": null,
+      "capability_source": "bundled-first-party-cli-adapter"
+    }
+  },
+  "runtime_identity": "cli_metadata",
+  "subscription_adapter": {
+    "module": "fable_advisor_mcp",
+    "allowed_seats": [
+      "planner",
+      "advisor"
+    ],
+    "allowed_operations": [
+      "create_plan",
+      "revise_plan",
+      "review_plan"
+    ],
+    "trust_strategy": "first_party_auth_and_runtime_metadata"
+  }
+}

--- a/plugins/codex-orchestration/skills/codex-orchestration/references/providers-and-models.md
+++ b/plugins/codex-orchestration/skills/codex-orchestration/references/providers-and-models.md
@@ -230,14 +230,27 @@ Direct v2 `model` overrides retain the parent's provider. They are the simplest 
 
 Claude Fable 5 and Claude Opus 5 are explicit built-in exceptions for Planner or Advisor. The plugin does not pretend either is a Codex model or translate Anthropic into the Responses protocol. Instead, a disabled-by-default local MCP server invokes the official `claude` CLI with the user's first-party Pro or Max login. Setup enables one Python 3.11+ launcher variant, and disable restores every prior plugin override value. The historical `fable-advisor-*` IDs are compatibility names shared by both sealed models. Codex's TOML editor can retain an inert empty table header after its final key is deleted; the configurator does not risk a broad TOML rewrite for cosmetic cleanup.
 
-The bridge removes `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, and Bedrock/Vertex/Foundry selection variables from the child environment. It re-checks `claude auth status`, pins the saved primary and effort, disables tools and session persistence, disables prompt suggestions, and requires JSON runtime metadata to contain that primary. Claude Code currently reports the internal helper `claude-haiku-4-5-20251001` during valid Fable calls; the bridge permits only that exact helper ID. No Opus helper identity is independently established, so the Opus runtime allowlist currently contains only `claude-opus-5`. Any missing primary or unknown additional model fails closed. Helper rotation therefore requires a reviewed plugin update rather than a wildcard. Setup and status never make a model call, and mocked local tests do not constitute a positive live Opus invocation.
+The bridge starts both `claude auth status` and model calls with only a minimal
+platform environment. It preserves canonical `HOME` on POSIX or `USERPROFILE` on
+Windows so the official CLI can discover the first-party login, but it does not
+inherit credential, config-redirection, provider/model/effort, endpoint/gateway,
+proxy/CA/mTLS, or telemetry override families. It pins the saved primary and effort,
+disables tools and session persistence, disables prompt suggestions, and requires
+JSON runtime metadata to contain that primary. Claude Code currently reports the
+internal helper `claude-haiku-4-5-20251001` during valid Fable calls; the bridge
+permits only that exact helper ID. No Opus helper identity is independently
+established, so the Opus runtime allowlist currently contains only `claude-opus-5`.
+Any missing primary or unknown additional model fails closed. Helper rotation
+therefore requires a reviewed plugin update rather than a wildcard. Setup and status
+never make a model call, and mocked local tests do not constitute a positive live
+Opus invocation.
 
 An MCP process is loaded for the lifetime of its Codex task. Updating the plugin or
 repairing policy state cannot replace that already loaded process. If a current-task
-Fable call fails after either operation while a fresh native status check still
-reports a ready first-party login, the loaded bridge is stale; fully quit and reopen
-Codex and start a new task. Do not re-authenticate unless the fresh status check
-itself reports authentication unavailable.
+bundled Claude call fails after either operation while a fresh native status check
+still reports a ready first-party login, the loaded bridge is stale; fully quit and
+reopen Codex and start a new task. Do not re-authenticate unless the fresh status
+check itself reports authentication unavailable.
 
 The saved policy authorizes the root to call these planning tools and prohibits children from doing so. Current MCP requests provide no caller identity to the server, so that specific caller boundary is instruction-enforced, not server-authenticated. The bridge mechanically uses the same full saved-state validator as native status/repair/disable, restricts the operation surface, and runs the selected Claude model without tools or persistence.
 

--- a/plugins/codex-orchestration/skills/codex-orchestration/references/providers-and-models.md
+++ b/plugins/codex-orchestration/skills/codex-orchestration/references/providers-and-models.md
@@ -27,6 +27,7 @@ These facts were source-checked and runtime-tested on July 10, 2026. Always capa
 | `usage_hint_text` | Appended to the spawn tool description | Carries the exact Planner/Advisor/Executor routes where the root chooses children. |
 | `multi_agent_mode_hint_text` | Replaces the default proactive/explicit mode hint and is sent to root and child tasks | Must contain both root and child boundaries. |
 | Claude Fable 5 MCP route | Root-directed `create_plan`, `revise_plan`, and `review_plan` tools invoke the authenticated Claude Code CLI headlessly with no model tools | Built-in cross-provider Planner or Advisor exception; current MCP requests do not provide caller identity, so caller isolation is policy-enforced. |
+| Claude Opus 5 MCP route | Uses the same bounded compatibility launchers with exact model `claude-opus-5` and Claude Code 2.1.219+ | Sealed cross-provider Planner or Advisor; at most one bundled Claude subscription seat may be active. |
 | `fork_turns` default | `all` | Different model/effort/role overrides are rejected unless the call uses `none` or a positive partial fork. |
 | Effective concurrency | Determined by the active Codex version and `agents.max_threads` configuration | This plugin never changes the limit or forces a worker count. |
 | Older CLI 0.142.5 | Rejects `multi_agent_mode_hint_text` as an unknown feature-table field | Never write the global native policy without checking every known shared-config client. |
@@ -80,7 +81,7 @@ agent_type="codex_orchestration_executor", fork_turns="none"
 agent_type="codex_orchestration_advisor", fork_turns="none"
 ```
 
-For Claude Fable 5 it names the enabled bundled MCP server and tells the root to use `create_plan`/`revise_plan` for the Planner seat or `review_plan` for the Advisor seat. These are root tool calls, not `spawn_agent`, so `fork_turns` does not apply.
+For Claude Fable 5 or Claude Opus 5 it names the enabled bundled MCP server and tells the root to use `create_plan`/`revise_plan` for the Planner seat or `review_plan` for the Advisor seat. These are root tool calls, not `spawn_agent`, so `fork_turns` does not apply.
 
 The custom mode text is visible in spawned children too. That is why it says: if root, orchestrate; if child, stay within the packet and never spawn.
 
@@ -150,7 +151,7 @@ The configurator writes each owned nested field separately, except when converti
 `--repair` is a separate, preview-first recovery path for a valid saved state whose
 live mode and/or usage hint bytes changed while every other owned control still
 matches. Both live strings must retain the plugin marker. Namespace, spawn metadata,
-plugin-scoped Fable enablement, and any scalar-conversion table shape must match the
+plugin-scoped bundled Claude launcher enablement, and any scalar-conversion table shape must match the
 saved state exactly. Repair writes only the differing hint fields using the user
 layer version, leaves seat and restore records byte-for-byte unchanged, verifies both
 user and effective readback, restores the pre-repair hints after an effective-layer
@@ -165,7 +166,7 @@ Restore state lives at:
 ~/.codex/.codex-orchestration-routing.json
 ```
 
-It contains the prior and managed values of the four routing fields, chosen Planner/Advisor/Executor routes, schema/version markers, scalar-conversion metadata when needed, and config path. When Claude Fable 5 is selected for either planning seat, it also records only the plugin-scoped MCP launcher overrides that setup touched. It never copies provider definitions, auth stores, account identifiers, or credentials. A normal clean setup contains generated policy text, the namespace value, seat IDs, and restoration metadata. Explicit replacement must retain the user's exact old hint text so disable can restore it; routing hints must never contain credentials. State is written with a same-directory atomic replacement and restrictive file mode where supported. If persistence fails after config apply, the configurator rolls the config back using the returned version.
+It contains the prior and managed values of the four routing fields, chosen Planner/Advisor/Executor routes, schema/version markers, scalar-conversion metadata when needed, and config path. When Claude Fable 5 or Claude Opus 5 is selected for either planning seat, it also records only the plugin-scoped MCP launcher overrides that setup touched. It never copies provider definitions, auth stores, account identifiers, or credentials. A normal clean setup contains generated policy text, the namespace value, seat IDs, and restoration metadata. Explicit replacement must retain the user's exact old hint text so disable can restore it; routing hints must never contain credentials. State is written with a same-directory atomic replacement and restrictive file mode where supported. If persistence fails after config apply, the configurator rolls the config back using the returned version.
 
 Disable compares every current managed value before restoration. If the user edited a managed field after setup, it stops instead of erasing that work. Without state, each surviving marker proves ownership only of that hint string. Disable may safely remove the marked string or strings, but it leaves metadata visibility and the tool namespace unchanged because their previous values are unknown.
 
@@ -227,9 +228,9 @@ On Windows, in-place update and removal stage the replacement beside the existin
 
 Direct v2 `model` overrides retain the parent's provider. They are the simplest route for an OpenAI root and OpenAI Luna/Terra child.
 
-Claude Fable 5 is the explicit built-in exception for Planner or Advisor. The plugin does not pretend it is a Codex model or translate Anthropic into the Responses protocol. Instead, a disabled-by-default local MCP server invokes the official `claude` CLI with the user's first-party Pro or Max login. Setup enables one Python 3.11+ launcher variant, and disable restores every prior plugin override value. Codex's TOML editor can retain an inert empty table header after its final key is deleted; the configurator does not risk a broad TOML rewrite for cosmetic cleanup.
+Claude Fable 5 and Claude Opus 5 are explicit built-in exceptions for Planner or Advisor. The plugin does not pretend either is a Codex model or translate Anthropic into the Responses protocol. Instead, a disabled-by-default local MCP server invokes the official `claude` CLI with the user's first-party Pro or Max login. Setup enables one Python 3.11+ launcher variant, and disable restores every prior plugin override value. The historical `fable-advisor-*` IDs are compatibility names shared by both sealed models. Codex's TOML editor can retain an inert empty table header after its final key is deleted; the configurator does not risk a broad TOML rewrite for cosmetic cleanup.
 
-The bridge removes `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, and Bedrock/Vertex/Foundry selection variables from the child environment. It re-checks `claude auth status`, pins `claude-fable-5` and the saved effort, disables tools and session persistence, disables prompt suggestions, and requires JSON runtime metadata to contain that primary model. Claude Code currently reports the internal helper `claude-haiku-4-5-20251001` during valid Fable calls; the bridge permits only that exact helper ID and returns every observed ID in `used_models`. Missing Fable or any unknown additional model fails closed. Helper rotation therefore requires a reviewed plugin update rather than a wildcard. Setup and status never make a model call.
+The bridge removes `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, and Bedrock/Vertex/Foundry selection variables from the child environment. It re-checks `claude auth status`, pins the saved primary and effort, disables tools and session persistence, disables prompt suggestions, and requires JSON runtime metadata to contain that primary. Claude Code currently reports the internal helper `claude-haiku-4-5-20251001` during valid Fable calls; the bridge permits only that exact helper ID. No Opus helper identity is independently established, so the Opus runtime allowlist currently contains only `claude-opus-5`. Any missing primary or unknown additional model fails closed. Helper rotation therefore requires a reviewed plugin update rather than a wildcard. Setup and status never make a model call, and mocked local tests do not constitute a positive live Opus invocation.
 
 An MCP process is loaded for the lifetime of its Codex task. Updating the plugin or
 repairing policy state cannot replace that already loaded process. If a current-task
@@ -238,11 +239,18 @@ reports a ready first-party login, the loaded bridge is stale; fully quit and re
 Codex and start a new task. Do not re-authenticate unless the fresh status check
 itself reports authentication unavailable.
 
-The saved policy authorizes the root to call these planning tools and prohibits children from doing so. Current MCP requests provide no caller identity to the server, so that specific caller boundary is instruction-enforced, not server-authenticated. The bridge mechanically uses the same full saved-state validator as native status/repair/disable, restricts the operation surface, and runs Fable without tools or persistence.
+The saved policy authorizes the root to call these planning tools and prohibits children from doing so. Current MCP requests provide no caller identity to the server, so that specific caller boundary is instruction-enforced, not server-authenticated. The bridge mechanically uses the same full saved-state validator as native status/repair/disable, restricts the operation surface, and runs the selected Claude model without tools or persistence.
 
-Saved state compatibility is explicit: schema 1 must carry policy version 1 and predates Fable and Planner; schema 2 must carry policy version 2 and may authorize only the historical Fable Advisor shape; schema 3 must carry policy version 3 and adds Planner; schema 4 must carry policy version 4 and adds the optional direct-model Designer route. Schema and policy values must be actual JSON integers, not booleans or floats. Legacy state cannot contain fields introduced later; nested snapshots, scalar conversion, MCP launchers, and routes must match an emitted contract; and managed policy strings must carry the plugin marker before status, seat change, disable, or Fable trusts them. Designer cannot use Fable or a persistent unqualified agent name, while Planner/Advisor independence remains the only route-separation rule. Unknown extensions intentionally fail closed.
+Saved state compatibility is explicit: schema 1 must carry policy version 1 and predates Fable and Planner; schema 2 must carry policy version 2 and may authorize only the historical Fable Advisor shape; schema 3 must carry policy version 3 and adds Planner; schema 4 must carry policy version 4 and adds the optional direct-model Designer route; schema 5 must carry policy version 5 and adds the Opus-only `claude_subscription` planning route while keeping Fable's legacy route shape unchanged. Schema and policy values must be actual JSON integers, not booleans or floats. Legacy state cannot contain fields introduced later; nested snapshots, scalar conversion, MCP launchers, and routes must match an emitted contract; and managed policy strings must carry the plugin marker before status, seat change, disable, or the bridge trusts them. Designer cannot use a bundled Claude route or a persistent unqualified agent name. Planner/Advisor may contain at most one bundled Claude subscription seat. Unknown extensions intentionally fail closed.
 
 Fable setup defaults to `high`. It accepts the Claude Code effort values `low`, `medium`, `high`, `xhigh`, and `max`; the user-facing label `ultra` normalizes to the effective Claude Code value `max` because the CLI has no separate Ultra setting. Setup checks the installed CLI's advertised choices before persisting the route. The bridge reads only the normalized saved value, so tool callers cannot raise the effort at review time. Existing saved `max` routes remain compatible.
+
+Opus setup also defaults to `high` and seals exactly `low`, `medium`, `high`,
+`xhigh`, and `max`, with no alias. It requires Claude Code 2.1.219 or newer.
+The selected effort must be contained in a non-empty parseable CLI advertisement;
+extra advertised values remain unselectable. An Opus effort can be updated on the
+same seat. Replacing or moving an Opus-involved bundled route requires a full
+managed-policy disable followed by a fresh complete setup.
 
 A cross-provider seat normally needs:
 
@@ -265,7 +273,7 @@ A task-local Planner or Advisor is planning-only by instruction. Do not claim it
 
 A saved advisor requests `sandbox_mode = "read-only"`, but live parent permission overrides may be reapplied to children. Keep the behavioral prohibition on edits and mutation even with the requested sandbox.
 
-The Claude Fable 5 bridge is mechanically narrower than a child: its tools accept only bounded plan or review inputs, launch Claude with safe mode and no tools, and expose no edit or shell operation. It still has open-world model access, so every call must be deliberate and self-contained.
+The bundled Claude bridge is mechanically narrower than a child: its tools accept only bounded plan or review inputs, launch Claude with safe mode and no tools, and expose no edit or shell operation. It still has open-world model access, so every call must be deliberate and self-contained.
 
 Planner or Advisor failure is never approval. Configured seats are required for a non-trivial Executor plan unless the user explicitly marks one best-effort for the current task. Transport failure, malformed output, missing context, stale plan versions, or wrong routes stop Executor work by default.
 

--- a/plugins/codex-orchestration/skills/codex-orchestration/scripts/configure_native_routing.py
+++ b/plugins/codex-orchestration/skills/codex-orchestration/scripts/configure_native_routing.py
@@ -560,13 +560,23 @@ class AppServer:
 
     def close(self) -> None:
         process = getattr(self, "_process", None)
-        if process is not None and process.poll() is None:
-            process.terminate()
-            try:
-                process.wait(timeout=3)
-            except subprocess.TimeoutExpired:
-                process.kill()
-                process.wait(timeout=3)
+        if process is not None:
+            stdin = process.stdin
+            if stdin is not None and not stdin.closed:
+                try:
+                    stdin.close()
+                except OSError:
+                    pass
+            if process.poll() is None:
+                try:
+                    process.wait(timeout=3)
+                except subprocess.TimeoutExpired:
+                    process.terminate()
+                    try:
+                        process.wait(timeout=3)
+                    except subprocess.TimeoutExpired:
+                        process.kill()
+                        process.wait(timeout=3)
         stderr = getattr(self, "_stderr", None)
         if stderr is not None:
             stderr.close()

--- a/plugins/codex-orchestration/skills/codex-orchestration/scripts/configure_native_routing.py
+++ b/plugins/codex-orchestration/skills/codex-orchestration/scripts/configure_native_routing.py
@@ -277,6 +277,11 @@ def _validate_args(args: argparse.Namespace) -> None:
     ):
         if value is not None and not pattern.fullmatch(value):
             raise ConfigurationError(f"Invalid {label}: {value!r}.")
+        if "model" in label and value in {FABLE_MODEL, OPUS_MODEL}:
+            raise ConfigurationError(
+                f"{label.title()} {value!r} is a reserved Claude model ID; "
+                "select its bundled sealed route instead."
+            )
     for label, value in (
         ("executor effort", args.executor_effort),
         ("planner effort", args.planner_effort),
@@ -898,10 +903,23 @@ def select_fable_server() -> str:
 
 
 def _parse_claude_version(output: str) -> tuple[int, int, int]:
-    match = re.search(r"(?<!\d)(\d+)\.(\d+)\.(\d+)(?!\d)", output)
+    match = re.fullmatch(
+        (
+            r"[ \t\r\n]*"
+            r"(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)"
+            r" \(Claude Code\)"
+            r"[ \t\r\n]*"
+        ),
+        output,
+    )
     if match is None:
         raise ConfigurationError("Claude Code returned an unparseable version.")
-    return tuple(map(int, match.groups()))
+    try:
+        return tuple(map(int, match.groups()))
+    except ValueError as exc:
+        raise ConfigurationError(
+            "Claude Code returned an unparseable version."
+        ) from exc
 
 
 def verify_claude_prerequisites(model: str, effort: str) -> dict[str, str]:
@@ -979,7 +997,13 @@ def verify_claude_prerequisites(model: str, effort: str) -> dict[str, str]:
         "--output-format",
         "--system-prompt",
     )
-    missing = [flag for flag in required if flag not in help_result.stdout]
+    advertised_options = set(
+        re.findall(
+            r"(?<![A-Za-z0-9_-])--[A-Za-z0-9][A-Za-z0-9-]*(?![A-Za-z0-9_-])",
+            help_result.stdout,
+        )
+    )
+    missing = [flag for flag in required if flag not in advertised_options]
     if help_result.returncode != 0 or missing:
         detail = ", ".join(missing) if missing else f"exit {help_result.returncode}"
         raise ConfigurationError(

--- a/plugins/codex-orchestration/skills/codex-orchestration/scripts/configure_native_routing.py
+++ b/plugins/codex-orchestration/skills/codex-orchestration/scripts/configure_native_routing.py
@@ -28,6 +28,8 @@ from routing_state import (
     FABLE_EFFORTS,
     FABLE_MODEL,
     MANAGED_MARKER,
+    OPUS_EFFORTS,
+    OPUS_MODEL,
     ROUTING_TOOL_NAMESPACE,
     RoutingStateError,
     validate_routing_state,
@@ -39,14 +41,16 @@ except ModuleNotFoundError as exc:  # pragma: no cover - Python < 3.11
     raise SystemExit("Python 3.11 or newer is required (missing tomllib).") from exc
 
 
-POLICY_VERSION = 4
-STATE_SCHEMA = 4
+POLICY_VERSION = 5
+STATE_SCHEMA = 5
 STATE_FILENAME = ".codex-orchestration-routing.json"
 PROBE_VALUE = "CODEX_ORCHESTRATION_CAPABILITY_PROBE"
 PLUGIN_ID = "codex-orchestration@codex-orchestration"
 FABLE_DEFAULT_EFFORT = "high"
 FABLE_EFFORT_CHOICES = ("low", "medium", "high", "xhigh", "max")
 FABLE_EFFORT_ALIASES = {"ultra": "max"}
+OPUS_DEFAULT_EFFORT = "high"
+OPUS_MIN_CLAUDE_VERSION = (2, 1, 219)
 FABLE_SERVERS = {
     "fable-advisor-python3": ("python3", []),
     "fable-advisor-python": ("python", []),
@@ -117,6 +121,11 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Use the bundled Claude Fable 5 planner through Claude Code.",
     )
+    planner.add_argument(
+        "--planner-opus",
+        action="store_true",
+        help="Use the bundled Claude Opus 5 planner through Claude Code.",
+    )
     parser.add_argument(
         "--planner-effort",
         default="auto",
@@ -130,6 +139,11 @@ def parse_args() -> argparse.Namespace:
         "--advisor-fable",
         action="store_true",
         help="Use the bundled Claude Fable 5 advisor through Claude Code.",
+    )
+    advisor.add_argument(
+        "--advisor-opus",
+        action="store_true",
+        help="Use the bundled Claude Opus 5 advisor through Claude Code.",
     )
     parser.add_argument(
         "--advisor-effort",
@@ -187,9 +201,11 @@ def _validate_args(args: argparse.Namespace) -> None:
             args.planner_model,
             args.planner_agent,
             args.planner_fable,
+            args.planner_opus,
             args.advisor_model,
             args.advisor_agent,
             args.advisor_fable,
+            args.advisor_opus,
             args.designer_model,
             args.executor_effort != "auto",
             args.planner_effort != "auto",
@@ -233,9 +249,22 @@ def _validate_args(args: argparse.Namespace) -> None:
         normalize_fable_effort(args.planner_effort)
     if args.advisor_fable:
         normalize_fable_effort(args.advisor_effort)
-    if args.planner_fable and args.advisor_fable:
+    if args.planner_opus:
+        normalize_opus_effort(args.planner_effort)
+    if args.advisor_opus:
+        normalize_opus_effort(args.advisor_effort)
+    if sum(
+        bool(selected)
+        for selected in (
+            args.planner_fable,
+            args.planner_opus,
+            args.advisor_fable,
+            args.advisor_opus,
+        )
+    ) > 1:
         raise ConfigurationError(
-            "Planner and Advisor routes must be distinct; both cannot use Claude Fable 5."
+            "Planner and Advisor routes must be distinct; configure at most one "
+            "bundled Claude subscription seat."
         )
     for label, value, pattern in (
         ("executor model", args.executor_model, MODEL_RE),
@@ -269,6 +298,18 @@ def normalize_fable_effort(value: str) -> str:
             f"Claude Fable 5 effort must be one of: {supported}."
         )
     return effective
+
+
+def normalize_opus_effort(value: str) -> str:
+    """Return one exact documented Claude Opus 5 effort."""
+
+    requested = OPUS_DEFAULT_EFFORT if value == "auto" else value
+    if requested not in OPUS_EFFORTS:
+        supported = ", ".join(sorted(OPUS_EFFORTS))
+        raise ConfigurationError(
+            f"Claude Opus 5 effort must be one of: {supported}."
+        )
+    return requested
 
 
 def resolve_binary(value: str) -> Path:
@@ -410,7 +451,7 @@ class AppServer:
                     "clientInfo": {
                         "name": "codex_orchestration_installer",
                         "title": "Codex Orchestration Installer",
-                        "version": "0.8.0",
+                        "version": "0.9.0",
                     },
                     "capabilities": {"experimentalApi": True},
                 },
@@ -597,17 +638,21 @@ def validate_planning_routes(
         return
     planner_kind = planner.get("kind")
     advisor_kind = advisor.get("kind")
+    subscription_kinds = {"fable", "claude_subscription"}
     identical = (
         planner_kind == advisor_kind == "model"
         and planner.get("model") == advisor.get("model")
     ) or (
         planner_kind == advisor_kind == "agent"
         and planner.get("agent") == advisor.get("agent")
-    ) or planner_kind == advisor_kind == "fable"
+    ) or (
+        planner_kind in subscription_kinds and advisor_kind in subscription_kinds
+    )
     if identical:
         raise ConfigurationError(
             "Planner and Advisor routes must be distinct (different direct model IDs, "
-            "different custom-agent names, and at most one Claude Fable 5 seat)."
+            "different custom-agent names, and at most one bundled Claude "
+            "subscription seat)."
         )
 
 
@@ -825,6 +870,8 @@ def resolve_model_effort(
 
 
 def select_fable_server() -> str:
+    """Select the historical launcher ID shared by bundled Claude routes."""
+
     for server, (launcher, prefix) in FABLE_SERVERS.items():
         executable = shutil.which(launcher)
         if not executable:
@@ -844,33 +891,56 @@ def select_fable_server() -> str:
         if result.returncode == 0 and match and tuple(map(int, match.groups())) >= (3, 11):
             return server
     raise ConfigurationError(
-        "Claude Fable 5 requires a Python 3.11+ launcher named python3, python, "
+        "Bundled Claude planning routes require a Python 3.11+ launcher named "
+        "python3, python, "
         "or py. Install one and retry."
     )
 
 
-def verify_fable_prerequisites(effort: str) -> dict[str, str]:
+def _parse_claude_version(output: str) -> tuple[int, int, int]:
+    match = re.search(r"(?<!\d)(\d+)\.(\d+)\.(\d+)(?!\d)", output)
+    if match is None:
+        raise ConfigurationError("Claude Code returned an unparseable version.")
+    return tuple(map(int, match.groups()))
+
+
+def verify_claude_prerequisites(model: str, effort: str) -> dict[str, str]:
+    display_name = (
+        "Claude Fable 5" if model == FABLE_MODEL else "Claude Opus 5"
+        if model == OPUS_MODEL
+        else None
+    )
+    if display_name is None:
+        raise ConfigurationError("The bundled Claude model is not sealed.")
     try:
-        from fable_advisor_mcp import AdvisorError, check_claude_auth, resolve_claude
+        from fable_advisor_mcp import (
+            AdvisorError,
+            check_claude_auth,
+            resolve_claude,
+            sanitized_environment,
+        )
     except ImportError as exc:  # pragma: no cover - corrupt package
-        raise ConfigurationError("The bundled Claude Fable 5 bridge is missing.") from exc
+        raise ConfigurationError("The bundled Claude planning bridge is missing.") from exc
     try:
         claude = resolve_claude()
         auth = check_claude_auth(claude)
+        environment = sanitized_environment()
+        version_result = (
+            subprocess.run(
+                [str(claude), "--version"],
+                env=environment,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                timeout=PROBE_TIMEOUT_SECONDS,
+                check=False,
+            )
+            if model == OPUS_MODEL
+            else None
+        )
         help_result = subprocess.run(
             [str(claude), "--help"],
-            env={
-                key: value
-                for key, value in os.environ.items()
-                if key
-                not in {
-                    "ANTHROPIC_API_KEY",
-                    "ANTHROPIC_AUTH_TOKEN",
-                    "CLAUDE_CODE_USE_BEDROCK",
-                    "CLAUDE_CODE_USE_VERTEX",
-                    "CLAUDE_CODE_USE_FOUNDRY",
-                }
-            },
+            env=environment,
             text=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
@@ -879,12 +949,42 @@ def verify_fable_prerequisites(effort: str) -> dict[str, str]:
         )
     except (AdvisorError, OSError, subprocess.TimeoutExpired) as exc:
         raise ConfigurationError(str(exc)) from exc
-    required = ("--model", "--effort", "--safe-mode", "--prompt-suggestions")
+    installed_version: tuple[int, int, int] | None = None
+    if version_result is not None:
+        if version_result.returncode != 0:
+            raise ConfigurationError(
+                f"Claude Code version check exited with {version_result.returncode}."
+            )
+        installed_version = _parse_claude_version(version_result.stdout)
+    if (
+        model == OPUS_MODEL
+        and installed_version is not None
+        and installed_version < OPUS_MIN_CLAUDE_VERSION
+    ):
+        required = ".".join(map(str, OPUS_MIN_CLAUDE_VERSION))
+        observed = ".".join(map(str, installed_version))
+        raise ConfigurationError(
+            f"Claude Opus 5 requires Claude Code {required} or newer; "
+            f"found {observed}."
+        )
+    required = (
+        "--print",
+        "--model",
+        "--effort",
+        "--safe-mode",
+        "--tools",
+        "--permission-mode",
+        "--no-session-persistence",
+        "--prompt-suggestions",
+        "--output-format",
+        "--system-prompt",
+    )
     missing = [flag for flag in required if flag not in help_result.stdout]
     if help_result.returncode != 0 or missing:
         detail = ", ".join(missing) if missing else f"exit {help_result.returncode}"
         raise ConfigurationError(
-            f"Claude Code is too old for the Fable advisor bridge ({detail}); update it."
+            f"Claude Code is too old for the bundled planning bridge ({detail}); "
+            "update it."
         )
     effort_match = re.search(
         r"--effort\s+<level>.*?\((low[^)]*)\)",
@@ -897,11 +997,24 @@ def verify_fable_prerequisites(effort: str) -> dict[str, str]:
         else set()
     )
     if effort not in advertised_efforts:
+        effort_label = "Fable" if model == FABLE_MODEL else display_name
         raise ConfigurationError(
-            f"Claude Code does not advertise Fable effort {effort!r}; "
+            f"Claude Code does not advertise {effort_label} effort {effort!r}; "
             "update Claude Code or choose a supported effort."
         )
-    return {"claude": str(claude), **auth}
+    result = {
+        "claude": str(claude),
+        **auth,
+    }
+    if installed_version is not None:
+        result["version"] = ".".join(map(str, installed_version))
+    return result
+
+
+def verify_fable_prerequisites(effort: str) -> dict[str, str]:
+    """Backward-compatible prerequisite helper for existing integrations."""
+
+    return verify_claude_prerequisites(FABLE_MODEL, effort)
 
 
 def _route_summary(route: dict[str, Any]) -> str:
@@ -909,6 +1022,8 @@ def _route_summary(route: dict[str, Any]) -> str:
         return f"custom agent {route['agent']}"
     if route["kind"] == "fable":
         return f"Claude Fable 5 {route['effort']}"
+    if route["kind"] == "claude_subscription":
+        return f"Claude Opus 5 {route['effort']}"
     return f"{route['model']}@{route['effort']}"
 
 
@@ -1045,11 +1160,14 @@ On PLAN_REVISE, record the latest finding IDs before revision. After the Planner
 
 When executor delegation materially improves speed, cost, quality, or context isolation, use only the configured executor route. Give each executor one bounded, self-contained packet with objective, relevant facts, constraints, owned files or read-only scope, dependencies, acceptance criteria, verification, and handoff format. Inspect every handoff, integrate it, and run final checks yourself.
 
-Explicit user instructions win, including no-subagents and task-local seat overrides. Persistent and task-local Planner and Advisor routes must remain distinct: reject the same direct model ID, the same custom-agent name, or Fable in both seats. This policy does not create or change a Goal, weaken approvals, alter permissions, or force a worker count.
+Explicit user instructions win, including no-subagents and task-local seat overrides. Persistent and task-local Planner and Advisor routes must remain distinct: reject the same direct model ID, the same custom-agent name, or more than one bundled Claude subscription seat. This policy does not create or change a Goal, weaken approvals, alter permissions, or force a worker count.
 
-Planner and Advisor are policy-isolated, root-directed seats: they cannot contact each other, Designer, or Executors, spawn descendants, edit files, execute work, or release Executor. They return only to the root. Designer is also root-directed: it cannot contact Planner, Advisor, or Executor, spawn descendants, redesign the root plan, change implementation code, or release Executor. Designer may edit only explicitly delegated design artifacts. Fable MCP requests do not carry caller identity, so caller isolation is instruction-enforced even though the bridge itself disables tools and persistence. If you are a spawned child, stay inside the supplied packet, report only to the root, never call planning tools, and never spawn descendants. An Executor never redesigns the root plan or contacts Planner, Advisor, or Designer.
+Planner and Advisor are policy-isolated, root-directed seats: they cannot contact each other, Designer, or Executors, spawn descendants, edit files, execute work, or release Executor. They return only to the root. Designer is also root-directed: it cannot contact Planner, Advisor, or Executor, spawn descendants, redesign the root plan, change implementation code, or release Executor. Designer may edit only explicitly delegated design artifacts. Bundled Claude MCP requests do not carry caller identity, so caller isolation is instruction-enforced even though the bridge itself disables tools and persistence. If you are a spawned child, stay inside the supplied packet, report only to the root, never call planning tools, and never spawn descendants. An Executor never redesigns the root plan or contacts Planner, Advisor, or Designer.
 """
-    if planner is not None and planner["kind"] == "fable":
+    if planner is not None and planner["kind"] in {
+        "fable",
+        "claude_subscription",
+    }:
         planner_hint = (
             "For the initial Planner draft, call `create_plan` from MCP server "
             f"{json.dumps(planner['server'])}; after PLAN_REVISE, call `revise_plan` "
@@ -1067,7 +1185,10 @@ Planner and Advisor are policy-isolated, root-directed seats: they cannot contac
         )
     else:
         planner_hint = "No Planner route is configured; the root drafts and revises."
-    if advisor is not None and advisor["kind"] == "fable":
+    if advisor is not None and advisor["kind"] in {
+        "fable",
+        "claude_subscription",
+    }:
         advisor_hint = (
             "For an advisor review, call `review_plan` from MCP server "
             f"{json.dumps(advisor['server'])} with the round's self-contained packet. "
@@ -1105,7 +1226,7 @@ For delegated executor work, call this tool with {_spawn_route(executor)}, fork_
 
 {provider_guard}
 
-Never use fork_turns = "all" with model, reasoning_effort, or agent_type: a full-history fork inherits the root route and rejects those overrides. Never silently substitute the root model when an exact child route is unavailable. Report the unavailable route to the root. A user's explicit current-task model, effort, agent, or no-subagents instruction overrides this saved default, but a task-local Planner and Advisor must still be distinct: reject the same direct model ID, the same custom-agent name, or Fable in both seats.
+Never use fork_turns = "all" with model, reasoning_effort, or agent_type: a full-history fork inherits the root route and rejects those overrides. Never silently substitute the root model when an exact child route is unavailable. Report the unavailable route to the root. A user's explicit current-task model, effort, agent, or no-subagents instruction overrides this saved default, but a task-local Planner and Advisor must still be distinct: reject the same direct model ID, the same custom-agent name, or more than one bundled Claude subscription seat.
 
 If you are a spawned child, do not call this tool or create descendants. Finish only your assigned packet and return to the root.
 """
@@ -1215,6 +1336,60 @@ def _managed_matches(state: dict[str, Any], current: dict[str, Any]) -> bool:
     return True
 
 
+def _subscription_seat(
+    planner: dict[str, Any] | None,
+    advisor: dict[str, Any] | None,
+) -> tuple[str, dict[str, Any]] | None:
+    for seat, route in (("planner", planner), ("advisor", advisor)):
+        if isinstance(route, dict) and route.get("kind") in {
+            "fable",
+            "claude_subscription",
+        }:
+            return seat, route
+    return None
+
+
+def _guard_subscription_transition(
+    existing_state: dict[str, Any] | None,
+    planner: dict[str, Any] | None,
+    advisor: dict[str, Any] | None,
+) -> None:
+    """Require an explicit full disable before replacing or moving Opus."""
+
+    if existing_state is None:
+        return
+    existing = _subscription_seat(
+        existing_state.get("planner"), existing_state.get("advisor")
+    )
+    requested = _subscription_seat(planner, advisor)
+    if existing is None:
+        return
+    existing_seat, existing_route = existing
+    opus_involved = existing_route.get("model") == OPUS_MODEL or (
+        requested is not None and requested[1].get("model") == OPUS_MODEL
+    )
+    if not opus_involved:
+        return
+    same_route = (
+        requested is not None
+        and requested[0] == existing_seat
+        and requested[1].get("model") == existing_route.get("model")
+    )
+    if same_route:
+        return
+    requested_label = (
+        f"{requested[0]} {requested[1].get('model')}"
+        if requested is not None
+        else "no bundled Claude subscription seat"
+    )
+    raise ConfigurationError(
+        "Refusing to replace or move the existing "
+        f"{existing_seat} {existing_route.get('model')} route with {requested_label}. "
+        "First run configure_native_routing.py --disable --apply, then run one "
+        "fresh complete setup command."
+    )
+
+
 def _batch_write(
     app: AppServer,
     edits: list[dict[str, Any]],
@@ -1296,7 +1471,7 @@ def _status(
             "model such as current Sol or Terra"
         )
         print(f"Config: {app.config_path}")
-        fable_available = True
+        subscription_available = True
         if state_matches:
             print(f"Executor: {_route_summary(state['executor'])}")
             planner = state.get("planner")
@@ -1305,20 +1480,26 @@ def _status(
             print(f"Planner: {_route_summary(planner) if planner else 'root'}")
             print(f"Advisor: {_route_summary(advisor) if advisor else 'none'}")
             print(f"Designer: {_route_summary(designer) if designer else 'none'}")
-            fable_routes = [
+            subscription_routes = [
                 route
                 for route in (planner, advisor)
-                if isinstance(route, dict) and route.get("kind") == "fable"
+                if isinstance(route, dict)
+                and route.get("kind") in {"fable", "claude_subscription"}
             ]
-            for route in fable_routes:
+            for route in subscription_routes:
+                label = (
+                    "Claude Fable 5"
+                    if route["model"] == FABLE_MODEL
+                    else "Claude Opus 5"
+                )
                 try:
-                    verify_fable_prerequisites(route["effort"])
+                    verify_claude_prerequisites(route["model"], route["effort"])
                 except ConfigurationError as exc:
-                    fable_available = False
-                    print(f"Claude Fable 5: unavailable — {exc}")
+                    subscription_available = False
+                    print(f"{label}: unavailable — {exc}")
                 else:
                     print(
-                        "Claude Fable 5: ready — first-party login; no model call made"
+                        f"{label}: ready — first-party login; no model call made"
                     )
             try:
                 verified = verify_agent_routes(
@@ -1380,7 +1561,7 @@ def _status(
             and routing_state.startswith("installed and effective")
             and state_matches
             and agent_routes_available
-            and fable_available
+            and subscription_available
             and not role_issues
             and not orphaned_roles
         )
@@ -1402,6 +1583,7 @@ def _prepare_setup_state(
     current = _current_values(config)
     feature = current["feature"]
     scalar_feature = isinstance(feature, bool)
+    _guard_subscription_transition(existing_state, planner, advisor)
 
     if existing_state is not None:
         if not _managed_matches(existing_state, current):
@@ -1556,7 +1738,8 @@ def _prepare_setup_state(
     existing_managed = existing_state.get("managed", {}) if existing_state else {}
     manage_mcp = (
         any(
-            isinstance(route, dict) and route.get("kind") == "fable"
+            isinstance(route, dict)
+            and route.get("kind") in {"fable", "claude_subscription"}
             for route in (planner, advisor)
         )
         or isinstance(existing_managed, dict)
@@ -1567,15 +1750,20 @@ def _prepare_setup_state(
         previous_mcp = previous.get("mcp")
         if not isinstance(previous_mcp, dict):
             previous_mcp = {}
-        fable_route = next(
+        subscription_route = next(
             (
                 route
                 for route in (planner, advisor)
-                if isinstance(route, dict) and route.get("kind") == "fable"
+                if isinstance(route, dict)
+                and route.get("kind") in {"fable", "claude_subscription"}
             ),
             None,
         )
-        selected = fable_route.get("server") if fable_route is not None else None
+        selected = (
+            subscription_route.get("server")
+            if subscription_route is not None
+            else None
+        )
         existing_mcp = (
             existing_managed.get("mcp")
             if isinstance(existing_managed, dict)
@@ -1682,7 +1870,8 @@ def _repair(
             return 0
         raise ConfigurationError(
             "Routing repair permits only managed mode/usage drift; another owned "
-            "control or Fable launcher setting changed."
+            "control or Fable launcher setting changed. The compatibility launcher "
+            "is shared by bundled Claude routes."
         )
 
     if any(not _is_managed(current[field]) for field in ("mode", "usage")):
@@ -1702,7 +1891,8 @@ def _repair(
     if not controls_match or not mcp_matches:
         raise ConfigurationError(
             "Routing repair permits only managed mode/usage drift; another owned "
-            "control or Fable launcher setting changed."
+            "control or Fable launcher setting changed. The compatibility launcher "
+            "is shared by bundled Claude routes."
         )
 
     if isinstance(state.get("scalar_origin"), bool):
@@ -1747,15 +1937,27 @@ def _repair(
     print(f"Will restore saved managed {rendered} {label} only.")
     print(
         "Will preserve the restore snapshot, seat routes, namespace, spawn metadata, "
-        "Fable launcher enablement, credentials, chats, and sessions."
+        "bundled Claude launcher enablement, credentials, chats, and sessions."
     )
-    fable_configured = any(
-        isinstance(route, dict) and route.get("kind") == "fable"
+    subscription_configured = any(
+        isinstance(route, dict)
+        and route.get("kind") in {"fable", "claude_subscription"}
         for route in (state.get("planner"), state.get("advisor"))
     )
-    if fable_configured:
+    if subscription_configured:
+        configured_model = next(
+            route.get("model")
+            for route in (state.get("planner"), state.get("advisor"))
+            if isinstance(route, dict)
+            and route.get("kind") in {"fable", "claude_subscription"}
+        )
+        label = (
+            "Claude Fable 5"
+            if configured_model == FABLE_MODEL
+            else "Claude Opus 5"
+        )
         print(
-            "This repair does not change Claude Fable 5 authentication or request "
+            f"This repair does not change {label} authentication or request "
             "re-authentication."
         )
     if not apply:
@@ -2018,10 +2220,15 @@ def main() -> int:
             planner: dict[str, Any] | None = None
             advisor: dict[str, Any] | None = None
             designer: dict[str, Any] | None = None
-            fable_auth: dict[str, str] | None = None
-            fable_server = (
+            subscription_auth: dict[str, str] | None = None
+            subscription_server = (
                 select_fable_server()
-                if args.planner_fable or args.advisor_fable
+                if (
+                    args.planner_fable
+                    or args.planner_opus
+                    or args.advisor_fable
+                    or args.advisor_opus
+                )
                 else None
             )
             if args.planner_model:
@@ -2044,7 +2251,14 @@ def main() -> int:
                     "kind": "fable",
                     "model": FABLE_MODEL,
                     "effort": normalize_fable_effort(args.planner_effort),
-                    "server": fable_server,
+                    "server": subscription_server,
+                }
+            elif args.planner_opus:
+                planner = {
+                    "kind": "claude_subscription",
+                    "model": OPUS_MODEL,
+                    "effort": normalize_opus_effort(args.planner_effort),
+                    "server": subscription_server,
                 }
 
             if args.advisor_model:
@@ -2067,7 +2281,14 @@ def main() -> int:
                     "kind": "fable",
                     "model": FABLE_MODEL,
                     "effort": normalize_fable_effort(args.advisor_effort),
-                    "server": fable_server,
+                    "server": subscription_server,
+                }
+            elif args.advisor_opus:
+                advisor = {
+                    "kind": "claude_subscription",
+                    "model": OPUS_MODEL,
+                    "effort": normalize_opus_effort(args.advisor_effort),
+                    "server": subscription_server,
                 }
 
             if args.designer_model:
@@ -2084,13 +2305,14 @@ def main() -> int:
                     "effort": designer_effort,
                 }
             validate_planning_routes(planner, advisor)
-            fable_efforts = {
-                route["effort"]
+            subscription_prerequisites = {
+                (route["model"], route["effort"])
                 for route in (planner, advisor)
-                if isinstance(route, dict) and route.get("kind") == "fable"
+                if isinstance(route, dict)
+                and route.get("kind") in {"fable", "claude_subscription"}
             }
-            for effort in sorted(fable_efforts):
-                fable_auth = verify_fable_prerequisites(effort)
+            for model, effort in sorted(subscription_prerequisites):
+                subscription_auth = verify_claude_prerequisites(model, effort)
 
             verified_agents = verify_agent_routes(
                 app.codex_home,
@@ -2128,9 +2350,14 @@ def main() -> int:
                     f"Advisor effort alias: {args.advisor_effort} -> "
                     f"{advisor['effort']} (Claude Code effective value)"
                 )
-            if fable_auth is not None:
+            if subscription_auth is not None:
+                subscription_label = (
+                    "Claude Opus 5"
+                    if args.planner_opus or args.advisor_opus
+                    else "Claude Fable 5"
+                )
                 print(
-                    "Claude Fable 5 login: ready — first-party; "
+                    f"{subscription_label} login: ready — first-party; "
                     "setup makes no model call"
                 )
             if verified_agents:

--- a/plugins/codex-orchestration/skills/codex-orchestration/scripts/external_subscription.py
+++ b/plugins/codex-orchestration/skills/codex-orchestration/scripts/external_subscription.py
@@ -11,6 +11,12 @@ import fable_advisor_mcp
 
 FABLE_PROVIDER = "claude-fable"
 FABLE_MODEL = "claude-fable-5"
+OPUS_PROVIDER = "claude-opus"
+OPUS_MODEL = "claude-opus-5"
+SEALED_MODELS = {
+    FABLE_PROVIDER: FABLE_MODEL,
+    OPUS_PROVIDER: OPUS_MODEL,
+}
 OPERATION_SEATS = {
     "create_plan": "planner",
     "revise_plan": "planner",
@@ -35,10 +41,13 @@ def validate_route(
 ) -> tuple[dict[str, Any], str]:
     """Resolve only manifest-sealed provider/model/effort/operation tuples."""
 
-    _require(provider_id == FABLE_PROVIDER, "subscription provider is not audited")
+    _require(provider_id in SEALED_MODELS, "subscription provider is not audited")
     provider = external_providers.load_provider(provider_id)
     _require(provider["lane"] == "subscription", "provider is not a subscription adapter")
-    _require(model == FABLE_MODEL, "subscription model is not sealed")
+    _require(
+        model == SEALED_MODELS[provider_id],
+        "subscription provider/model pair is not sealed",
+    )
     selected_effort = external_providers.resolve_effort(provider, model, effort)
     adapter = provider["subscription_adapter"]
     _require(
@@ -67,10 +76,10 @@ def status(
         provider_id, model, effort, operation
     )
     route = fable_advisor_mcp.load_fable_route(seat=seat)
-    _require(route["model"] == model, "configured Fable route model drifted")
+    _require(route["model"] == model, "configured Claude route model drifted")
     _require(
         route["effort"] == selected_effort,
-        "configured Fable effort differs from the requested effort",
+        "configured Claude effort differs from the requested effort",
     )
     executable = fable_advisor_mcp.resolve_claude()
     auth = fable_advisor_mcp.check_claude_auth(executable)
@@ -93,7 +102,7 @@ def invoke(
     model: str = FABLE_MODEL,
     effort: str = "high",
 ) -> dict[str, Any]:
-    """Dispatch one operation through the existing no-tools Fable bridge."""
+    """Dispatch one operation through the existing no-tools Claude bridge."""
 
     _, selected_effort = validate_route(provider_id, model, effort, operation)
     expected_keys = {
@@ -108,6 +117,16 @@ def invoke(
     _require(
         all(type(value) is str and bool(value.strip()) for value in arguments.values()),
         "subscription arguments must be non-empty strings",
+    )
+    seat = OPERATION_SEATS[operation]
+    configured = fable_advisor_mcp.load_fable_route(seat=seat)
+    _require(
+        configured["model"] == model,
+        "configured Claude route model differs from the requested model",
+    )
+    _require(
+        configured["effort"] == selected_effort,
+        "configured Claude route effort differs from the requested effort",
     )
     dispatch: dict[str, Callable[..., dict[str, Any]]] = {
         "create_plan": fable_advisor_mcp.create_plan,
@@ -126,5 +145,10 @@ def invoke(
     _require(
         model in result.get("used_models", []),
         "subscription runtime metadata omitted the primary model",
+    )
+    allowed_runtime = fable_advisor_mcp.ALLOWED_RUNTIME_MODELS_BY_PRIMARY[model]
+    _require(
+        set(result.get("used_models", [])).issubset(allowed_runtime),
+        "subscription runtime metadata included an unsealed helper model",
     )
     return result

--- a/plugins/codex-orchestration/skills/codex-orchestration/scripts/fable_advisor_mcp.py
+++ b/plugins/codex-orchestration/skills/codex-orchestration/scripts/fable_advisor_mcp.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Root-directed, no-tools MCP bridge from Codex to Claude Fable 5.
+"""Root-directed, no-tools MCP bridge to sealed Claude subscription models.
 
 The managed policy reserves stateless Planner and Advisor operations for the
 root; MCP requests do not carry caller identity, so the server cannot enforce
@@ -25,6 +25,7 @@ import routing_state
 STATE_FILENAME = ".codex-orchestration-routing.json"
 MANAGED_MARKER = routing_state.MANAGED_MARKER
 FABLE_MODEL = routing_state.FABLE_MODEL
+OPUS_MODEL = routing_state.OPUS_MODEL
 FABLE_SERVERS = routing_state.FABLE_SERVERS
 SUPPORTED_EFFORTS = routing_state.FABLE_EFFORTS
 # Claude Code currently reports this exact internal helper alongside Fable for
@@ -32,6 +33,12 @@ SUPPORTED_EFFORTS = routing_state.FABLE_EFFORTS
 # rotates or any other model appears.
 FABLE_HELPER_MODEL = "claude-haiku-4-5-20251001"
 ALLOWED_RUNTIME_MODELS = frozenset({FABLE_MODEL, FABLE_HELPER_MODEL})
+ALLOWED_RUNTIME_MODELS_BY_PRIMARY = {
+    FABLE_MODEL: ALLOWED_RUNTIME_MODELS,
+    # No Opus helper identity has been independently verified. Fail closed if
+    # Claude Code reports anything beyond the sealed primary.
+    OPUS_MODEL: frozenset({OPUS_MODEL}),
+}
 CLAUDE_TIMEOUT_SECONDS = 600
 AUTH_TIMEOUT_SECONDS = 20
 # Applies to the combined user-controlled text sent by one model operation.
@@ -39,7 +46,52 @@ MAX_INPUT_CHARS = 200_000
 SENSITIVE_ENV = {
     "ANTHROPIC_API_KEY",
     "ANTHROPIC_AUTH_TOKEN",
+    "ANTHROPIC_AWS_API_KEY",
+    "ANTHROPIC_AWS_BASE_URL",
+    "ANTHROPIC_AWS_WORKSPACE_ID",
+    "ANTHROPIC_BASE_URL",
+    "ANTHROPIC_BEDROCK_BASE_URL",
+    "ANTHROPIC_BEDROCK_MANTLE_BASE_URL",
+    "ANTHROPIC_BETAS",
+    "ANTHROPIC_CUSTOM_HEADERS",
+    "ANTHROPIC_CUSTOM_MODEL_OPTION",
+    "ANTHROPIC_CUSTOM_MODEL_OPTION_DESCRIPTION",
+    "ANTHROPIC_CUSTOM_MODEL_OPTION_NAME",
+    "ANTHROPIC_CUSTOM_MODEL_OPTION_SUPPORTED_CAPABILITIES",
+    "ANTHROPIC_DEFAULT_FABLE_MODEL",
+    "ANTHROPIC_DEFAULT_FABLE_MODEL_DESCRIPTION",
+    "ANTHROPIC_DEFAULT_FABLE_MODEL_NAME",
+    "ANTHROPIC_DEFAULT_FABLE_MODEL_SUPPORTED_CAPABILITIES",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL_DESCRIPTION",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL_NAME",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL_SUPPORTED_CAPABILITIES",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL_DESCRIPTION",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL_NAME",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL_SUPPORTED_CAPABILITIES",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL_DESCRIPTION",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL_NAME",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL_SUPPORTED_CAPABILITIES",
+    "ANTHROPIC_FOUNDRY_API_KEY",
+    "ANTHROPIC_FOUNDRY_AUTH_TOKEN",
+    "ANTHROPIC_FOUNDRY_BASE_URL",
+    "ANTHROPIC_FOUNDRY_RESOURCE",
+    "ANTHROPIC_MODEL",
+    "ANTHROPIC_SMALL_FAST_MODEL",
+    "ANTHROPIC_VERTEX_BASE_URL",
+    "ANTHROPIC_VERTEX_PROJECT_ID",
+    "CLAUDE_CODE_EFFORT_LEVEL",
+    "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY",
+    "CLAUDE_CODE_SKIP_BEDROCK_AUTH",
+    "CLAUDE_CODE_SKIP_FOUNDRY_AUTH",
+    "CLAUDE_CODE_SKIP_MANTLE_AUTH",
+    "CLAUDE_CODE_SKIP_VERTEX_AUTH",
+    "CLAUDE_CODE_SUBAGENT_MODEL",
+    "CLAUDE_CODE_USE_ANTHROPIC_AWS",
     "CLAUDE_CODE_USE_BEDROCK",
+    "CLAUDE_CODE_USE_MANTLE",
     "CLAUDE_CODE_USE_VERTEX",
     "CLAUDE_CODE_USE_FOUNDRY",
 }
@@ -49,18 +101,18 @@ STALE_BRIDGE_RECOVERY = (
     "start a new task; do not re-authenticate solely for this loaded-bridge failure."
 )
 
-ADVISOR_SYSTEM_PROMPT = """You are Claude Fable 5 acting only as a plan advisor to Codex's root orchestrator.
+ADVISOR_SYSTEM_PROMPT = """You are the configured Claude model acting only as a plan advisor to Codex's root orchestrator.
 Review the supplied self-contained packet for material correctness, missing constraints, unsafe sequencing, ownership conflicts, and verification gaps. Do not edit files, call tools, spawn agents, contact the Planner or executors, or attempt implementation.
 
 Your first non-empty line must be exactly PLAN_APPROVED or PLAN_REVISE.
 Use PLAN_APPROVED only when no material gap is present. Use PLAN_REVISE when correction is needed. For PLAN_REVISE, assign every material finding a stable, unique finding ID and give a concrete correction. On later rounds, preserve IDs from the supplied cumulative ledger. Ignore style preferences. Report only to the root orchestrator."""
 
-PLANNER_CREATE_SYSTEM_PROMPT = """You are Claude Fable 5 acting only as a plan author for Codex's root orchestrator.
+PLANNER_CREATE_SYSTEM_PROMPT = """You are the configured Claude model acting only as a plan author for Codex's root orchestrator.
 Create a concrete implementation plan from the supplied self-contained packet. Include constraints, ownership, sequencing, acceptance criteria, security and compatibility boundaries, and behavioral plus regression verification. Do not edit files, call tools, spawn agents, contact the Advisor or executors, or attempt implementation.
 
 Your first non-empty line must be exactly PLAN_DRAFT. Return the complete draft plan after that signal. Report only to the root orchestrator."""
 
-PLANNER_REVISE_SYSTEM_PROMPT = """You are Claude Fable 5 acting only as a stateless plan reviser for Codex's root orchestrator.
+PLANNER_REVISE_SYSTEM_PROMPT = """You are the configured Claude model acting only as a stateless plan reviser for Codex's root orchestrator.
 Revise the supplied canonical current plan using the original task, its source plan version, the latest Advisor critique, and the compact cumulative history. Do not edit files, call tools, spawn agents, contact the Advisor or executors, or attempt implementation.
 
 Your response must use exactly this top-level structure:
@@ -81,7 +133,7 @@ Seat = Literal["planner", "advisor"]
 
 
 class AdvisorError(RuntimeError):
-    """Fail-closed error for any Fable bridge operation."""
+    """Fail-closed error for any bundled Claude bridge operation."""
 
 
 def codex_home() -> Path:
@@ -167,7 +219,9 @@ def _read_routing_state(home: Path | None = None) -> dict[str, Any]:
             raise AdvisorError("The saved routing state has multiple hard links.")
         payload = json.loads(path.read_text(encoding="utf-8"))
     except FileNotFoundError as exc:
-        raise AdvisorError("Claude Fable 5 is not configured; run setup first.") from exc
+        raise AdvisorError(
+            "A bundled Claude planning model is not configured; run setup first."
+        ) from exc
     except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise AdvisorError("Could not read valid routing state.") from exc
     try:
@@ -189,20 +243,25 @@ def _read_routing_state(home: Path | None = None) -> dict[str, Any]:
 
 def _validate_seat(seat: str) -> Seat:
     if seat not in {"planner", "advisor"}:
-        raise AdvisorError("Fable seat must be `planner` or `advisor`.")
+        raise AdvisorError("Claude planning seat must be `planner` or `advisor`.")
     return seat  # type: ignore[return-value]
 
 
 def _validate_fable_route(route: Any, *, seat: Seat) -> dict[str, str]:
-    if not isinstance(route, dict) or route.get("kind") != "fable":
-        raise AdvisorError(f"Claude Fable 5 is not the configured {seat}.")
+    if not isinstance(route, dict) or route.get("kind") not in {
+        "fable",
+        "claude_subscription",
+    }:
+        raise AdvisorError(
+            f"A bundled Claude model is not the configured {seat}."
+        )
     return {"model": route["model"], "effort": route["effort"]}
 
 
 def load_fable_route(
     home: Path | None = None, *, seat: str = "advisor"
 ) -> dict[str, str]:
-    """Load and validate one explicitly authorized Fable seat.
+    """Load and validate one explicitly authorized bundled Claude seat.
 
     ``seat`` defaults to Advisor for compatibility with the original bridge.
     It is deliberately constrained and resolved from disk on every invocation.
@@ -230,20 +289,31 @@ def _first_non_empty_line(response: str) -> str:
     return next((line.strip() for line in response.splitlines() if line.strip()), "")
 
 
-def _validate_runtime_models(usage: Any) -> list[str]:
+def _validate_runtime_models(
+    usage: Any, primary_model: str = FABLE_MODEL
+) -> list[str]:
+    allowed_models = ALLOWED_RUNTIME_MODELS_BY_PRIMARY.get(primary_model)
+    if allowed_models is None:
+        raise AdvisorError("The configured Claude primary model is not sealed.")
+    policy_label = "Fable" if primary_model == FABLE_MODEL else "Claude"
+    primary_label = (
+        "Claude Fable 5" if primary_model == FABLE_MODEL else "Claude Opus 5"
+    )
     raw_models = list(usage) if isinstance(usage, dict) else []
     if not all(isinstance(model, str) for model in raw_models):
         raise AdvisorError(
-            "Runtime metadata reported a model outside the allowed Fable runtime policy."
+            f"Runtime metadata reported a model outside the allowed {policy_label} "
+            "runtime policy."
         )
     used_models = sorted(raw_models)
-    if FABLE_MODEL not in used_models:
+    if primary_model not in used_models:
         raise AdvisorError(
-            "Runtime metadata did not confirm the pinned Claude Fable 5 primary model."
+            f"Runtime metadata did not confirm the pinned {primary_label} primary model."
         )
-    if not set(used_models).issubset(ALLOWED_RUNTIME_MODELS):
+    if not set(used_models).issubset(allowed_models):
         raise AdvisorError(
-            "Runtime metadata reported a model outside the allowed Fable runtime policy."
+            f"Runtime metadata reported a model outside the allowed {policy_label} "
+            "runtime policy."
         )
     return used_models
 
@@ -256,14 +326,17 @@ def _invoke_fable(
     system_prompt: str,
     allowed_signals: set[str],
 ) -> tuple[str, str, dict[str, str], dict[str, str], list[str]]:
-    """Run one stateless, seat-authorized, no-tools Fable operation."""
+    """Run one stateless, seat-authorized, no-tools Claude operation."""
 
     route = load_fable_route(seat=seat)
+    display_name = (
+        "Claude Fable 5" if route["model"] == FABLE_MODEL else "Claude Opus 5"
+    )
     claude = resolve_claude()
     auth = check_claude_auth(claude)
     command = [
         str(claude),
-        "-p",
+        "--print",
         "--model",
         route["model"],
         "--effort",
@@ -293,30 +366,30 @@ def _invoke_fable(
             check=False,
         )
     except subprocess.TimeoutExpired as exc:
-        raise AdvisorError(f"Claude Fable 5 {operation} timed out.") from exc
+        raise AdvisorError(f"{display_name} {operation} timed out.") from exc
     except OSError as exc:
-        raise AdvisorError(f"Could not start Claude Fable 5 {operation}.") from exc
+        raise AdvisorError(f"Could not start {display_name} {operation}.") from exc
     if result.returncode != 0:
         raise AdvisorError(
-            f"Claude Fable 5 {operation} exited with {result.returncode}; output withheld."
+            f"{display_name} {operation} exited with {result.returncode}; output withheld."
         )
     try:
         payload = json.loads(result.stdout)
     except json.JSONDecodeError as exc:
-        raise AdvisorError(f"Claude Fable 5 {operation} returned malformed JSON.") from exc
+        raise AdvisorError(f"{display_name} {operation} returned malformed JSON.") from exc
     if not isinstance(payload, dict) or not isinstance(payload.get("result"), str):
-        raise AdvisorError(f"Claude Fable 5 {operation} returned an unexpected response.")
+        raise AdvisorError(f"{display_name} {operation} returned an unexpected response.")
     # Authorize the complete runtime identity set before interpreting or
     # returning any model-authored plan/review content.
-    used_models = _validate_runtime_models(payload.get("modelUsage"))
+    used_models = _validate_runtime_models(payload.get("modelUsage"), route["model"])
     response = payload["result"].strip()
     signal = _first_non_empty_line(response)
     if signal not in allowed_signals:
         if operation == "plan review":
-            raise AdvisorError("Claude Fable 5 omitted the required plan decision.")
+            raise AdvisorError(f"{display_name} omitted the required plan decision.")
         expected = " or ".join(sorted(allowed_signals))
         raise AdvisorError(
-            f"Claude Fable 5 {operation} omitted the required {expected} signal."
+            f"{display_name} {operation} omitted the required {expected} signal."
         )
     return signal, response, route, auth, used_models
 
@@ -327,7 +400,7 @@ def _base_result(
     return {
         # ``model`` is the route's pinned primary identity; ``used_models``
         # preserves every runtime-reported model, including an allowed helper.
-        "model": FABLE_MODEL,
+        "model": route["model"],
         "effort": route["effort"],
         "auth_method": auth["auth_method"],
         "used_models": used_models,
@@ -360,20 +433,20 @@ def _validate_revision_structure(response: str) -> None:
     ]
     if len(ledger_positions) != 1 or len(plan_positions) != 1:
         raise AdvisorError(
-            "Claude Fable 5 plan revision must contain exactly one FINDINGS_LEDGER "
+            "Claude plan revision must contain exactly one FINDINGS_LEDGER "
             "and one REVISED_PLAN section."
         )
     ledger_index = ledger_positions[0]
     plan_index = plan_positions[0]
     if ledger_index >= plan_index:
         raise AdvisorError(
-            "Claude Fable 5 plan revision sections are in the wrong order."
+            "Claude plan revision sections are in the wrong order."
         )
     ledger = "\n".join(lines[ledger_index + 1 : plan_index]).strip()
     revised_plan = "\n".join(lines[plan_index + 1 :]).strip()
     if not ledger or not revised_plan:
         raise AdvisorError(
-            "Claude Fable 5 plan revision has an empty FINDINGS_LEDGER or REVISED_PLAN section."
+            "Claude plan revision has an empty FINDINGS_LEDGER or REVISED_PLAN section."
         )
 
 
@@ -427,6 +500,8 @@ def review_plan(packet: str) -> dict[str, Any]:
 
 
 def _configured_fable_seats() -> dict[str, dict[str, str]]:
+    """Return configured bundled Claude seats (legacy public name)."""
+
     payload = _read_routing_state()
     routes: dict[str, dict[str, str]] = {}
     for seat in ("planner", "advisor"):
@@ -435,11 +510,13 @@ def _configured_fable_seats() -> dict[str, dict[str, str]]:
             continue
         if not isinstance(value, dict):
             raise AdvisorError(f"The saved {seat} route is invalid.")
-        if value.get("kind") != "fable":
+        if value.get("kind") not in {"fable", "claude_subscription"}:
             continue
         routes[seat] = _validate_fable_route(value, seat=_validate_seat(seat))
     if not routes:
-        raise AdvisorError("Claude Fable 5 is not configured for Planner or Advisor.")
+        raise AdvisorError(
+            "No bundled Claude model is configured for Planner or Advisor."
+        )
     return routes
 
 
@@ -473,8 +550,8 @@ def tool_definitions() -> list[dict[str, Any]]:
     return [
         {
             "name": "create_plan",
-            "title": "Create a plan with Claude Fable 5",
-            "description": "Create one stateless plan draft with the configured Fable Planner.",
+            "title": "Create a plan with the configured Claude model",
+            "description": "Create one stateless plan draft with the configured Claude Planner.",
             "inputSchema": {
                 "type": "object",
                 "properties": {"packet": {**string_property, "description": "Complete planning packet."}},
@@ -485,7 +562,7 @@ def tool_definitions() -> list[dict[str, Any]]:
         },
         {
             "name": "revise_plan",
-            "title": "Revise a plan with Claude Fable 5",
+            "title": "Revise a plan with the configured Claude model",
             "description": "Create one stateless revision with a findings ledger and complete revised plan.",
             "inputSchema": {
                 "type": "object",
@@ -502,8 +579,8 @@ def tool_definitions() -> list[dict[str, Any]]:
         },
         {
             "name": "review_plan",
-            "title": "Review a plan with Claude Fable 5",
-            "description": "Review one self-contained packet with the configured Fable Advisor.",
+            "title": "Review a plan with the configured Claude model",
+            "description": "Review one self-contained packet with the configured Claude Advisor.",
             "inputSchema": {
                 "type": "object",
                 "properties": {"packet": {**string_property, "description": "Complete context, plan, risks, slices, and checks."}},
@@ -514,8 +591,8 @@ def tool_definitions() -> list[dict[str, Any]]:
         },
         {
             "name": "status",
-            "title": "Check Claude Fable 5 Planner and Advisor status",
-            "description": "Check configured Fable seats and first-party login without a model call.",
+            "title": "Check bundled Claude Planner and Advisor status",
+            "description": "Check configured Claude seats and first-party login without a model call.",
             "inputSchema": {"type": "object", "properties": {}, "additionalProperties": False},
             "annotations": annotations,
         },
@@ -547,7 +624,12 @@ def handle_request(request: dict[str, Any]) -> dict[str, Any] | None:
         result = {
             "protocolVersion": "2025-06-18",
             "capabilities": {"tools": {"listChanged": False}},
-            "serverInfo": {"name": "codex-orchestration-fable-advisor", "version": "2.0.0"},
+            # Preserve the historical launcher identity for loaded-plugin
+            # compatibility; the tool metadata describes either sealed model.
+            "serverInfo": {
+                "name": "codex-orchestration-fable-advisor",
+                "version": "2.0.0",
+            },
         }
     elif method == "ping":
         result = {}

--- a/plugins/codex-orchestration/skills/codex-orchestration/scripts/fable_advisor_mcp.py
+++ b/plugins/codex-orchestration/skills/codex-orchestration/scripts/fable_advisor_mcp.py
@@ -11,6 +11,7 @@ no-tools/no-persistence process.
 from __future__ import annotations
 
 import json
+import math
 import os
 from pathlib import Path
 import stat
@@ -142,9 +143,30 @@ def codex_home() -> Path:
 
 
 def sanitized_environment() -> dict[str, str]:
-    env = os.environ.copy()
-    for name in SENSITIVE_ENV:
-        env.pop(name, None)
+    common_names = ("PATH", "LANG", "LC_ALL", "LC_CTYPE")
+    if os.name == "nt":
+        canonical_names = (
+            *common_names,
+            "SystemRoot",
+            "ComSpec",
+            "PATHEXT",
+            "TEMP",
+            "TMP",
+            "USERPROFILE",
+        )
+        inherited = {name.casefold(): value for name, value in os.environ.items()}
+        env = {
+            canonical: inherited[canonical.casefold()]
+            for canonical in canonical_names
+            if canonical.casefold() in inherited
+        }
+    else:
+        env = {
+            name: os.environ[name]
+            for name in (*common_names, "HOME", "TMPDIR")
+            if name in os.environ
+        }
+    env["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"] = "1"
     return env
 
 
@@ -299,12 +321,33 @@ def _validate_runtime_models(
     primary_label = (
         "Claude Fable 5" if primary_model == FABLE_MODEL else "Claude Opus 5"
     )
-    raw_models = list(usage) if isinstance(usage, dict) else []
-    if not all(isinstance(model, str) for model in raw_models):
+    if not isinstance(usage, dict):
+        raise AdvisorError("Runtime metadata has a malformed modelUsage mapping.")
+    raw_models = list(usage)
+    if not all(isinstance(model, str) and bool(model.strip()) for model in raw_models):
         raise AdvisorError(
             f"Runtime metadata reported a model outside the allowed {policy_label} "
             "runtime policy."
         )
+    for model_usage in usage.values():
+        if not isinstance(model_usage, dict) or not model_usage:
+            raise AdvisorError("Runtime metadata has a malformed modelUsage value.")
+        for field, value in model_usage.items():
+            is_nonnegative_finite_number = (
+                type(value) is int
+                and value >= 0
+                or type(value) is float
+                and math.isfinite(value)
+                and value >= 0
+            )
+            if (
+                not isinstance(field, str)
+                or not field.strip()
+                or not is_nonnegative_finite_number
+            ):
+                raise AdvisorError(
+                    "Runtime metadata has a malformed modelUsage value."
+                )
     used_models = sorted(raw_models)
     if primary_model not in used_models:
         raise AdvisorError(

--- a/plugins/codex-orchestration/skills/codex-orchestration/scripts/routing_state.py
+++ b/plugins/codex-orchestration/skills/codex-orchestration/scripts/routing_state.py
@@ -15,6 +15,8 @@ MANAGED_MARKER = "[codex-orchestration managed-policy v1]"
 ROUTING_TOOL_NAMESPACE = "agents"
 FABLE_MODEL = "claude-fable-5"
 FABLE_EFFORTS = frozenset({"low", "medium", "high", "xhigh", "max"})
+OPUS_MODEL = "claude-opus-5"
+OPUS_EFFORTS = frozenset({"low", "medium", "high", "xhigh", "max"})
 FABLE_SERVERS = frozenset(
     {
         "fable-advisor-python3",
@@ -23,7 +25,7 @@ FABLE_SERVERS = frozenset(
     }
 )
 
-_SCHEMA_POLICY_PAIRS = {1: 1, 2: 2, 3: 3, 4: 4}
+_SCHEMA_POLICY_PAIRS = {1: 1, 2: 2, 3: 3, 4: 4, 5: 5}
 _MODEL_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:+/@-]{0,199}$")
 _AGENT_RE = re.compile(r"^[a-z][a-z0-9_]{0,62}$")
 _EFFORT_RE = re.compile(r"^[a-z][a-z0-9_-]{0,31}$")
@@ -135,6 +137,24 @@ def _validate_route(route: Any, *, seat: str, schema: int) -> str:
             type(route["server"]) is str and route["server"] in FABLE_SERVERS,
             "Fable server is unsupported",
         )
+    elif kind == "claude_subscription":
+        _require(
+            seat in {"planner", "advisor"} and schema >= 5,
+            f"{seat} cannot use a Claude subscription route in schema {schema}",
+        )
+        _require(
+            set(route) == {"kind", "model", "effort", "server"},
+            f"{seat} Claude subscription route has the wrong shape",
+        )
+        _require(route["model"] == OPUS_MODEL, "Claude subscription model is not pinned")
+        _require(
+            type(route["effort"]) is str and route["effort"] in OPUS_EFFORTS,
+            "Claude Opus 5 effort is unsupported",
+        )
+        _require(
+            type(route["server"]) is str and route["server"] in FABLE_SERVERS,
+            "Claude subscription server is unsupported",
+        )
     else:
         raise RoutingStateError(f"{seat} route kind is unsupported")
     return kind
@@ -145,13 +165,16 @@ def _validate_route_separation(planner: Any, advisor: Any) -> None:
         return
     planner_kind = planner["kind"]
     advisor_kind = advisor["kind"]
+    subscription_kinds = {"fable", "claude_subscription"}
     same_route = (
         planner_kind == advisor_kind == "model"
         and planner["model"] == advisor["model"]
     ) or (
         planner_kind == advisor_kind == "agent"
         and planner["agent"] == advisor["agent"]
-    ) or planner_kind == advisor_kind == "fable"
+    ) or (
+        planner_kind in subscription_kinds and advisor_kind in subscription_kinds
+    )
     _require(not same_route, "Planner and Advisor routes are not independent")
 
 
@@ -203,7 +226,7 @@ def _validate_scalar_conversion(state: dict[str, Any], managed: dict[str, Any]) 
 
 
 def validate_routing_state(value: Any) -> dict[str, Any]:
-    """Validate and return one exact, complete persisted schema 1 through 4.
+    """Validate and return one exact, complete persisted schema 1 through 5.
 
     Unknown keys and future extensions are rejected intentionally. Callers must
     perform their own secure file read and any caller-specific path/seat checks.
@@ -284,12 +307,16 @@ def validate_routing_state(value: Any) -> dict[str, Any]:
     ):
         _validate_snapshot(previous[key], expected_type)
 
-    fable_routes = [
+    subscription_routes = [
         route
         for route in (planner, advisor)
-        if type(route) is dict and route.get("kind") == "fable"
+        if type(route) is dict
+        and route.get("kind") in {"fable", "claude_subscription"}
     ]
-    _require(len(fable_routes) <= 1, "more than one Fable seat is configured")
+    _require(
+        len(subscription_routes) <= 1,
+        "more than one Claude subscription seat is configured",
+    )
     if managed_has_mcp:
         managed_mcp = managed["mcp"]
         previous_mcp = previous["mcp"]
@@ -310,14 +337,17 @@ def validate_routing_state(value: Any) -> dict[str, Any]:
     else:
         true_servers = []
 
-    if fable_routes:
-        selected_server = fable_routes[0]["server"]
+    if subscription_routes:
+        selected_server = subscription_routes[0]["server"]
         _require(
             true_servers == [selected_server],
-            "MCP state must enable exactly the selected Fable launcher",
+            "MCP state must enable exactly the selected Claude launcher",
         )
     else:
-        _require(not true_servers, "MCP state enables a launcher without a Fable seat")
+        _require(
+            not true_servers,
+            "MCP state enables a launcher without a Claude subscription seat",
+        )
 
     _validate_scalar_conversion(value, managed)
     return value

--- a/plugins/codex-orchestration/skills/codex-orchestration/scripts/routing_state.py
+++ b/plugins/codex-orchestration/skills/codex-orchestration/scripts/routing_state.py
@@ -106,6 +106,10 @@ def _validate_route(route: Any, *, seat: str, schema: int) -> str:
             f"{seat} model route has an invalid model",
         )
         _require(
+            route["model"] not in {FABLE_MODEL, OPUS_MODEL},
+            f"{seat} model route uses a reserved Claude model",
+        )
+        _require(
             type(route["effort"]) is str
             and _EFFORT_RE.fullmatch(route["effort"]) is not None,
             f"{seat} model route has an invalid effort",

--- a/scripts/preflight.py
+++ b/scripts/preflight.py
@@ -24,6 +24,11 @@ PORTABILITY_BASE_MODULES = (
     "tests.test_packaging",
     "tests.test_skill_contract",
 )
+ROUTING_PORTABILITY_MODULES = (
+    "tests.test_native_routing",
+    "tests.test_routing_state",
+    "tests.test_fable_advisor_mcp",
+)
 EXTERNAL_PORTABILITY_MODULES = (
     "tests.test_external_cli_trust",
     "tests.test_external_configurator",
@@ -347,6 +352,15 @@ def ci_checks(
                 timeout=600,
             ),
         ]
+        results.extend(
+            unittest_check(
+                root,
+                f"portability-{module.rsplit('.', 1)[-1].removeprefix('test_').replace('_', '-')}",
+                [module],
+                timeout=300,
+            )
+            for module in ROUTING_PORTABILITY_MODULES
+        )
         results.extend(
             unittest_check(
                 root,

--- a/tests/plugin_lifecycle_smoke.py
+++ b/tests/plugin_lifecycle_smoke.py
@@ -32,7 +32,7 @@ PLUGIN_ID = "codex-orchestration@codex-orchestration"
 MARKETPLACE_NAME = "codex-orchestration"
 OLD_RELEASE = "a1d9c546665c3253cdcaa8fe5c0c060199a6126c"
 OLD_VERSION = "0.5.0"
-NEW_VERSION = "0.8.0"
+NEW_VERSION = "0.9.0"
 COMMAND_TIMEOUT_SECONDS = 60
 
 

--- a/tests/test_external_providers.py
+++ b/tests/test_external_providers.py
@@ -21,9 +21,10 @@ import external_providers as PROVIDERS  # noqa: E402
 
 
 class ExternalProviderTests(unittest.TestCase):
-    def test_bundled_openrouter_and_fable_templates_are_strict(self) -> None:
+    def test_bundled_openrouter_and_claude_templates_are_strict(self) -> None:
         openrouter = PROVIDERS.load_provider("openrouter")
         fable = PROVIDERS.load_provider("claude-fable")
+        opus = PROVIDERS.load_provider("claude-opus")
         self.assertEqual(openrouter["wire_api"], "responses")
         self.assertEqual(openrouter["base_url"], "https://openrouter.ai/api/v1")
         self.assertEqual(
@@ -39,6 +40,13 @@ class ExternalProviderTests(unittest.TestCase):
         )
         self.assertEqual(fable["lane"], "subscription")
         self.assertEqual(fable["runtime_identity"], "cli_metadata")
+        self.assertEqual(opus["lane"], "subscription")
+        self.assertEqual(opus["runtime_identity"], "cli_metadata")
+        self.assertEqual(set(opus["models"]), {"claude-opus-5"})
+        self.assertEqual(
+            opus["models"]["claude-opus-5"]["supported_efforts"],
+            ["low", "medium", "high", "xhigh", "max"],
+        )
 
     def test_kimi_effort_is_explicit_and_never_clamped(self) -> None:
         provider = PROVIDERS.load_provider("openrouter")

--- a/tests/test_external_subscription.py
+++ b/tests/test_external_subscription.py
@@ -19,7 +19,7 @@ SPEC.loader.exec_module(SUBSCRIPTION)
 
 
 class ExternalSubscriptionTests(unittest.TestCase):
-    def test_only_fable_manifest_model_seats_and_operations_are_allowed(self) -> None:
+    def test_only_sealed_subscription_provider_model_pairs_are_allowed(self) -> None:
         provider, effort = SUBSCRIPTION.validate_route(
             "claude-fable", "claude-fable-5", "high", "create_plan"
         )
@@ -27,9 +27,16 @@ class ExternalSubscriptionTests(unittest.TestCase):
             provider["subscription_adapter"]["module"], "fable_advisor_mcp"
         )
         self.assertEqual(effort, "high")
+        opus, opus_effort = SUBSCRIPTION.validate_route(
+            "claude-opus", "claude-opus-5", "xhigh", "review_plan"
+        )
+        self.assertEqual(opus["name"], "Claude Opus 5")
+        self.assertEqual(opus_effort, "xhigh")
         for values in (
             ("unknown", "claude-fable-5", "high", "create_plan"),
             ("claude-fable", "claude-other", "high", "create_plan"),
+            ("claude-fable", "claude-opus-5", "high", "create_plan"),
+            ("claude-opus", "claude-fable-5", "high", "create_plan"),
             ("claude-fable", "claude-fable-5", "extreme", "create_plan"),
             ("claude-fable", "claude-fable-5", "high", "general_prompt"),
         ):
@@ -66,6 +73,10 @@ class ExternalSubscriptionTests(unittest.TestCase):
             "signal": "PLAN_DRAFT",
         }
         with mock.patch.object(
+            SUBSCRIPTION.fable_advisor_mcp,
+            "load_fable_route",
+            return_value={"model": "claude-fable-5", "effort": "high"},
+        ), mock.patch.object(
             SUBSCRIPTION.fable_advisor_mcp, "create_plan", return_value=expected
         ) as create:
             result = SUBSCRIPTION.invoke(
@@ -81,6 +92,10 @@ class ExternalSubscriptionTests(unittest.TestCase):
             SUBSCRIPTION.invoke("create_plan", {"prompt": "wrong key"})
         with mock.patch.object(
             SUBSCRIPTION.fable_advisor_mcp,
+            "load_fable_route",
+            return_value={"model": "claude-fable-5", "effort": "high"},
+        ), mock.patch.object(
+            SUBSCRIPTION.fable_advisor_mcp,
             "create_plan",
             return_value={
                 "model": "claude-fable-5",
@@ -92,6 +107,51 @@ class ExternalSubscriptionTests(unittest.TestCase):
                 SUBSCRIPTION.SubscriptionAdapterError, "metadata"
             ):
                 SUBSCRIPTION.invoke("create_plan", {"packet": "bounded"})
+
+    def test_opus_dispatch_checks_route_before_invocation(self) -> None:
+        expected = {
+            "model": "claude-opus-5",
+            "effort": "xhigh",
+            "used_models": ["claude-opus-5"],
+            "decision": "PLAN_APPROVED",
+        }
+        with mock.patch.object(
+            SUBSCRIPTION.fable_advisor_mcp,
+            "load_fable_route",
+            return_value={"model": "claude-opus-5", "effort": "xhigh"},
+        ), mock.patch.object(
+            SUBSCRIPTION.fable_advisor_mcp,
+            "review_plan",
+            return_value=expected,
+        ) as review:
+            result = SUBSCRIPTION.invoke(
+                "review_plan",
+                {"packet": "bounded"},
+                provider_id="claude-opus",
+                model="claude-opus-5",
+                effort="xhigh",
+            )
+        self.assertIs(result, expected)
+        review.assert_called_once_with(packet="bounded")
+
+        with mock.patch.object(
+            SUBSCRIPTION.fable_advisor_mcp,
+            "load_fable_route",
+            return_value={"model": "claude-fable-5", "effort": "high"},
+        ), mock.patch.object(
+            SUBSCRIPTION.fable_advisor_mcp, "review_plan"
+        ) as review:
+            with self.assertRaisesRegex(
+                SUBSCRIPTION.SubscriptionAdapterError, "differs"
+            ):
+                SUBSCRIPTION.invoke(
+                    "review_plan",
+                    {"packet": "bounded"},
+                    provider_id="claude-opus",
+                    model="claude-opus-5",
+                    effort="xhigh",
+                )
+            review.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_external_subscription.py
+++ b/tests/test_external_subscription.py
@@ -153,6 +153,70 @@ class ExternalSubscriptionTests(unittest.TestCase):
                 )
             review.assert_not_called()
 
+    def test_opus_planner_create_and_revise_dispatch_exact_public_operations(
+        self,
+    ) -> None:
+        route = {"model": "claude-opus-5", "effort": "max"}
+        created = {
+            "model": "claude-opus-5",
+            "effort": "max",
+            "used_models": ["claude-opus-5"],
+            "signal": "PLAN_DRAFT",
+            "plan": "PLAN_DRAFT\nDraft",
+        }
+        revised = {
+            "model": "claude-opus-5",
+            "effort": "max",
+            "used_models": ["claude-opus-5"],
+            "signal": "PLAN_REVISION",
+            "revision": (
+                "PLAN_REVISION\n\n## FINDINGS_LEDGER\n"
+                "F-1 INCORPORATED\n\n## REVISED_PLAN\nv2 plan"
+            ),
+        }
+        revision_arguments = {
+            "task": "original task",
+            "current_plan": "v1 plan",
+            "critique": "F-1 missing check",
+            "history": "F-1 pending",
+        }
+        with (
+            mock.patch.object(
+                SUBSCRIPTION.fable_advisor_mcp,
+                "load_fable_route",
+                return_value=route,
+            ),
+            mock.patch.object(
+                SUBSCRIPTION.fable_advisor_mcp,
+                "create_plan",
+                return_value=created,
+            ) as create,
+            mock.patch.object(
+                SUBSCRIPTION.fable_advisor_mcp,
+                "revise_plan",
+                return_value=revised,
+            ) as revise,
+        ):
+            create_result = SUBSCRIPTION.invoke(
+                "create_plan",
+                {"packet": "bounded planning packet"},
+                provider_id="claude-opus",
+                model="claude-opus-5",
+                effort="max",
+            )
+            revise_result = SUBSCRIPTION.invoke(
+                "revise_plan",
+                revision_arguments,
+                provider_id="claude-opus",
+                model="claude-opus-5",
+                effort="max",
+            )
+
+        self.assertIs(create_result, created)
+        self.assertIs(revise_result, revised)
+        create.assert_called_once_with(packet="bounded planning packet")
+        revise.assert_called_once_with(**revision_arguments)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_fable_advisor_mcp.py
+++ b/tests/test_fable_advisor_mcp.py
@@ -26,6 +26,7 @@ SPEC = importlib.util.spec_from_file_location("fable_advisor_mcp", SCRIPT)
 assert SPEC and SPEC.loader
 FABLE = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(FABLE)
+DEFAULT_MODEL_USAGE = object()
 
 
 class FableAdvisorMcpTests(unittest.TestCase):
@@ -128,7 +129,7 @@ class FableAdvisorMcpTests(unittest.TestCase):
         )
 
     def model_result(
-        self, response: str, *, model_usage: dict[str, object] | None = None
+        self, response: str, *, model_usage: object = DEFAULT_MODEL_USAGE
     ) -> subprocess.CompletedProcess[str]:
         return self.completed(
             ["claude"],
@@ -136,7 +137,7 @@ class FableAdvisorMcpTests(unittest.TestCase):
                 {
                     "result": response,
                     "modelUsage": model_usage
-                    if model_usage is not None
+                    if model_usage is not DEFAULT_MODEL_USAGE
                     else {"claude-fable-5": {"outputTokens": 12}},
                 }
             ),
@@ -147,7 +148,7 @@ class FableAdvisorMcpTests(unittest.TestCase):
         function: object,
         *args: str,
         model_response: str,
-        model_usage: dict[str, object] | None = None,
+        model_usage: object = DEFAULT_MODEL_USAGE,
     ) -> tuple[dict[str, object], list[tuple[list[str], dict[str, object]]]]:
         calls: list[tuple[list[str], dict[str, object]]] = []
 
@@ -234,6 +235,111 @@ class FableAdvisorMcpTests(unittest.TestCase):
             for name in FABLE.SENSITIVE_ENV:
                 self.assertNotIn(name, sanitized)
 
+    def test_auth_and_model_subprocesses_receive_only_platform_runtime_environment(
+        self,
+    ) -> None:
+        hostile = {
+            "CLAUDE_CODE_OAUTH_TOKEN": "oauth-secret",
+            "ANTHROPIC_API_KEY": "provider-secret",
+            "CLAUDE_CONFIG_DIR": "/hostile/config",
+            "CLAUDE_CODE_CLIENT_KEY": "client-secret",
+            "ANTHROPIC_UNKNOWN_GATEWAY_HEADER": "smuggled",
+            "HTTP_PROXY": "http://hostile.invalid",
+            "HTTPS_PROXY": "https://hostile.invalid",
+            "SSL_CERT_FILE": "/hostile/ca.pem",
+            "NODE_EXTRA_CA_CERTS": "/hostile/node-ca.pem",
+            "AWS_SECRET_ACCESS_KEY": "aws-secret",
+            "GOOGLE_APPLICATION_CREDENTIALS": "/hostile/google.json",
+            "AZURE_CLIENT_SECRET": "azure-secret",
+            "OTEL_EXPORTER_OTLP_HEADERS": "authorization=secret",
+            "APPDATA": r"C:\hostile\roaming",
+            "LOCALAPPDATA": r"C:\hostile\local",
+        }
+        scenarios = (
+            (
+                "posix",
+                {
+                    "PATH": "/trusted/bin",
+                    "LANG": "en_US.UTF-8",
+                    "LC_ALL": "C.UTF-8",
+                    "LC_CTYPE": "UTF-8",
+                    "HOME": "/trusted/home",
+                    "TMPDIR": "/trusted/tmp",
+                    "SystemRoot": r"C:\should-not-pass",
+                    **hostile,
+                },
+                {
+                    "PATH": "/trusted/bin",
+                    "LANG": "en_US.UTF-8",
+                    "LC_ALL": "C.UTF-8",
+                    "LC_CTYPE": "UTF-8",
+                    "HOME": "/trusted/home",
+                    "TMPDIR": "/trusted/tmp",
+                    "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+                },
+            ),
+            (
+                "nt",
+                {
+                    "path": r"C:\trusted\bin",
+                    "lang": "en-US",
+                    "lc_all": "C",
+                    "lc_ctype": "UTF-8",
+                    "systemroot": r"C:\Windows",
+                    "comspec": r"C:\Windows\System32\cmd.exe",
+                    "pathext": ".COM;.EXE",
+                    "temp": r"C:\trusted\temp",
+                    "tmp": r"C:\trusted\tmp",
+                    "userprofile": r"C:\Users\trusted",
+                    "home": r"C:\hostile\home-redirection",
+                    **{name.lower(): value for name, value in hostile.items()},
+                },
+                {
+                    "PATH": r"C:\trusted\bin",
+                    "LANG": "en-US",
+                    "LC_ALL": "C",
+                    "LC_CTYPE": "UTF-8",
+                    "SystemRoot": r"C:\Windows",
+                    "ComSpec": r"C:\Windows\System32\cmd.exe",
+                    "PATHEXT": ".COM;.EXE",
+                    "TEMP": r"C:\trusted\temp",
+                    "TMP": r"C:\trusted\tmp",
+                    "USERPROFILE": r"C:\Users\trusted",
+                    "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+                },
+            ),
+        )
+        executable = Path("/fake/claude")
+        for platform, inherited, expected in scenarios:
+            with self.subTest(platform=platform):
+                calls: list[tuple[list[str], dict[str, object]]] = []
+
+                def fake_run(
+                    command: list[str], **kwargs: object
+                ) -> subprocess.CompletedProcess[str]:
+                    calls.append((command, kwargs))
+                    if command[-2:] == ["auth", "status"]:
+                        return self.auth_result()
+                    return self.model_result("PLAN_APPROVED\nNo material gap found.")
+
+                with (
+                    mock.patch.dict(os.environ, inherited, clear=True),
+                    mock.patch.object(FABLE.os, "name", platform),
+                    mock.patch.object(
+                        FABLE,
+                        "load_fable_route",
+                        return_value={"model": FABLE.FABLE_MODEL, "effort": "high"},
+                    ),
+                    mock.patch.object(FABLE, "resolve_claude", return_value=executable),
+                    mock.patch.object(FABLE.subprocess, "run", side_effect=fake_run),
+                ):
+                    result = FABLE.review_plan("Review this complete plan.")
+
+                self.assertEqual(result["decision"], "PLAN_APPROVED")
+                self.assertEqual(len(calls), 2)
+                for _, kwargs in calls:
+                    self.assertEqual(kwargs["env"], expected)
+
     def test_runtime_model_policy_accepts_only_fable_and_exact_allowed_helper(
         self,
     ) -> None:
@@ -285,6 +391,59 @@ class FableAdvisorMcpTests(unittest.TestCase):
                         model_usage=model_usage,
                     )
                 self.assertNotIn(secret, str(failure.exception))
+
+    def test_runtime_model_usage_values_fail_closed(self) -> None:
+        malformed_values = (
+            None,
+            "12",
+            12,
+            1.5,
+            [],
+            {},
+            {"outputTokens": -1},
+            {"outputTokens": float("nan")},
+            {"outputTokens": float("inf")},
+            {"outputTokens": float("-inf")},
+            {"outputTokens": True},
+            {"": 12},
+            {"outputTokens": "12"},
+        )
+        for usage_value in malformed_values:
+            with self.subTest(usage_value=usage_value):
+                with self.assertRaisesRegex(FABLE.AdvisorError, "[Rr]untime metadata"):
+                    self.invoke_with_results(
+                        FABLE.review_plan,
+                        "packet",
+                        model_response="PLAN_APPROVED\nNo material gap found.",
+                        model_usage={FABLE.FABLE_MODEL: usage_value},
+                    )
+
+        for usage in (
+            {7: {"outputTokens": 1}},
+            {FABLE.FABLE_MODEL: {7: 1}},
+            {"": {"outputTokens": 1}, FABLE.FABLE_MODEL: {"outputTokens": 1}},
+        ):
+            with self.subTest(non_json_key=usage):
+                with self.assertRaisesRegex(FABLE.AdvisorError, "[Rr]untime metadata"):
+                    FABLE._validate_runtime_models(usage)
+
+        for usage in (
+            {FABLE.FABLE_MODEL: {"outputTokens": 0}},
+            {FABLE.FABLE_MODEL: {"outputTokens": 10**309}},
+            {FABLE.FABLE_MODEL: {"costUSD": 0.25, "outputTokens": 12}},
+            {
+                FABLE.FABLE_MODEL: {"outputTokens": 12},
+                FABLE.FABLE_HELPER_MODEL: {"outputTokens": 1},
+            },
+        ):
+            with self.subTest(valid_usage=usage):
+                result, _ = self.invoke_with_results(
+                    FABLE.review_plan,
+                    "packet",
+                    model_response="PLAN_APPROVED\nNo material gap found.",
+                    model_usage=usage,
+                )
+                self.assertEqual(result["decision"], "PLAN_APPROVED")
 
     def test_each_operation_pins_its_authorized_seat_effort(self) -> None:
         self.write_state(planner=self.route("low"))
@@ -395,6 +554,66 @@ class FableAdvisorMcpTests(unittest.TestCase):
                 model_response="PLAN_APPROVED\nNo material gap.",
                 model_usage={FABLE.FABLE_HELPER_MODEL: {"outputTokens": 1}},
             )
+
+    def test_opus_planner_create_and_revise_pin_exact_route_and_primary_usage(
+        self,
+    ) -> None:
+        self.write_state(schema=5, planner=self.opus_route("max"))
+        created, create_calls = self.invoke_with_results(
+            FABLE.create_plan,
+            "bounded task packet",
+            model_response="PLAN_DRAFT\n1. Verify the boundary.",
+            model_usage={FABLE.OPUS_MODEL: {"outputTokens": 12}},
+        )
+        self.assertEqual(created["signal"], "PLAN_DRAFT")
+        self.assertEqual(created["model"], FABLE.OPUS_MODEL)
+        self.assertEqual(created["effort"], "max")
+        self.assertEqual(created["used_models"], [FABLE.OPUS_MODEL])
+        create_command = create_calls[1][0]
+        self.assertEqual(
+            create_command[create_command.index("--model") + 1], FABLE.OPUS_MODEL
+        )
+        self.assertEqual(create_command[create_command.index("--effort") + 1], "max")
+        self.assertEqual(
+            create_command[create_command.index("--system-prompt") + 1],
+            FABLE.PLANNER_CREATE_SYSTEM_PROMPT,
+        )
+
+        revision = (
+            "PLAN_REVISION\n\n"
+            "## FINDINGS_LEDGER\n"
+            "F-1 INCORPORATED: added the missing check.\n\n"
+            "## REVISED_PLAN\n"
+            "Source v1; revised v2. Verify the boundary."
+        )
+        revised, revise_calls = self.invoke_with_results(
+            FABLE.revise_plan,
+            "original task",
+            "v1 canonical plan",
+            "F-1 missing check",
+            "F-1 pending",
+            model_response=revision,
+            model_usage={FABLE.OPUS_MODEL: {"outputTokens": 24}},
+        )
+        self.assertEqual(revised["signal"], "PLAN_REVISION")
+        self.assertEqual(revised["revision"], revision)
+        self.assertEqual(revised["model"], FABLE.OPUS_MODEL)
+        self.assertEqual(revised["effort"], "max")
+        self.assertEqual(revised["used_models"], [FABLE.OPUS_MODEL])
+        revise_command, revise_kwargs = revise_calls[1]
+        self.assertEqual(
+            revise_command[revise_command.index("--model") + 1], FABLE.OPUS_MODEL
+        )
+        self.assertEqual(revise_command[revise_command.index("--effort") + 1], "max")
+        self.assertEqual(
+            revise_command[revise_command.index("--system-prompt") + 1],
+            FABLE.PLANNER_REVISE_SYSTEM_PROMPT,
+        )
+        self.assertIn("# ORIGINAL_TASK\noriginal task", revise_kwargs["input"])
+        self.assertIn(
+            "# CANONICAL_CURRENT_PLAN_WITH_SOURCE_VERSION\nv1 canonical plan",
+            revise_kwargs["input"],
+        )
 
     def test_authorization_state_tampering_fails_before_any_subprocess(self) -> None:
         mutations = {

--- a/tests/test_fable_advisor_mcp.py
+++ b/tests/test_fable_advisor_mcp.py
@@ -46,15 +46,25 @@ class FableAdvisorMcpTests(unittest.TestCase):
             "server": "fable-advisor-python3",
         }
 
+    @staticmethod
+    def opus_route(effort: str = "high") -> dict[str, str]:
+        return {
+            "kind": "claude_subscription",
+            "model": "claude-opus-5",
+            "effort": effort,
+            "server": "fable-advisor-python3",
+        }
+
     def write_state(self, *, schema: int = 3, **seats: object) -> None:
-        fable_routes = [
+        subscription_routes = [
             route
             for route in seats.values()
-            if isinstance(route, dict) and route.get("kind") == "fable"
+            if isinstance(route, dict)
+            and route.get("kind") in {"fable", "claude_subscription"}
         ]
         managed_mcp = {
             route["server"]: True
-            for route in fable_routes[:1]
+            for route in subscription_routes[:1]
             if isinstance(route.get("server"), str)
         }
         previous_mcp = {
@@ -162,9 +172,7 @@ class FableAdvisorMcpTests(unittest.TestCase):
     def test_review_is_pinned_sanitized_read_only_and_runtime_confirmed(self) -> None:
         env = {
             "CODEX_HOME": str(self.home),
-            "ANTHROPIC_API_KEY": "must-not-leak",
-            "ANTHROPIC_AUTH_TOKEN": "must-not-leak",
-            "CLAUDE_CODE_USE_BEDROCK": "1",
+            **{name: "must-not-leak" for name in FABLE.SENSITIVE_ENV},
         }
         calls: list[tuple[list[str], dict[str, object]]] = []
 
@@ -193,6 +201,7 @@ class FableAdvisorMcpTests(unittest.TestCase):
         self.assertEqual(auth_command[-2:], ["auth", "status"])
         review_command, review_kwargs = calls[1]
         for flag in (
+            "--print",
             "--safe-mode",
             "--tools",
             "--permission-mode",
@@ -345,8 +354,47 @@ class FableAdvisorMcpTests(unittest.TestCase):
         with self.assertRaisesRegex(FABLE.AdvisorError, "state is invalid"):
             FABLE.load_fable_route(self.home)
         self.write_state(schema=5, advisor=self.route())
-        with self.assertRaisesRegex(FABLE.AdvisorError, "state is invalid"):
-            FABLE.load_fable_route(self.home)
+        self.assertEqual(FABLE.load_fable_route(self.home)["model"], FABLE.FABLE_MODEL)
+
+    def test_opus_route_pins_primary_and_rejects_every_unverified_helper(self) -> None:
+        self.write_state(schema=5, advisor=self.opus_route("xhigh"))
+        result, calls = self.invoke_with_results(
+            FABLE.review_plan,
+            "packet",
+            model_response="PLAN_APPROVED\nNo material gap.",
+            model_usage={FABLE.OPUS_MODEL: {"outputTokens": 12}},
+        )
+        self.assertEqual(result["model"], FABLE.OPUS_MODEL)
+        self.assertEqual(result["effort"], "xhigh")
+        review_command = calls[1][0]
+        self.assertEqual(
+            review_command[review_command.index("--model") + 1], FABLE.OPUS_MODEL
+        )
+        self.assertEqual(
+            review_command[review_command.index("--effort") + 1], "xhigh"
+        )
+
+        with self.assertRaisesRegex(
+            FABLE.AdvisorError, "outside the allowed Claude runtime policy"
+        ):
+            self.invoke_with_results(
+                FABLE.review_plan,
+                "packet",
+                model_response="PLAN_APPROVED\nNo material gap.",
+                model_usage={
+                    FABLE.OPUS_MODEL: {"outputTokens": 12},
+                    FABLE.FABLE_HELPER_MODEL: {"outputTokens": 1},
+                },
+            )
+        with self.assertRaisesRegex(
+            FABLE.AdvisorError, "did not confirm the pinned Claude Opus 5"
+        ):
+            self.invoke_with_results(
+                FABLE.review_plan,
+                "packet",
+                model_response="PLAN_APPROVED\nNo material gap.",
+                model_usage={FABLE.FABLE_HELPER_MODEL: {"outputTokens": 1}},
+            )
 
     def test_authorization_state_tampering_fails_before_any_subprocess(self) -> None:
         mutations = {

--- a/tests/test_native_routing.py
+++ b/tests/test_native_routing.py
@@ -256,53 +256,92 @@ for line in sys.stdin:
 '''
 
 
+def _write_test_cli(
+    directory: Path,
+    name: str,
+    source: str,
+    *,
+    windows: bool | None = None,
+) -> tuple[Path, Path]:
+    is_windows = os.name == "nt" if windows is None else windows
+    source_path = directory / (f"{name}.py" if is_windows else name)
+    source_path.write_text(textwrap.dedent(source), encoding="utf-8")
+    source_path.chmod(0o755)
+    if not is_windows:
+        return source_path, source_path
+
+    launcher = directory / f"{name}.cmd"
+    launcher.write_text(
+        (
+            "@echo off\r\n"
+            f'"{sys.executable}" "%~dp0{source_path.name}" %*\r\n'
+        ),
+        encoding="utf-8",
+        newline="",
+    )
+    return source_path, launcher
+
+
 class NativeRoutingTests(unittest.TestCase):
     def setUp(self) -> None:
         self.temp = tempfile.TemporaryDirectory()
         self.root = Path(self.temp.name)
         self.home = self.root / "home"
         self.home.mkdir()
-        self.codex = self.root / "fake-codex"
-        self.codex.write_text(textwrap.dedent(FAKE_CODEX), encoding="utf-8")
-        self.codex.chmod(0o755)
+        _, self.codex = _write_test_cli(self.root, "fake-codex", FAKE_CODEX)
         self.bin = self.root / "bin"
         self.bin.mkdir()
-        self.claude = self.bin / "claude"
-        self.claude.write_text(
-            textwrap.dedent(
-                """\
-                #!/usr/bin/env python3
-                import json
-                import sys
-                if sys.argv[1:] == ["auth", "status"]:
-                    print(json.dumps({
-                        "loggedIn": True,
-                        "authMethod": "claude.ai",
-                        "apiProvider": "firstParty",
-                        "subscriptionType": "max",
-                    }))
-                    raise SystemExit(0)
-                if sys.argv[1:] == ["--help"]:
-                    print(
-                        "--print --model --effort <level> Effort level "
-                        "(low, medium, high, xhigh, max) "
-                        "--safe-mode --tools --permission-mode "
-                        "--no-session-persistence --prompt-suggestions "
-                        "--output-format --system-prompt"
-                    )
-                    raise SystemExit(0)
-                if sys.argv[1:] == ["--version"]:
-                    print("2.1.219 (Claude Code)")
-                    raise SystemExit(0)
-                raise SystemExit(2)
-                """
-            ),
-            encoding="utf-8",
+        self.claude, _ = _write_test_cli(
+            self.bin,
+            "claude",
+            """\
+            #!/usr/bin/env python3
+            import json
+            import sys
+            if sys.argv[1:] == ["auth", "status"]:
+                print(json.dumps({
+                    "loggedIn": True,
+                    "authMethod": "claude.ai",
+                    "apiProvider": "firstParty",
+                    "subscriptionType": "max",
+                }))
+                raise SystemExit(0)
+            if sys.argv[1:] == ["--help"]:
+                print(
+                    "--print --model --effort <level> Effort level "
+                    "(low, medium, high, xhigh, max) "
+                    "--safe-mode --tools --permission-mode "
+                    "--no-session-persistence --prompt-suggestions "
+                    "--output-format --system-prompt"
+                )
+                raise SystemExit(0)
+            if sys.argv[1:] == ["--version"]:
+                print("2.1.219 (Claude Code)")
+                raise SystemExit(0)
+            raise SystemExit(2)
+            """,
         )
-        self.claude.chmod(0o755)
 
     def tearDown(self) -> None:
         self.temp.cleanup()
+
+    def test_fake_cli_fixture_builds_windows_native_launchers(self) -> None:
+        fixture_root = self.root / "windows-fixture"
+        fixture_root.mkdir()
+        source, launcher = _write_test_cli(
+            fixture_root,
+            "fake-tool",
+            "# fake Python CLI\n",
+            windows=True,
+        )
+
+        self.assertEqual(source.name, "fake-tool.py")
+        self.assertEqual(launcher.name, "fake-tool.cmd")
+        self.assertEqual(source.read_text(encoding="utf-8"), "# fake Python CLI\n")
+        wrapper = launcher.read_text(encoding="utf-8")
+        self.assertIn(f'"{sys.executable}"', wrapper)
+        self.assertIn('"%~dp0fake-tool.py"', wrapper)
+        self.assertIn("%*", wrapper)
 
     def run_script(
         self,
@@ -313,6 +352,8 @@ class NativeRoutingTests(unittest.TestCase):
         compatibility = ["--allow-incompatible-client"] if allow_incompatible else []
         env = os.environ.copy()
         env["PATH"] = f"{self.bin}{os.pathsep}{env.get('PATH', '')}"
+        if os.name == "nt":
+            env.setdefault("PATHEXT", ".COM;.EXE;.BAT;.CMD")
         result = subprocess.run(
             [
                 sys.executable,
@@ -511,6 +552,47 @@ class NativeRoutingTests(unittest.TestCase):
                 )
                 self.assertEqual(result.returncode, 2)
                 self.assertIn("does not accept seat settings", result.stderr)
+
+    def test_reserved_claude_model_ids_require_their_sealed_cli_routes(self) -> None:
+        missing_codex = self.root / "must-not-start-app-server"
+        for option in (
+            "--executor-model",
+            "--planner-model",
+            "--advisor-model",
+            "--designer-model",
+        ):
+            for model in (NATIVE.FABLE_MODEL, NATIVE.OPUS_MODEL):
+                arguments = [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--codex-bin",
+                    str(missing_codex),
+                ]
+                if option != "--executor-model":
+                    arguments.extend(("--executor-model", "gpt-5.6-luna"))
+                arguments.extend((option, model))
+                with self.subTest(option=option, model=model):
+                    rejected = subprocess.run(
+                        arguments,
+                        text=True,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                        timeout=20,
+                        check=False,
+                    )
+                    self.assertEqual(rejected.returncode, 2)
+                    self.assertIn("reserved Claude model", rejected.stderr)
+                    self.assertNotIn("Codex binary does not exist", rejected.stderr)
+                    self.assertFalse(
+                        (self.home / ".fake-user-config.json").exists()
+                    )
+                    self.assertFalse(
+                        (self.home / NATIVE.STATE_FILENAME).exists()
+                    )
+
+        self.write_personal_agent("claude_opus_5")
+        agent = self.run_script("--executor-agent", "claude_opus_5")
+        self.assertIn("Dry run only", agent.stdout)
 
     def test_capability_probe_checks_the_complete_routing_surface(self) -> None:
         completed = subprocess.CompletedProcess([], 0, stdout="supported")
@@ -1342,9 +1424,7 @@ class NativeRoutingTests(unittest.TestCase):
         self.assertEqual(feature["tool_namespace"], "agents")
 
     def test_incompatible_client_blocks_setup_but_never_disable(self) -> None:
-        old_codex = self.root / "old-codex"
-        old_codex.write_text(textwrap.dedent(FAKE_CODEX), encoding="utf-8")
-        old_codex.chmod(0o755)
+        _, old_codex = _write_test_cli(self.root, "old-codex", FAKE_CODEX)
         refused = self.run_script(
             "--executor-model",
             "gpt-5.6-luna",
@@ -1388,9 +1468,7 @@ class NativeRoutingTests(unittest.TestCase):
             "high",
             "--apply",
         )
-        old_codex = self.root / "old-status-codex"
-        old_codex.write_text(textwrap.dedent(FAKE_CODEX), encoding="utf-8")
-        old_codex.chmod(0o755)
+        _, old_codex = _write_test_cli(self.root, "old-status-codex", FAKE_CODEX)
         incompatible = self.run_script(
             "--status",
             "--require-effective",
@@ -2159,6 +2237,63 @@ class NativeRoutingTests(unittest.TestCase):
         )
         self.assertIn("Planner: Claude Fable 5 high", fable.stdout)
 
+    def test_generic_opus_transitions_are_rejected_without_writes(self) -> None:
+        state_path = self.home / NATIVE.STATE_FILENAME
+        version_path = self.home / ".fake-version"
+
+        self.run_script(
+            "--executor-model",
+            "gpt-5.6-luna",
+            "--advisor-fable",
+            "--apply",
+        )
+        before_config = self.read_fake_config()
+        before_state = state_path.read_text(encoding="utf-8")
+        before_version = version_path.read_text(encoding="utf-8")
+        fable_to_generic = self.run_script(
+            "--executor-model",
+            "gpt-5.6-luna",
+            "--advisor-model",
+            NATIVE.OPUS_MODEL,
+            "--advisor-effort",
+            "high",
+            "--confirm-unlisted-models",
+            "--apply",
+            check=False,
+        )
+        self.assertEqual(fable_to_generic.returncode, 2)
+        self.assertIn("reserved Claude model", fable_to_generic.stderr)
+        self.assertEqual(self.read_fake_config(), before_config)
+        self.assertEqual(state_path.read_text(encoding="utf-8"), before_state)
+        self.assertEqual(version_path.read_text(encoding="utf-8"), before_version)
+
+        self.run_script("--disable", "--apply")
+        self.run_script(
+            "--executor-model",
+            "gpt-5.6-luna",
+            "--advisor-model",
+            "gpt-5.6-terra",
+            "--apply",
+        )
+        forged = json.loads(state_path.read_text(encoding="utf-8"))
+        forged["advisor"]["model"] = NATIVE.OPUS_MODEL
+        state_path.write_text(json.dumps(forged), encoding="utf-8")
+        before_config = self.read_fake_config()
+        before_state = state_path.read_text(encoding="utf-8")
+        before_version = version_path.read_text(encoding="utf-8")
+        generic_to_fable = self.run_script(
+            "--executor-model",
+            "gpt-5.6-luna",
+            "--advisor-fable",
+            "--apply",
+            check=False,
+        )
+        self.assertEqual(generic_to_fable.returncode, 2)
+        self.assertIn("Saved routing state is invalid", generic_to_fable.stderr)
+        self.assertEqual(self.read_fake_config(), before_config)
+        self.assertEqual(state_path.read_text(encoding="utf-8"), before_state)
+        self.assertEqual(version_path.read_text(encoding="utf-8"), before_version)
+
     def test_opus_version_and_effort_prerequisites_fail_closed(self) -> None:
         original = self.claude.read_text(encoding="utf-8")
         self.claude.write_text(
@@ -2174,6 +2309,76 @@ class NativeRoutingTests(unittest.TestCase):
         self.assertEqual(too_old.returncode, 2)
         self.assertIn("requires Claude Code 2.1.219 or newer", too_old.stderr)
         self.assertFalse((self.home / NATIVE.STATE_FILENAME).exists())
+
+    def test_opus_version_output_must_be_one_canonical_version_line(self) -> None:
+        original = self.claude.read_text(encoding="utf-8")
+
+        for output in (
+            "2.1.219 (Claude Code)",
+            " \t2.1.219 (Claude Code)\r\n",
+            "2.1.220 (Claude Code)",
+            "2.2.0 (Claude Code)",
+            "3.0.0 (Claude Code)",
+        ):
+            with self.subTest(accepted=output):
+                self.claude.write_text(
+                    original.replace(
+                        'print("2.1.219 (Claude Code)")',
+                        f"print({output!r})",
+                    ),
+                    encoding="utf-8",
+                )
+                accepted = self.run_script(
+                    "--executor-model",
+                    "gpt-5.6-luna",
+                    "--advisor-opus",
+                )
+                self.assertIn("Dry run only", accepted.stdout)
+
+        for output in (
+            "wrapper 9.9.9\n2.1.219 (Claude Code)",
+            "2.1.219 (Claude Code)\n2.1.220 (Claude Code)",
+            "Claude Code 2.1.219",
+            "prefix2.1.219 (Claude Code)",
+            "2.1.219 (Claude Code)suffix",
+            "02.1.219 (Claude Code)",
+            f"{'9' * 5000}.1.1 (Claude Code)",
+        ):
+            with self.subTest(rejected=output):
+                self.claude.write_text(
+                    original.replace(
+                        'print("2.1.219 (Claude Code)")',
+                        f"print({output!r})",
+                    ),
+                    encoding="utf-8",
+                )
+                rejected = self.run_script(
+                    "--executor-model",
+                    "gpt-5.6-luna",
+                    "--advisor-opus",
+                    check=False,
+                )
+                self.assertEqual(rejected.returncode, 2)
+                self.assertIn("unparseable version", rejected.stderr)
+                self.assertFalse(
+                    (self.home / NATIVE.STATE_FILENAME).exists()
+                )
+
+        self.claude.write_text(
+            original.replace(
+                'print("2.1.219 (Claude Code)")',
+                "print('2.1.218 (Claude Code)')",
+            ),
+            encoding="utf-8",
+        )
+        too_old = self.run_script(
+            "--executor-model",
+            "gpt-5.6-luna",
+            "--advisor-opus",
+            check=False,
+        )
+        self.assertEqual(too_old.returncode, 2)
+        self.assertIn("requires Claude Code 2.1.219 or newer", too_old.stderr)
 
     def test_bundled_claude_prerequisite_checks_every_runtime_control(self) -> None:
         original = self.claude.read_text(encoding="utf-8")
@@ -2282,6 +2487,56 @@ class NativeRoutingTests(unittest.TestCase):
         self.assertEqual(malformed.returncode, 2)
         self.assertIn("unparseable version", malformed.stderr)
         self.assertFalse((self.home / NATIVE.STATE_FILENAME).exists())
+
+    def test_bundled_claude_requires_exact_long_option_tokens(self) -> None:
+        original = self.claude.read_text(encoding="utf-8")
+        required = (
+            "--print",
+            "--model",
+            "--effort",
+            "--safe-mode",
+            "--tools",
+            "--permission-mode",
+            "--no-session-persistence",
+            "--prompt-suggestions",
+            "--output-format",
+            "--system-prompt",
+        )
+        for flag in required:
+            for fake in (
+                f"{flag}-FAKE",
+                f"--FAKE{flag}",
+            ):
+                with self.subTest(flag=flag, fake=fake):
+                    self.claude.write_text(
+                        original.replace(flag, fake),
+                        encoding="utf-8",
+                    )
+                    rejected = self.run_script(
+                        "--executor-model",
+                        "gpt-5.6-luna",
+                        "--advisor-opus",
+                        check=False,
+                    )
+                    self.assertEqual(rejected.returncode, 2)
+                    self.assertIn(flag, rejected.stderr)
+                    self.assertFalse(
+                        (self.home / NATIVE.STATE_FILENAME).exists()
+                    )
+
+        duplicate_crlf = original.replace(
+            "--print --model",
+            r"--print\r\n--model",
+        )
+        for flag in required:
+            duplicate_crlf = duplicate_crlf.replace(flag, f"{flag} {flag}")
+        self.claude.write_text(duplicate_crlf, encoding="utf-8")
+        accepted = self.run_script(
+            "--executor-model",
+            "gpt-5.6-luna",
+            "--advisor-opus",
+        )
+        self.assertIn("Dry run only", accepted.stdout)
 
     def test_opus_effort_set_matches_documented_contract(self) -> None:
         self.assertEqual(

--- a/tests/test_native_routing.py
+++ b/tests/test_native_routing.py
@@ -284,10 +284,15 @@ class NativeRoutingTests(unittest.TestCase):
                     raise SystemExit(0)
                 if sys.argv[1:] == ["--help"]:
                     print(
-                        "--model --effort <level> Effort level "
+                        "--print --model --effort <level> Effort level "
                         "(low, medium, high, xhigh, max) "
-                        "--safe-mode --prompt-suggestions"
+                        "--safe-mode --tools --permission-mode "
+                        "--no-session-persistence --prompt-suggestions "
+                        "--output-format --system-prompt"
                     )
+                    raise SystemExit(0)
+                if sys.argv[1:] == ["--version"]:
+                    print("2.1.219 (Claude Code)")
                     raise SystemExit(0)
                 raise SystemExit(2)
                 """
@@ -399,7 +404,7 @@ class NativeRoutingTests(unittest.TestCase):
         self.assertIn('Never use fork_turns = "all"', usage)
         self.assertIn("task-local Planner and Advisor must still be distinct", usage)
         self.assertIn("same direct model ID", usage)
-        self.assertIn("Fable in both seats", usage)
+        self.assertIn("more than one bundled Claude subscription seat", usage)
         self.assertIn("If you are a spawned child, do not call this tool", usage)
         self.assertNotIn("tool_namespace", mode + usage)
         self.assertNotIn("enabled = true", mode + usage)
@@ -592,8 +597,8 @@ class NativeRoutingTests(unittest.TestCase):
         state = json.loads(
             (self.home / NATIVE.STATE_FILENAME).read_text(encoding="utf-8")
         )
-        self.assertEqual(state["schema"], 4)
-        self.assertEqual(state["policy_version"], 4)
+        self.assertEqual(state["schema"], 5)
+        self.assertEqual(state["policy_version"], 5)
         self.assertEqual(state["planner"]["effort"], "xhigh")
         self.assertEqual(state["designer"]["effort"], "medium")
 
@@ -644,8 +649,8 @@ class NativeRoutingTests(unittest.TestCase):
                     "--apply",
                 )
                 upgraded = json.loads(state_path.read_text(encoding="utf-8"))
-                self.assertEqual(upgraded["schema"], 4)
-                self.assertEqual(upgraded["policy_version"], 4)
+                self.assertEqual(upgraded["schema"], 5)
+                self.assertEqual(upgraded["policy_version"], 5)
                 self.assertEqual(upgraded["previous"], original_previous)
                 self.assertEqual(upgraded["planner"]["model"], "gpt-5.6-sol")
                 self.assertEqual(upgraded["designer"]["model"], "gpt-5.6-luna")
@@ -1833,7 +1838,7 @@ class NativeRoutingTests(unittest.TestCase):
             check=False,
         )
         self.assertEqual(result.returncode, 2)
-        self.assertIn("both cannot use Claude Fable 5", result.stderr)
+        self.assertIn("at most one bundled Claude subscription seat", result.stderr)
         self.assertFalse((self.home / NATIVE.STATE_FILENAME).exists())
 
     def test_fable_planner_with_gpt_advisor_uses_one_launcher_and_restores(self) -> None:
@@ -2028,6 +2033,264 @@ class NativeRoutingTests(unittest.TestCase):
             NATIVE.ConfigurationError, "low.*medium.*high.*xhigh.*max.*ultra"
         ):
             NATIVE.normalize_fable_effort("extreme")
+
+    def test_opus_setup_status_update_and_disable_are_no_model_call(self) -> None:
+        setup = self.run_script(
+            "--executor-model",
+            "gpt-5.6-luna",
+            "--advisor-opus",
+            "--advisor-effort",
+            "xhigh",
+            "--apply",
+        )
+        self.assertIn("Advisor: Claude Opus 5 xhigh", setup.stdout)
+        self.assertIn("setup makes no model call", setup.stdout)
+        state = json.loads(
+            (self.home / NATIVE.STATE_FILENAME).read_text(encoding="utf-8")
+        )
+        self.assertEqual(state["schema"], 5)
+        self.assertEqual(
+            state["advisor"],
+            {
+                "kind": "claude_subscription",
+                "model": "claude-opus-5",
+                "effort": "xhigh",
+                "server": "fable-advisor-python3",
+            },
+        )
+
+        status = self.run_script("--status", "--require-effective")
+        self.assertIn("Claude Opus 5: ready", status.stdout)
+        self.assertIn("no model call made", status.stdout)
+
+        update = self.run_script(
+            "--executor-model",
+            "gpt-5.6-luna",
+            "--advisor-opus",
+            "--advisor-effort",
+            "max",
+            "--apply",
+        )
+        self.assertIn("Advisor: Claude Opus 5 max", update.stdout)
+        updated = json.loads(
+            (self.home / NATIVE.STATE_FILENAME).read_text(encoding="utf-8")
+        )
+        self.assertEqual(updated["advisor"]["effort"], "max")
+
+        self.run_script("--disable", "--apply")
+        self.assertFalse((self.home / NATIVE.STATE_FILENAME).exists())
+        servers = (
+            self.read_fake_config()
+            .get("plugins", {})
+            .get(NATIVE.PLUGIN_ID, {})
+            .get("mcp_servers", {})
+        )
+        self.assertTrue(
+            all(not entry.get("enabled", False) for entry in servers.values())
+        )
+
+    def test_opus_transition_requires_full_disable_then_roundtrips(self) -> None:
+        self.run_script(
+            "--executor-model",
+            "gpt-5.6-luna",
+            "--advisor-fable",
+            "--apply",
+        )
+        before_config = self.read_fake_config()
+        before_state = (self.home / NATIVE.STATE_FILENAME).read_text(encoding="utf-8")
+        rejected = self.run_script(
+            "--executor-model",
+            "gpt-5.6-luna",
+            "--advisor-opus",
+            "--apply",
+            check=False,
+        )
+        self.assertEqual(rejected.returncode, 2)
+        self.assertIn(
+            "configure_native_routing.py --disable --apply", rejected.stderr
+        )
+        self.assertEqual(self.read_fake_config(), before_config)
+        self.assertEqual(
+            (self.home / NATIVE.STATE_FILENAME).read_text(encoding="utf-8"),
+            before_state,
+        )
+
+        self.run_script("--disable", "--apply")
+        self.run_script(
+            "--executor-model",
+            "gpt-5.6-luna",
+            "--advisor-opus",
+            "--apply",
+        )
+        for requested in (
+            ("--advisor-fable",),
+            ("--planner-opus",),
+            (),
+        ):
+            with self.subTest(requested=requested):
+                before_config = self.read_fake_config()
+                before_state = (
+                    self.home / NATIVE.STATE_FILENAME
+                ).read_text(encoding="utf-8")
+                rejected = self.run_script(
+                    "--executor-model",
+                    "gpt-5.6-luna",
+                    *requested,
+                    "--apply",
+                    check=False,
+                )
+                self.assertEqual(rejected.returncode, 2)
+                self.assertIn(
+                    "configure_native_routing.py --disable --apply",
+                    rejected.stderr,
+                )
+                self.assertEqual(self.read_fake_config(), before_config)
+                self.assertEqual(
+                    (self.home / NATIVE.STATE_FILENAME).read_text(encoding="utf-8"),
+                    before_state,
+                )
+
+        self.run_script("--disable", "--apply")
+        fable = self.run_script(
+            "--executor-model",
+            "gpt-5.6-luna",
+            "--planner-fable",
+            "--apply",
+        )
+        self.assertIn("Planner: Claude Fable 5 high", fable.stdout)
+
+    def test_opus_version_and_effort_prerequisites_fail_closed(self) -> None:
+        original = self.claude.read_text(encoding="utf-8")
+        self.claude.write_text(
+            original.replace("2.1.219 (Claude Code)", "2.1.218 (Claude Code)"),
+            encoding="utf-8",
+        )
+        too_old = self.run_script(
+            "--executor-model",
+            "gpt-5.6-luna",
+            "--advisor-opus",
+            check=False,
+        )
+        self.assertEqual(too_old.returncode, 2)
+        self.assertIn("requires Claude Code 2.1.219 or newer", too_old.stderr)
+        self.assertFalse((self.home / NATIVE.STATE_FILENAME).exists())
+
+    def test_bundled_claude_prerequisite_checks_every_runtime_control(self) -> None:
+        original = self.claude.read_text(encoding="utf-8")
+        required = (
+            "--print",
+            "--model",
+            "--effort",
+            "--safe-mode",
+            "--tools",
+            "--permission-mode",
+            "--no-session-persistence",
+            "--prompt-suggestions",
+            "--output-format",
+            "--system-prompt",
+        )
+        for flag in required:
+            with self.subTest(flag=flag):
+                self.claude.write_text(
+                    original.replace(flag, f"--missing-{flag.removeprefix('--')}"),
+                    encoding="utf-8",
+                )
+                rejected = self.run_script(
+                    "--executor-model",
+                    "gpt-5.6-luna",
+                    "--advisor-opus",
+                    check=False,
+                )
+                self.assertEqual(rejected.returncode, 2)
+                self.assertIn(flag, rejected.stderr)
+                self.assertFalse((self.home / NATIVE.STATE_FILENAME).exists())
+        self.claude.write_text(original, encoding="utf-8")
+
+        self.claude.write_text(
+            original.replace(
+                "(low, medium, high, xhigh, max)",
+                "(low, medium, high, max, future)",
+            ),
+            encoding="utf-8",
+        )
+        missing = self.run_script(
+            "--executor-model",
+            "gpt-5.6-luna",
+            "--advisor-opus",
+            "--advisor-effort",
+            "xhigh",
+            check=False,
+        )
+        self.assertEqual(missing.returncode, 2)
+        self.assertIn("does not advertise Claude Opus 5 effort 'xhigh'", missing.stderr)
+
+        self.claude.write_text(
+            original.replace(
+                "(low, medium, high, xhigh, max)",
+                "(unparseable)",
+            ),
+            encoding="utf-8",
+        )
+        malformed_efforts = self.run_script(
+            "--executor-model",
+            "gpt-5.6-luna",
+            "--advisor-opus",
+            check=False,
+        )
+        self.assertEqual(malformed_efforts.returncode, 2)
+        self.assertIn(
+            "does not advertise Claude Opus 5 effort 'high'",
+            malformed_efforts.stderr,
+        )
+
+        self.claude.write_text(
+            original.replace(
+                "(low, medium, high, xhigh, max)",
+                "(low, medium, high, xhigh, max, future)",
+            ),
+            encoding="utf-8",
+        )
+        supported = self.run_script(
+            "--executor-model",
+            "gpt-5.6-luna",
+            "--advisor-opus",
+            "--advisor-effort",
+            "max",
+        )
+        self.assertIn("Dry run only", supported.stdout)
+        unsealed = self.run_script(
+            "--executor-model",
+            "gpt-5.6-luna",
+            "--advisor-opus",
+            "--advisor-effort",
+            "future",
+            check=False,
+        )
+        self.assertEqual(unsealed.returncode, 2)
+        self.assertIn("Claude Opus 5 effort must be one of", unsealed.stderr)
+
+        self.claude.write_text(
+            original.replace("2.1.219 (Claude Code)", "not-a-version"),
+            encoding="utf-8",
+        )
+        malformed = self.run_script(
+            "--executor-model",
+            "gpt-5.6-luna",
+            "--advisor-opus",
+            check=False,
+        )
+        self.assertEqual(malformed.returncode, 2)
+        self.assertIn("unparseable version", malformed.stderr)
+        self.assertFalse((self.home / NATIVE.STATE_FILENAME).exists())
+
+    def test_opus_effort_set_matches_documented_contract(self) -> None:
+        self.assertEqual(
+            NATIVE.OPUS_EFFORTS,
+            {"low", "medium", "high", "xhigh", "max"},
+        )
+        self.assertEqual(NATIVE.normalize_opus_effort("auto"), "high")
+        for effort in NATIVE.OPUS_EFFORTS:
+            self.assertEqual(NATIVE.normalize_opus_effort(effort), effort)
 
     def test_fable_setup_rejects_effort_missing_from_installed_claude(self) -> None:
         self.claude.write_text(

--- a/tests/test_native_routing.py
+++ b/tests/test_native_routing.py
@@ -1590,7 +1590,7 @@ class NativeRoutingTests(unittest.TestCase):
             "managed_by": "codex-orchestration",
             "config_file": str(self.home / "config.toml"),
         }
-        with mock.patch.object(NATIVE.os, "fchmod", None):
+        with mock.patch.object(NATIVE.os, "fchmod", None, create=True):
             NATIVE._write_state(state_path, state)
         self.assertEqual(json.loads(state_path.read_text(encoding="utf-8")), state)
 

--- a/tests/test_native_routing.py
+++ b/tests/test_native_routing.py
@@ -343,6 +343,46 @@ class NativeRoutingTests(unittest.TestCase):
         self.assertIn('"%~dp0fake-tool.py"', wrapper)
         self.assertIn("%*", wrapper)
 
+    def test_app_server_close_requests_eof_before_forced_termination(self) -> None:
+        server = object.__new__(NATIVE.AppServer)
+        process = mock.Mock()
+        process.poll.return_value = None
+        process.stdin.closed = False
+        process.wait.return_value = 0
+        server._process = process
+        server._stderr = mock.Mock()
+
+        server.close()
+
+        process.stdin.close.assert_called_once_with()
+        process.wait.assert_called_once_with(timeout=3)
+        process.terminate.assert_not_called()
+        process.kill.assert_not_called()
+        server._stderr.close.assert_called_once_with()
+
+    def test_app_server_close_still_forces_a_process_that_ignores_eof(self) -> None:
+        server = object.__new__(NATIVE.AppServer)
+        process = mock.Mock()
+        process.poll.return_value = None
+        process.stdin.closed = False
+        process.wait.side_effect = [
+            subprocess.TimeoutExpired(["codex", "app-server"], 3),
+            0,
+        ]
+        server._process = process
+        server._stderr = mock.Mock()
+
+        server.close()
+
+        process.stdin.close.assert_called_once_with()
+        self.assertEqual(
+            process.wait.call_args_list,
+            [mock.call(timeout=3), mock.call(timeout=3)],
+        )
+        process.terminate.assert_called_once_with()
+        process.kill.assert_not_called()
+        server._stderr.close.assert_called_once_with()
+
     def run_script(
         self,
         *arguments: str,

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -5,6 +5,9 @@ from pathlib import Path
 import re
 import subprocess
 import unittest
+from unittest import mock
+
+from scripts import preflight
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -133,6 +136,53 @@ class PackagingTests(unittest.TestCase):
             self.assertIn(f'"{module}"', preflight)
         self.assertIn("name: analyze (python)", codeql)
         self.assertEqual(codeql.count("github/codeql-action/analyze@"), 1)
+
+    def test_portability_runs_routing_and_subscription_bridge_regressions(self) -> None:
+        calls: list[tuple[str, tuple[str, ...], int]] = []
+
+        def record_unittest(
+            root: Path,
+            name: str,
+            modules: list[str] | None = None,
+            *,
+            timeout: int = 600,
+            env: dict[str, str] | None = None,
+        ) -> preflight.CheckResult:
+            del root, env
+            calls.append((name, tuple(modules or ()), timeout))
+            return preflight.CheckResult(name, "PASS")
+
+        with (
+            mock.patch.object(
+                preflight,
+                "compile_check",
+                return_value=preflight.CheckResult("compile", "PASS"),
+            ),
+            mock.patch.object(
+                preflight, "unittest_check", side_effect=record_unittest
+            ),
+        ):
+            results = preflight.ci_checks(
+                "portability",
+                REPO_ROOT,
+                base_sha=None,
+                head_sha=None,
+            )
+
+        expected = {
+            "portability-native-routing": ("tests.test_native_routing",),
+            "portability-routing-state": ("tests.test_routing_state",),
+            "portability-fable-advisor-mcp": ("tests.test_fable_advisor_mcp",),
+        }
+        observed = {name: modules for name, modules, _ in calls}
+        self.assertEqual(
+            {name: observed.get(name) for name in expected},
+            expected,
+        )
+        for name, _, timeout in calls:
+            if name in expected:
+                self.assertEqual(timeout, 300, name)
+        self.assertTrue(all(result.status == "PASS" for result in results))
 
     def test_workflow_actions_permissions_and_cli_versions_remain_pinned(self) -> None:
         ci = (REPO_ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -205,7 +205,7 @@ class PackagingTests(unittest.TestCase):
 
         self.assertEqual(manifest["name"], "codex-orchestration")
         self.assertEqual(manifest["skills"], "./skills/")
-        self.assertEqual(manifest["version"], "0.8.0")
+        self.assertEqual(manifest["version"], "0.9.0")
         self.assertEqual(manifest["mcpServers"], "./.mcp.json")
         self.assertRegex(
             manifest["version"],
@@ -228,7 +228,7 @@ class PackagingTests(unittest.TestCase):
         self.assertFalse((SKILL_ROOT / "scripts" / "update_plugin.py").exists())
         self.assertIn("config/batchWrite", native.read_text(encoding="utf-8"))
         self.assertIn('"--repair"', native.read_text(encoding="utf-8"))
-        self.assertIn('"version": "0.8.0"', native.read_text(encoding="utf-8"))
+        self.assertIn('"version": "0.9.0"', native.read_text(encoding="utf-8"))
         self.assertIn("validate_routing_state", routing_state.read_text(encoding="utf-8"))
         self.assertIn("Standalone custom agent", custom.read_text(encoding="utf-8"))
 
@@ -249,6 +249,7 @@ class PackagingTests(unittest.TestCase):
             self.assertTrue((scripts / name).is_file(), name)
         openrouter = json.loads((providers / "openrouter.json").read_text("utf-8"))
         fable = json.loads((providers / "claude-fable.json").read_text("utf-8"))
+        opus = json.loads((providers / "claude-opus.json").read_text("utf-8"))
         self.assertEqual(openrouter["models"].keys(), {"moonshotai/kimi-k3"})
         self.assertEqual(openrouter["version"], 2)
         self.assertFalse(openrouter["experimental"])
@@ -258,6 +259,12 @@ class PackagingTests(unittest.TestCase):
             ["max"],
         )
         self.assertEqual(fable["subscription_adapter"]["module"], "fable_advisor_mcp")
+        self.assertEqual(opus["models"].keys(), {"claude-opus-5"})
+        self.assertEqual(
+            opus["models"]["claude-opus-5"]["supported_efforts"],
+            ["low", "medium", "high", "xhigh", "max"],
+        )
+        self.assertEqual(opus["subscription_adapter"]["module"], "fable_advisor_mcp")
         external_reference = SKILL_ROOT / "references/external-models.md"
         self.assertTrue(external_reference.is_file())
 
@@ -332,7 +339,7 @@ class PackagingTests(unittest.TestCase):
         self.assertIn("@openai/codex@0.144.1", workflow)
         smoke_text = smoke.read_text(encoding="utf-8")
         self.assertIn('OLD_VERSION = "0.5.0"', smoke_text)
-        self.assertIn('NEW_VERSION = "0.8.0"', smoke_text)
+        self.assertIn('NEW_VERSION = "0.9.0"', smoke_text)
         self.assertIn("old Advisor-only cache unexpectedly supports Planner", smoke_text)
         self.assertIn("Upgraded installed skill is missing Planner contract", smoke_text)
         self.assertIn("reused the Advisor-only 0.5.0 cache directory", smoke_text)

--- a/tests/test_release_check.py
+++ b/tests/test_release_check.py
@@ -69,7 +69,7 @@ class TempRepository:
 
 class ReleaseCheckTests(unittest.TestCase):
     def test_checkout_release_metadata_is_consistent(self) -> None:
-        self.assertEqual(RELEASE.run_check(REPO_ROOT, require_tag=False), "0.8.0")
+        self.assertEqual(RELEASE.run_check(REPO_ROOT, require_tag=False), "0.9.0")
 
     def test_unreleased_checkout_is_not_tag_ready(self) -> None:
         with self.assertRaisesRegex(RELEASE.ReleaseCheckError, "not tagged"):

--- a/tests/test_routing_state.py
+++ b/tests/test_routing_state.py
@@ -222,6 +222,59 @@ class RoutingStateTests(unittest.TestCase):
         with self.assertRaises(STATE.RoutingStateError):
             STATE.validate_routing_state(legacy)
 
+    def test_reserved_claude_models_cannot_use_generic_model_routes(self) -> None:
+        seats_by_schema = {
+            1: ("executor", "advisor"),
+            2: ("executor", "advisor"),
+            3: ("executor", "planner", "advisor"),
+            4: ("executor", "planner", "advisor", "designer"),
+            5: ("executor", "planner", "advisor", "designer"),
+        }
+        for schema, seats in seats_by_schema.items():
+            for seat in seats:
+                for model in (STATE.FABLE_MODEL, STATE.OPUS_MODEL):
+                    with self.subTest(schema=schema, seat=seat, model=model):
+                        invalid = genuine_state(schema)
+                        invalid[seat] = {
+                            "kind": "model",
+                            "model": model,
+                            "effort": "high",
+                        }
+                        if not any(
+                            isinstance(invalid.get(candidate), dict)
+                            and invalid[candidate].get("kind")
+                            in {"fable", "claude_subscription"}
+                            for candidate in ("planner", "advisor")
+                        ):
+                            for server in invalid["managed"].get("mcp", {}):
+                                invalid["managed"]["mcp"][server] = False
+                        with self.assertRaises(STATE.RoutingStateError):
+                            STATE.validate_routing_state(invalid)
+
+        for sealed, generic in (
+            (fable_route(), STATE.OPUS_MODEL),
+            (opus_route(), STATE.FABLE_MODEL),
+        ):
+            for sealed_seat, generic_seat in (
+                ("planner", "advisor"),
+                ("advisor", "planner"),
+            ):
+                with self.subTest(
+                    sealed_model=sealed["model"],
+                    sealed_seat=sealed_seat,
+                    generic_model=generic,
+                    generic_seat=generic_seat,
+                ):
+                    invalid = genuine_state(5)
+                    invalid[sealed_seat] = deepcopy(sealed)
+                    invalid[generic_seat] = {
+                        "kind": "model",
+                        "model": generic,
+                        "effort": "high",
+                    }
+                    with self.assertRaises(STATE.RoutingStateError):
+                        STATE.validate_routing_state(invalid)
+
     def test_legacy_schemas_reject_future_surfaces(self) -> None:
         scenarios = []
         schema_one = genuine_state(1)

--- a/tests/test_routing_state.py
+++ b/tests/test_routing_state.py
@@ -36,6 +36,15 @@ def fable_route(server: str = "fable-advisor-python3") -> dict[str, str]:
     }
 
 
+def opus_route(server: str = "fable-advisor-python3") -> dict[str, str]:
+    return {
+        "kind": "claude_subscription",
+        "model": STATE.OPUS_MODEL,
+        "effort": "xhigh",
+        "server": server,
+    }
+
+
 def genuine_state(schema: int) -> dict[str, object]:
     managed: dict[str, object] = {
         "mode": f"{STATE.MANAGED_MARKER}\nmode body",
@@ -65,7 +74,7 @@ def genuine_state(schema: int) -> dict[str, object]:
         state["advisor"] = fable_route()
     if schema >= 3:
         state["planner"] = fable_route()
-    if schema == 4:
+    if schema >= 4:
         state["designer"] = {
             "kind": "model",
             "model": "gpt-designer",
@@ -84,8 +93,8 @@ def genuine_state(schema: int) -> dict[str, object]:
 
 
 class RoutingStateTests(unittest.TestCase):
-    def test_genuine_schemas_one_through_four_are_accepted(self) -> None:
-        for schema in (1, 2, 3, 4):
+    def test_genuine_schemas_one_through_five_are_accepted(self) -> None:
+        for schema in (1, 2, 3, 4, 5):
             with self.subTest(schema=schema):
                 state = genuine_state(schema)
                 self.assertIs(STATE.validate_routing_state(state), state)
@@ -115,8 +124,8 @@ class RoutingStateTests(unittest.TestCase):
             return lambda state: state.__setitem__("policy_version", value)
 
         mutations = [
-            *( (f"schema {value!r}", schema(value)) for value in (True, 1.0, "4", None, 0, 5) ),
-            *( (f"policy {value!r}", policy(value)) for value in (True, 4.0, "4", None, 0, 5, 3) ),
+            *( (f"schema {value!r}", schema(value)) for value in (True, 1.0, "4", None, 0, 6) ),
+            *( (f"policy {value!r}", policy(value)) for value in (True, 4.0, "4", None, 0, 6, 3) ),
             ("missing top key", lambda state: state.pop("managed_by")),
             ("extra top key", lambda state: state.__setitem__("future", True)),
             ("wrong owner", lambda state: state.__setitem__("managed_by", "other")),
@@ -182,6 +191,36 @@ class RoutingStateTests(unittest.TestCase):
                 mutate(state)
                 with self.assertRaises(STATE.RoutingStateError):
                     STATE.validate_routing_state(state)
+
+    def test_schema_five_opus_route_is_sealed_and_exclusive(self) -> None:
+        state = genuine_state(5)
+        state["planner"] = opus_route()
+        self.assertIs(STATE.validate_routing_state(state), state)
+
+        mutations = {
+            "Fable cross encoded": lambda value: value["planner"].update(
+                model=STATE.FABLE_MODEL
+            ),
+            "wrong effort": lambda value: value["planner"].update(effort="ultra"),
+            "wrong server": lambda value: value["planner"].update(server="future"),
+            "extra key": lambda value: value["planner"].update(future=True),
+            "executor Opus": lambda value: value.update(executor=opus_route()),
+            "designer Opus": lambda value: value.update(designer=opus_route()),
+            "mixed subscription seats": lambda value: value.update(
+                advisor=fable_route()
+            ),
+        }
+        for label, mutate in mutations.items():
+            with self.subTest(label=label):
+                invalid = deepcopy(state)
+                mutate(invalid)
+                with self.assertRaises(STATE.RoutingStateError):
+                    STATE.validate_routing_state(invalid)
+
+        legacy = genuine_state(4)
+        legacy["planner"] = opus_route()
+        with self.assertRaises(STATE.RoutingStateError):
+            STATE.validate_routing_state(legacy)
 
     def test_legacy_schemas_reject_future_surfaces(self) -> None:
         scenarios = []

--- a/tests/test_skill_contract.py
+++ b/tests/test_skill_contract.py
@@ -29,6 +29,14 @@ ROUTING_STATE = (SKILL_ROOT / "scripts" / "routing_state.py").read_text(
 
 
 class SkillContractTests(unittest.TestCase):
+    def test_opus_is_a_sealed_subscription_planner_or_advisor(self) -> None:
+        self.assertIn("advisor: Claude Opus 5 XHigh", SKILL)
+        self.assertIn("--advisor-opus", SKILL)
+        self.assertIn("--planner-opus", SKILL)
+        self.assertIn("Claude Code 2.1.219 or newer", SKILL)
+        self.assertIn("No Opus helper identity is independently established", SKILL)
+        self.assertIn("more than one bundled Claude subscription seat", SKILL)
+
     def test_public_controls_are_simple_and_setup_is_persistent(self) -> None:
         self.assertIn("setup executor: GPT-5.6 Luna Extra High", SKILL)
         self.assertIn("setup planner: Claude Fable 5 High", SKILL)


### PR DESCRIPTION
## Summary

- add sealed `claude-opus-5` subscription routing for the Planner or Advisor seat
- introduce routing schema/policy version 5 while preserving schemas 1–4
- support the exact Opus effort set: `low`, `medium`, `high`, `xhigh`, and `max`
- require one canonical Claude Code version line at 2.1.219 or newer and exact runtime-control option tokens
- enforce one bundled Claude subscription seat across Fable and Opus, with disable-first transitions
- reject reserved Fable/Opus IDs on every generic model route and public model flag
- give both Claude subprocesses a minimal platform environment and validate runtime `modelUsage` structurally
- add exact Opus Planner create/revise coverage, protected portability coverage, release qualification, and plugin version 0.9.0

## Verification

- exact reviewed head: `7bbfcc100a9d34b25ff7f55f9774f8805569b26d`
- isolated full local preflight passed: diff check, compile, Ruff, focused tests, full tests, release identity, and plugin lifecycle smoke
- 154-test integrated repair/contract suite passed; the final native-routing module passed 72/72 and the bridge/dispatcher module set passed 26/26
- post-commit quick preflight and exact-SHA release identity passed against base `521f3deb6e7e35b1679d5f9139a0e4f1c04e8679`
- independent final-tree verification resolved large-integer metadata handling, Windows-native fake CLI launchers, oversized version parsing, the Windows-absent `os.fchmod` simulation, and graceful App Server shutdown before returning PASS
- no real Claude or Opus model call was made; live Opus Planner and Advisor qualification remains a manual release requirement
- protected Python 3.11/3.13, lifecycle, legacy-client, macOS/Windows portability, quality, and CodeQL checks remain authoritative

## Runtime boundary

This PR does not install or update the active plugin, change a user’s saved routing,
invoke Opus, or modify credentials. The official Claude CLI found on `PATH` remains a
documented trusted dependency.

## Review attestation

<!-- codex-review-attestation:start -->
{
  "schema": 1,
  "risk_tier": "security-state",
  "repository": "Cjbuilds/Codex-Orchestration",
  "base_branch": "main",
  "reviewed_head_sha": "7bbfcc100a9d34b25ff7f55f9774f8805569b26d",
  "reviewer_identity": "Codex independent verification worker (Mill)",
  "reviewer_route": "verification_worker / gpt-5.6-sol high",
  "threat_model": {
    "assets": [
      "First-party Claude subscription credentials and sealed Planner or Advisor routes",
      "Routing-state integrity and protected release evidence"
    ],
    "threats": [
      "Inherited environment overrides could redirect authentication or transport",
      "Reserved model cross-encoding or malformed runtime metadata could bypass route sealing",
      "Loose CLI parsing could accept unsupported runtime controls",
      "Terminating a Windows command wrapper could orphan its App Server child"
    ],
    "mitigations": [
      "Explicit platform environment allowlists and structural runtime model metadata validation",
      "Reserved-ID rejection at both CLI and persisted-state boundaries",
      "Canonical version parsing, exact option tokens, graceful EOF shutdown with bounded terminate and kill fallbacks, negative regressions, independent review, and protected checks"
    ]
  },
  "negative_test_evidence": [
    {
      "category": "negative",
      "evidence": "Generic Fable and Opus model routes plus no-write transition attacks reject across schemas and seats"
    },
    {
      "category": "malformed",
      "evidence": "Malformed modelUsage values, ambiguous versions, fake flag substrings, and oversized numeric inputs fail closed"
    },
    {
      "category": "regression",
      "evidence": "Exact Opus Planner create and revise operations, Windows launchers, graceful and forced App Server shutdown, Fable compatibility, and schemas one through five pass"
    }
  ],
  "findings_disposition": "All material findings were repaired with RED-GREEN regressions and the final exact diff was independently rechecked"
}
<!-- codex-review-attestation:end -->
