### PR TITLE
Fix explicit Codex skill invocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-## 0.9.1 — Unreleased
+## 0.9.2 — Unreleased
+
+- Correct explicit invocation examples to use the namespaced
+  `$codex-orchestration:codex-orchestration` skill label, while preserving
+  natural-language implicit invocation and documenting `/skills` only as Codex's
+  built-in skill discovery.
+
+## 0.9.1 — 2026-07-25
 
 - Accept first-party Claude Team subscriptions alongside Pro and Max while
   preserving exact first-party authentication checks and account-data redaction.
@@ -69,8 +76,9 @@
 
 ## 0.7.0 — 2026-07-18
 
-- Add `/codex-orchestration --update`, a canonical-source-checked orchestration of
-  Codex's native plugin upgrade/install commands. It refuses disabled, local,
+- Add the `$codex-orchestration:codex-orchestration --update` skill prompt, a
+  canonical-source-checked orchestration of Codex's native plugin upgrade/install
+  commands. It refuses disabled, local,
   missing, duplicate, or unexpected sources and verifies final source, version, and
   enabled state without removing the plugin or touching routing, credentials, chats,
   or sessions.

--- a/README.md
+++ b/README.md
@@ -72,28 +72,33 @@ Start a new Codex task after installation. Setup requires Python 3.11 or newer.
 
 ## Quick start
 
+Start an ordinary Codex prompt with the literal skill label
+`$codex-orchestration:codex-orchestration`. These examples are prompts for Codex,
+not terminal commands. You can also browse installed skills with Codex's built-in
+`/skills` discovery.
+
 Use Fable 5 to plan, Sol to advise, and Luna to implement:
 
 ```text
-/codex-orchestration setup planner: Claude Fable 5 High, advisor: GPT-5.6 Sol High, executor: GPT-5.6 Luna Extra High
+$codex-orchestration:codex-orchestration setup planner: Claude Fable 5 High, advisor: GPT-5.6 Sol High, executor: GPT-5.6 Luna Extra High
 ```
 
 Add a dedicated Designer when the work needs a design handoff:
 
 ```text
-/codex-orchestration setup planner: Claude Fable 5 High, advisor: GPT-5.6 Sol High, designer: GPT-5.6 Terra High, executor: GPT-5.6 Luna Extra High
+$codex-orchestration:codex-orchestration setup planner: Claude Fable 5 High, advisor: GPT-5.6 Sol High, designer: GPT-5.6 Terra High, executor: GPT-5.6 Luna Extra High
 ```
 
 Or let your current Codex model plan and use Fable 5 only as Advisor:
 
 ```text
-/codex-orchestration setup advisor: Claude Fable 5 High, executor: GPT-5.6 Luna Extra High
+$codex-orchestration:codex-orchestration setup advisor: Claude Fable 5 High, executor: GPT-5.6 Luna Extra High
 ```
 
 Or use Claude Opus 5 as the Advisor:
 
 ```text
-/codex-orchestration setup advisor: Claude Opus 5 XHigh, executor: GPT-5.6 Luna Extra High
+$codex-orchestration:codex-orchestration setup advisor: Claude Opus 5 XHigh, executor: GPT-5.6 Luna Extra High
 ```
 
 After setup, start another new task and use Codex normally. The saved workflow applies automatically.
@@ -109,7 +114,7 @@ Fable 5 and Opus 5 use the official Claude Code CLI and a compatible first-party
 ## Choose your roles
 
 ```text
-/codex-orchestration setup planner: <model and effort>, advisor: <model and effort>, designer: <model and effort>, executor: <model and effort>
+$codex-orchestration:codex-orchestration setup planner: <model and effort>, advisor: <model and effort>, designer: <model and effort>, executor: <model and effort>
 ```
 
 - Omit `planner` to use the current Codex model as Planner.
@@ -147,13 +152,13 @@ status inspection only; it never authorizes configuration, credentials, or spend
 Examples:
 
 ```text
-/codex-orchestration setup planner: Claude Fable 5 High, advisor: GPT-5.6 Sol High, executor: GPT-5.6 Luna Extra High
+$codex-orchestration:codex-orchestration setup planner: Claude Fable 5 High, advisor: GPT-5.6 Sol High, executor: GPT-5.6 Luna Extra High
 
-/codex-orchestration setup planner: GPT-5.6 Sol Extra High, advisor: Claude Fable 5 High, executor: GPT-5.6 Luna Extra High
+$codex-orchestration:codex-orchestration setup planner: GPT-5.6 Sol Extra High, advisor: Claude Fable 5 High, executor: GPT-5.6 Luna Extra High
 
-/codex-orchestration setup designer: GPT-5.6 Terra High, executor: GPT-5.6 Luna Extra High
+$codex-orchestration:codex-orchestration setup designer: GPT-5.6 Terra High, executor: GPT-5.6 Luna Extra High
 
-/codex-orchestration setup executor: GPT-5.6 Luna Extra High
+$codex-orchestration:codex-orchestration setup executor: GPT-5.6 Luna Extra High
 ```
 
 ## Bring another model into Codex
@@ -167,11 +172,11 @@ authentication.
 Ask for a role in plain language:
 
 ```text
-/codex-orchestration configure external role researcher with OpenRouter model moonshotai/kimi-k3 at max; job: gather evidence and cite sources
+$codex-orchestration:codex-orchestration configure external role researcher with OpenRouter model moonshotai/kimi-k3 at max; job: gather evidence and cite sources
 
-/codex-orchestration configure external role designer with OpenRouter model moonshotai/kimi-k3 at max; job: produce a bounded UX specification
+$codex-orchestration:codex-orchestration configure external role designer with OpenRouter model moonshotai/kimi-k3 at max; job: produce a bounded UX specification
 
-/codex-orchestration call researcher at max — review this bounded research packet
+$codex-orchestration:codex-orchestration call researcher at max — review this bounded research packet
 ```
 
 Setup is deliberately staged: preview and prepare the audited provider adapter,
@@ -210,7 +215,7 @@ families.
 Models already available through Codex can still become ordinary user-owned roles:
 
 ```text
-/codex-orchestration create project role: researcher
+$codex-orchestration:codex-orchestration create project role: researcher
 ```
 
 Project roles live in `.codex/agents/`; personal roles live in
@@ -220,17 +225,20 @@ Project roles live in `.codex/agents/`; personal roles live in
 
 Create a Codex Goal normally, then tell Codex to use the saved workflow until the Goal is complete. Codex still owns Goal state, permissions, integration, and verification; the plugin only guides which models perform each role.
 
-## Useful commands
+## Useful prompts
+
+Enter these in Codex chat. They invoke the installed skill; they are not shell
+commands or registered slash commands.
 
 ```text
-/codex-orchestration status
-/codex-orchestration status --require-effective
-/codex-orchestration repair
-/codex-orchestration --update
-/codex-orchestration setup planner: Claude Fable 5 High, advisor: GPT-5.6 Sol High, designer: GPT-5.6 Terra High, executor: GPT-5.6 Luna Extra High
-/codex-orchestration setup advisor: Claude Opus 5 XHigh, executor: GPT-5.6 Luna Extra High
-/codex-orchestration Planner: Claude Fable 5 High, Designer: Kimi K3
-/codex-orchestration disable
+$codex-orchestration:codex-orchestration status
+$codex-orchestration:codex-orchestration status --require-effective
+$codex-orchestration:codex-orchestration repair
+$codex-orchestration:codex-orchestration --update
+$codex-orchestration:codex-orchestration setup planner: Claude Fable 5 High, advisor: GPT-5.6 Sol High, designer: GPT-5.6 Terra High, executor: GPT-5.6 Luna Extra High
+$codex-orchestration:codex-orchestration setup advisor: Claude Opus 5 XHigh, executor: GPT-5.6 Luna Extra High
+$codex-orchestration:codex-orchestration Planner: Claude Fable 5 High, Designer: Kimi K3
+$codex-orchestration:codex-orchestration disable
 ```
 
 `Designer: Kimi K3` selects the audited task-local External Model role without
@@ -248,8 +256,9 @@ unavailable. The seat label never authorizes credential entry or a paid probe.
 An Opus seat can be updated in place on the same Planner or Advisor seat,
 including its effort. Replacing Opus with Fable, replacing Fable with Opus,
 moving Opus between Planner and Advisor, or removing Opus through another setup
-requires `/codex-orchestration disable` first, followed by one fresh complete
-setup. This prevents silent subscription route replacement.
+requires the prompt `$codex-orchestration:codex-orchestration disable` first,
+followed by one fresh complete setup. This prevents silent subscription route
+replacement.
 
 `repair` is narrower than setup or disable. When status reports that plugin-managed
 mode/usage hints conflict with otherwise intact saved state, it can restore only
@@ -279,10 +288,10 @@ Technical details are in [providers and models](plugins/codex-orchestration/skil
 For version 0.7.0 and newer, ask the installed plugin to update itself:
 
 ```text
-/codex-orchestration --update
+$codex-orchestration:codex-orchestration --update
 ```
 
-The command refuses disabled, local, missing, duplicate, or unexpected sources,
+The skill refuses disabled, local, missing, duplicate, or unexpected sources,
 then delegates refresh and installation only to Codex's native plugin manager and
 verifies the final canonical source, version, and enabled state. It does not remove
 the plugin or touch routing, credentials, chats, sessions, or the model picker.
@@ -310,16 +319,16 @@ Model roles; version **0.9.0 or newer** adds Claude Opus 5 subscription routing.
 Confirm with
 `codex plugin list --json`, then restart Codex Desktop and start a new task.
 
-If the version stays old or `marketplaceSource.sourceType` is `local`, Codex is pointed at a local checkout rather than the GitHub marketplace. Run `/codex-orchestration disable` first if a saved policy is active, then remove the plugin and that marketplace registration, add `Cjbuilds/Codex-Orchestration` again, and reinstall. This does not delete the local source checkout.
+If the version stays old or `marketplaceSource.sourceType` is `local`, Codex is pointed at a local checkout rather than the GitHub marketplace. Enter the prompt `$codex-orchestration:codex-orchestration disable` first if a saved policy is active, then remove the plugin and that marketplace registration, add `Cjbuilds/Codex-Orchestration` again, and reinstall. This does not delete the local source checkout.
 
-Before downgrading to a version older than the currently saved routing schema, run `/codex-orchestration disable` with the current version first.
+Before downgrading to a version older than the currently saved routing schema, enter the prompt `$codex-orchestration:codex-orchestration disable` with the current version first.
 
 ## Uninstall
 
-First run:
+First enter this prompt in Codex:
 
 ```text
-/codex-orchestration disable
+$codex-orchestration:codex-orchestration disable
 ```
 
 Then remove the plugin:

--- a/plugins/codex-orchestration/.codex-plugin/plugin.json
+++ b/plugins/codex-orchestration/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-orchestration",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Give Codex and audited external models safe, provider-pinned roles.",
   "author": {
     "name": "CJ Zafir",
@@ -36,9 +36,9 @@
       "Efficient execution"
     ],
     "defaultPrompt": [
-      "/codex-orchestration setup designer: GPT-5.6 Sol High, executor: GPT-5.6 Luna Extra High",
-      "/codex-orchestration --update",
-      "/codex-orchestration Planner: Claude Fable 5 High, Designer: Kimi K3"
+      "$codex-orchestration:codex-orchestration setup designer: GPT-5.6 Sol High, executor: GPT-5.6 Luna Extra High",
+      "$codex-orchestration:codex-orchestration --update",
+      "$codex-orchestration:codex-orchestration Planner: Claude Fable 5 High, Designer: Kimi K3"
     ]
   }
 }

--- a/plugins/codex-orchestration/skills/codex-orchestration/SKILL.md
+++ b/plugins/codex-orchestration/skills/codex-orchestration/SKILL.md
@@ -9,27 +9,31 @@ The model selected when this Codex task started is already the orchestrator. Nev
 
 This skill adds a model route to Codex's existing multi-agent flow. It does not create another scheduler.
 
-## Understand the command
+## Understand invocation
 
-Support these simple forms:
+For explicit invocation, require the literal skill label
+`$codex-orchestration:codex-orchestration` at the start of an ordinary Codex
+prompt. These are prompts handled by this skill, not shell commands or registered
+slash commands. Codex's built-in `/skills` discovery may be used to browse and
+select the installed skill. Support these simple forms:
 
 ```text
-/codex-orchestration setup executor: GPT-5.6 Luna Extra High
-/codex-orchestration setup executor: GPT-5.6 Luna Extra High, advisor: Claude Fable 5 High
-/codex-orchestration setup planner: Claude Fable 5 High, advisor: GPT-5.6 Sol High, executor: GPT-5.6 Luna Extra High
-/codex-orchestration setup advisor: Claude Opus 5 XHigh, executor: GPT-5.6 Luna Extra High
-/codex-orchestration setup designer: GPT-5.6 Sol High, executor: GPT-5.6 Luna Extra High
-/codex-orchestration Planner: Claude Fable 5 High, Designer: Kimi K3
-/codex-orchestration --update
-/codex-orchestration create project role: researcher
-/codex-orchestration create personal roles: researcher, writer, reviewer
-/codex-orchestration configure external role researcher with OpenRouter model moonshotai/kimi-k3 at max
-/codex-orchestration call researcher at max — <one bounded task>
-/codex-orchestration status
-/codex-orchestration repair
-/codex-orchestration disable
-/codex-orchestration remove custom roles personally
-/codex-orchestration executor: GPT-5.6 Terra high — <one task only>
+$codex-orchestration:codex-orchestration setup executor: GPT-5.6 Luna Extra High
+$codex-orchestration:codex-orchestration setup executor: GPT-5.6 Luna Extra High, advisor: Claude Fable 5 High
+$codex-orchestration:codex-orchestration setup planner: Claude Fable 5 High, advisor: GPT-5.6 Sol High, executor: GPT-5.6 Luna Extra High
+$codex-orchestration:codex-orchestration setup advisor: Claude Opus 5 XHigh, executor: GPT-5.6 Luna Extra High
+$codex-orchestration:codex-orchestration setup designer: GPT-5.6 Sol High, executor: GPT-5.6 Luna Extra High
+$codex-orchestration:codex-orchestration Planner: Claude Fable 5 High, Designer: Kimi K3
+$codex-orchestration:codex-orchestration --update
+$codex-orchestration:codex-orchestration create project role: researcher
+$codex-orchestration:codex-orchestration create personal roles: researcher, writer, reviewer
+$codex-orchestration:codex-orchestration configure external role researcher with OpenRouter model moonshotai/kimi-k3 at max
+$codex-orchestration:codex-orchestration call researcher at max — <one bounded task>
+$codex-orchestration:codex-orchestration status
+$codex-orchestration:codex-orchestration repair
+$codex-orchestration:codex-orchestration disable
+$codex-orchestration:codex-orchestration remove custom roles personally
+$codex-orchestration:codex-orchestration executor: GPT-5.6 Terra high — <one task only>
 is Kimi available to use as Designer?
 can I use Kimi K3 for design?
 ```
@@ -141,10 +145,11 @@ Read [providers-and-models.md](references/providers-and-models.md) before setup,
 
 ## Update the plugin
 
-Treat `/codex-orchestration --update` as an explicit request to update only this
-plugin. It cannot be combined with setup, status, disable, seat settings, custom
-role operations, or task work. Resolve the absolute Codex binary used by the active
-host. First run `codex plugin list --json` and require exactly one enabled
+Treat the explicit prompt `$codex-orchestration:codex-orchestration --update` as a
+request to update only this plugin. It cannot be combined with setup, status,
+disable, seat settings, custom role operations, or task work. Resolve the absolute
+Codex binary used by the active host. First run `codex plugin list --json` and
+require exactly one enabled
 `codex-orchestration@codex-orchestration` entry whose marketplace source type is
 `git` and source is the canonical HTTPS GitHub repository. Refuse local, disabled,
 missing, duplicate, or unexpected sources without mutation. Then run only:

--- a/plugins/codex-orchestration/skills/codex-orchestration/agents/openai.yaml
+++ b/plugins/codex-orchestration/skills/codex-orchestration/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "Codex Orchestration"
   short_description: "Plan, review, design, and build with multiple models"
-  default_prompt: "Use $codex-orchestration to configure Planner, Advisor, Designer, Executor, and audited External Model roles."
+  default_prompt: "Use $codex-orchestration:codex-orchestration to configure model roles."
 
 policy:
   allow_implicit_invocation: true

--- a/plugins/codex-orchestration/skills/codex-orchestration/scripts/configure_native_routing.py
+++ b/plugins/codex-orchestration/skills/codex-orchestration/scripts/configure_native_routing.py
@@ -456,7 +456,7 @@ class AppServer:
                     "clientInfo": {
                         "name": "codex_orchestration_installer",
                         "title": "Codex Orchestration Installer",
-                        "version": "0.9.1",
+                        "version": "0.9.2",
                     },
                     "capabilities": {"experimentalApi": True},
                 },

--- a/tests/plugin_lifecycle_smoke.py
+++ b/tests/plugin_lifecycle_smoke.py
@@ -32,7 +32,7 @@ PLUGIN_ID = "codex-orchestration@codex-orchestration"
 MARKETPLACE_NAME = "codex-orchestration"
 OLD_RELEASE = "a1d9c546665c3253cdcaa8fe5c0c060199a6126c"
 OLD_VERSION = "0.5.0"
-NEW_VERSION = "0.9.1"
+NEW_VERSION = "0.9.2"
 COMMAND_TIMEOUT_SECONDS = 60
 
 
@@ -533,8 +533,8 @@ def main() -> int:
                 "Designer may edit only explicitly delegated design artifacts",
                 "is Kimi available to use as Designer?",
                 "Implicit invocation is discovery, not mutation authority",
-                "/codex-orchestration repair",
-                "/codex-orchestration --update",
+                "$codex-orchestration:codex-orchestration repair",
+                "$codex-orchestration:codex-orchestration --update",
             ):
                 if expected not in installed_skill:
                     raise SmokeFailure(

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -255,7 +255,7 @@ class PackagingTests(unittest.TestCase):
 
         self.assertEqual(manifest["name"], "codex-orchestration")
         self.assertEqual(manifest["skills"], "./skills/")
-        self.assertEqual(manifest["version"], "0.9.1")
+        self.assertEqual(manifest["version"], "0.9.2")
         self.assertEqual(manifest["mcpServers"], "./.mcp.json")
         self.assertRegex(
             manifest["version"],
@@ -278,7 +278,7 @@ class PackagingTests(unittest.TestCase):
         self.assertFalse((SKILL_ROOT / "scripts" / "update_plugin.py").exists())
         self.assertIn("config/batchWrite", native.read_text(encoding="utf-8"))
         self.assertIn('"--repair"', native.read_text(encoding="utf-8"))
-        self.assertIn('"version": "0.9.1"', native.read_text(encoding="utf-8"))
+        self.assertIn('"version": "0.9.2"', native.read_text(encoding="utf-8"))
         self.assertIn("validate_routing_state", routing_state.read_text(encoding="utf-8"))
         self.assertIn("Standalone custom agent", custom.read_text(encoding="utf-8"))
 
@@ -339,8 +339,44 @@ class PackagingTests(unittest.TestCase):
         metadata = (SKILL_ROOT / "agents" / "openai.yaml").read_text(encoding="utf-8")
         readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
         skill = (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
+        manifest = json.loads(
+            (PLUGIN_ROOT / ".codex-plugin" / "plugin.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        prompts = "\n".join(manifest["interface"]["defaultPrompt"])
+        invocation = "$codex-orchestration:codex-orchestration"
+        raw_slash = "/codex-orchestration"
+        allowed_readme_fragments = (
+            "[External Models reference](plugins/codex-orchestration/skills/"
+            "codex-orchestration/references/external-models.md)",
+            "[providers and models](plugins/codex-orchestration/skills/"
+            "codex-orchestration/references/providers-and-models.md)",
+        )
 
-        self.assertIn("$codex-orchestration", metadata)
+        def assert_only_reviewed_raw_slashes(
+            surface: str, allowed: tuple[str, ...] = ()
+        ) -> None:
+            scrubbed = surface
+            for fragment in allowed:
+                self.assertEqual(scrubbed.count(fragment), 1, fragment)
+                scrubbed = scrubbed.replace(fragment, "", 1)
+            self.assertNotIn(raw_slash, scrubbed)
+
+        surfaces = (
+            ("README", readme, allowed_readme_fragments),
+            ("SKILL", skill, ()),
+            ("manifest defaultPrompt", prompts, ()),
+            ("OpenAI metadata", metadata, ()),
+        )
+        for name, surface, allowed in surfaces:
+            self.assertIn(invocation, surface, name)
+            assert_only_reviewed_raw_slashes(surface, allowed)
+            mutant = surface.replace(invocation, raw_slash, 1)
+            self.assertNotEqual(mutant, surface, name)
+            with self.subTest(mutated_surface=name), self.assertRaises(AssertionError):
+                assert_only_reviewed_raw_slashes(mutant, allowed)
+
         self.assertIn("allow_implicit_invocation: true", metadata)
         self.assertNotIn("allow_implicit_invocation: false", metadata)
         self.assertIn(
@@ -349,14 +385,40 @@ class PackagingTests(unittest.TestCase):
         )
         self.assertIn("available or callable as Designer", skill)
         self.assertIn("is Kimi available to use as Designer?", readme)
-        self.assertIn("/codex-orchestration setup executor:", readme)
+        self.assertIn(f"{invocation} setup executor:", readme)
         self.assertIn("GPT-5.6 Luna Extra High", readme)
-        self.assertIn("/codex-orchestration create project role:", readme)
-        self.assertIn("/codex-orchestration status", readme)
-        self.assertIn("/codex-orchestration disable", readme)
-        self.assertIn("/codex-orchestration --update", readme)
+        self.assertIn(f"{invocation} create project role:", readme)
+        self.assertIn(f"{invocation} status", readme)
+        self.assertIn(f"{invocation} disable", readme)
+        self.assertIn(f"{invocation} --update", readme)
         self.assertIn("designer: GPT-5.6", readme)
-        self.assertIn("codex plugin add codex-orchestration@codex-orchestration", readme)
+        self.assertIn(
+            "codex plugin add codex-orchestration@codex-orchestration", readme
+        )
+
+        unreviewed_raw_cases = (
+            "/codex-orchestration status",
+            "try /codex-orchestration repair",
+            "Prompt:/codex-orchestration status",
+            "**/codex-orchestration**",
+            "[/codex-orchestration]",
+            "“/codex-orchestration”",
+            "Prompt ](/codex-orchestration status)",
+            r"Prompt \](/codex-orchestration status)",
+            "`[docs](/codex-orchestration)`",
+            "[docs](/codex-orchestration status)",
+            '[docs](/safe "try /codex-orchestration status")',
+            "https://example.com/?next=/codex-orchestration",
+            "/codex-orchestration@marketplace",
+        )
+        for unreviewed in unreviewed_raw_cases:
+            with self.subTest(unreviewed_raw=unreviewed), self.assertRaises(
+                AssertionError
+            ):
+                assert_only_reviewed_raw_slashes(
+                    f"{readme}\n{unreviewed}",
+                    allowed_readme_fragments,
+                )
 
     def test_starter_prompts_fit_codex_limits(self) -> None:
         manifest = json.loads(
@@ -374,7 +436,9 @@ class PackagingTests(unittest.TestCase):
             line for line in metadata.splitlines() if "default_prompt:" in line
         )
         yaml_prompt = prompt_line.split(":", 1)[1].strip().strip('"')
-        self.assertTrue(yaml_prompt.startswith("Use $codex-orchestration"))
+        self.assertTrue(
+            yaml_prompt.startswith("Use $codex-orchestration:codex-orchestration")
+        )
         self.assertLessEqual(len(yaml_prompt), 128)
 
     def test_ci_runs_dual_version_plugin_lifecycle(self) -> None:
@@ -389,7 +453,7 @@ class PackagingTests(unittest.TestCase):
         self.assertIn("@openai/codex@0.144.1", workflow)
         smoke_text = smoke.read_text(encoding="utf-8")
         self.assertIn('OLD_VERSION = "0.5.0"', smoke_text)
-        self.assertIn('NEW_VERSION = "0.9.1"', smoke_text)
+        self.assertIn('NEW_VERSION = "0.9.2"', smoke_text)
         self.assertIn("old Advisor-only cache unexpectedly supports Planner", smoke_text)
         self.assertIn("Upgraded installed skill is missing Planner contract", smoke_text)
         self.assertIn("reused the Advisor-only 0.5.0 cache directory", smoke_text)
@@ -492,7 +556,7 @@ class PackagingTests(unittest.TestCase):
     def test_update_and_uninstall_remove_managed_state_explicitly(self) -> None:
         readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
 
-        self.assertIn("/codex-orchestration status", readme)
+        self.assertIn("$codex-orchestration:codex-orchestration status", readme)
         self.assertIn("Version **0.6.0 or newer**", readme)
         self.assertIn("`marketplaceSource.sourceType` is `local`", readme)
         self.assertIn("`disable` restores the routing values", readme)

--- a/tests/test_release_check.py
+++ b/tests/test_release_check.py
@@ -69,7 +69,7 @@ class TempRepository:
 
 class ReleaseCheckTests(unittest.TestCase):
     def test_checkout_release_metadata_is_consistent(self) -> None:
-        self.assertEqual(RELEASE.run_check(REPO_ROOT, require_tag=False), "0.9.1")
+        self.assertEqual(RELEASE.run_check(REPO_ROOT, require_tag=False), "0.9.2")
 
     def test_unreleased_checkout_is_not_tag_ready(self) -> None:
         with self.assertRaisesRegex(RELEASE.ReleaseCheckError, "not tagged"):

--- a/tests/test_skill_contract.py
+++ b/tests/test_skill_contract.py
@@ -40,10 +40,11 @@ class SkillContractTests(unittest.TestCase):
     def test_public_controls_are_simple_and_setup_is_persistent(self) -> None:
         self.assertIn("setup executor: GPT-5.6 Luna Extra High", SKILL)
         self.assertIn("setup planner: Claude Fable 5 High", SKILL)
-        self.assertIn("/codex-orchestration status", SKILL)
-        self.assertIn("/codex-orchestration repair", SKILL)
-        self.assertIn("/codex-orchestration disable", SKILL)
-        self.assertIn("/codex-orchestration --update", SKILL)
+        invocation = "$codex-orchestration:codex-orchestration"
+        self.assertIn(f"{invocation} status", SKILL)
+        self.assertIn(f"{invocation} repair", SKILL)
+        self.assertIn(f"{invocation} disable", SKILL)
+        self.assertIn(f"{invocation} --update", SKILL)
         self.assertIn("current-task override", SKILL)
         self.assertIn("no longer needs to invoke this skill", SKILL)
 


### PR DESCRIPTION
## Change summary

Fixes #9.

Codex Orchestration now documents the real explicit skill invocation,
`$codex-orchestration:codex-orchestration`, instead of presenting
`/codex-orchestration` as a registered slash command. README, packaged skill
guidance, starter prompts, OpenAI skill metadata, lifecycle assertions, and
release fixtures are aligned. Natural-language implicit invocation remains
enabled, and `/skills` is documented only as Codex's built-in discovery
surface.

The packaged payload advances from 0.9.1 to 0.9.2 across the manifest,
changelog, AppServer client identity, lifecycle fixture, packaging assertions,
and release check.

## Validation

Exact reviewed head: `8ae6a02f171f831826f7cde508cf50ac14669297`

- `python3 scripts/preflight.py full --base-sha 61b84db2b8e4c5d4a5f102b094a91d2ab159c5a7`
  — local git, compile, Ruff, focused tests, release identity, full tests, and
  real plugin lifecycle passed; hosted-only checks were intentionally skipped
  locally.
- `python3 scripts/preflight.py portability --ci` — every local portability
  module passed.
- `python3 scripts/release_check.py --repo-root . --base-sha 61b84db2b8e4c5d4a5f102b094a91d2ab159c5a7 --head-sha 8ae6a02f171f831826f7cde508cf50ac14669297 --require-exact-shas`
  — release metadata and identity valid for 0.9.2.
- Independent verifier reviewed the final tree and passed criteria A–G. Four
  actual surface replacements and thirteen malformed variants are rejected by
  the fail-closed regression.
- Hosted Python 3.11/3.13, macOS/Windows portability, and CodeQL remain
  authoritative and must pass on this exact SHA before merge.

## Review attestation

<!-- codex-review-attestation:start -->
{
  "schema": 1,
  "risk_tier": "security-state",
  "repository": "Cjbuilds/Codex-Orchestration",
  "base_branch": "main",
  "reviewed_head_sha": "8ae6a02f171f831826f7cde508cf50ac14669297",
  "reviewer_identity": "Codex independent verification worker Pauli",
  "reviewer_route": "verification_worker using gpt-5.6-sol at high reasoning",
  "threat_model": {
    "assets": [
      "Correct Codex skill invocation and user trust in command semantics",
      "Plugin cache and release identity for the distributed 0.9.2 payload"
    ],
    "threats": [
      "Misleading slash-command examples could direct users to a command Codex never registered",
      "Overbroad exceptions could hide a reintroduced legacy slash prompt in packaged surfaces",
      "Reusing a published payload version could leave stale instructions in the Codex plugin cache"
    ],
    "mitigations": [
      "Exact namespaced invocation is required across README, SKILL, manifest prompts, and OpenAI metadata",
      "A fail-closed allowlist permits only two exact reviewed repository links and rejects every other raw slash occurrence",
      "Release identity is synchronized at 0.9.2 and exact-base and exact-head release validation passed"
    ]
  },
  "negative_test_evidence": [
    {
      "category": "regression",
      "evidence": "The focused contract passes on the final head and fails when README, SKILL, a manifest prompt, or OpenAI metadata is replaced with the legacy slash form."
    },
    {
      "category": "negative",
      "evidence": "No command or prompt registration was added; only two exact reviewed repository-link fragments are allowed and every other raw slash occurrence fails closed."
    },
    {
      "category": "malformed",
      "evidence": "Thirteen malformed forms covering prose, colon labels, Markdown, escaped closers, code spans, invalid links, link titles, URL queries, and marketplace suffixes are rejected."
    }
  ],
  "findings_disposition": "Independent verification found boundary and Markdown-suppression gaps during development; all were repaired, the generalized parser was removed, and final re-verification passed A through G with no unresolved findings on exact head 8ae6a02f171f831826f7cde508cf50ac14669297."
}
<!-- codex-review-attestation:end -->
