### PR TITLE
Fix Claude 2.1.220 modelUsage identity metadata validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.9.4 — Unreleased
+
+- Accept Claude Code 2.1.220's first-party `canonicalModel` and `provider`
+  fields in runtime `modelUsage` while allowing only reviewed primary
+  alias/canonical pairs or an exact helper identity, requiring
+  `provider=firstParty`, retaining at least one numeric usage field, and
+  rejecting every other string-valued field.
+
 ## 0.9.3 — Unreleased
 
 - Raise the bounded Advisor approval loop from five to eight reviews while

--- a/plugins/codex-orchestration/.codex-plugin/plugin.json
+++ b/plugins/codex-orchestration/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-orchestration",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Give Codex and audited external models safe, provider-pinned roles.",
   "author": {
     "name": "CJ Zafir",

--- a/plugins/codex-orchestration/skills/codex-orchestration/SKILL.md
+++ b/plugins/codex-orchestration/skills/codex-orchestration/SKILL.md
@@ -489,6 +489,10 @@ The configured Fable route remains `claude-fable-5`, while runtime `modelUsage`
 may confirm either reviewed Fable primary identity. This does not make
 `claude-opus-4-8` an Opus route alias. Opus still requires the exact
 `claude-opus-5` primary.
+Claude Code's optional first-party `canonicalModel` and `provider` usage metadata
+are accepted only when the canonical identity stays within the reviewed primary
+alias set or exactly matches its helper key, the provider is exactly `firstParty`,
+and the entry still contains numeric usage.
 
 Plugin and policy updates cannot replace the MCP process already loaded into the
 current task. If a bundled Claude call fails after an update or repair, run fresh

--- a/plugins/codex-orchestration/skills/codex-orchestration/scripts/configure_native_routing.py
+++ b/plugins/codex-orchestration/skills/codex-orchestration/scripts/configure_native_routing.py
@@ -457,7 +457,7 @@ class AppServer:
                     "clientInfo": {
                         "name": "codex_orchestration_installer",
                         "title": "Codex Orchestration Installer",
-                        "version": "0.9.3",
+                        "version": "0.9.4",
                     },
                     "capabilities": {"experimentalApi": True},
                 },

--- a/plugins/codex-orchestration/skills/codex-orchestration/scripts/fable_advisor_mcp.py
+++ b/plugins/codex-orchestration/skills/codex-orchestration/scripts/fable_advisor_mcp.py
@@ -373,25 +373,38 @@ def _validate_runtime_models(
             f"Runtime metadata reported a model outside the allowed {policy_label} "
             "runtime policy."
         )
-    for model_usage in usage.values():
+    for model, model_usage in usage.items():
         if not isinstance(model_usage, dict) or not model_usage:
             raise AdvisorError("Runtime metadata has a malformed modelUsage value.")
+        has_numeric_usage = False
         for field, value in model_usage.items():
-            is_nonnegative_finite_number = (
-                type(value) is int
-                and value >= 0
-                or type(value) is float
-                and math.isfinite(value)
-                and value >= 0
-            )
+            if field == "canonicalModel":
+                valid_value = isinstance(value, str) and (
+                    model in reviewed_primaries
+                    and value in reviewed_primaries
+                    or value == model
+                )
+            elif field == "provider":
+                valid_value = value == "firstParty"
+            else:
+                valid_value = (
+                    type(value) is int
+                    and value >= 0
+                    or type(value) is float
+                    and math.isfinite(value)
+                    and value >= 0
+                )
+                has_numeric_usage = has_numeric_usage or valid_value
             if (
                 not isinstance(field, str)
                 or not field.strip()
-                or not is_nonnegative_finite_number
+                or not valid_value
             ):
                 raise AdvisorError(
                     "Runtime metadata has a malformed modelUsage value."
                 )
+        if not has_numeric_usage:
+            raise AdvisorError("Runtime metadata has a malformed modelUsage value.")
     used_models = sorted(raw_models)
     if not set(used_models).intersection(reviewed_primaries):
         raise AdvisorError(

--- a/tests/plugin_lifecycle_smoke.py
+++ b/tests/plugin_lifecycle_smoke.py
@@ -32,7 +32,7 @@ PLUGIN_ID = "codex-orchestration@codex-orchestration"
 MARKETPLACE_NAME = "codex-orchestration"
 OLD_RELEASE = "a1d9c546665c3253cdcaa8fe5c0c060199a6126c"
 OLD_VERSION = "0.5.0"
-NEW_VERSION = "0.9.3"
+NEW_VERSION = "0.9.4"
 COMMAND_TIMEOUT_SECONDS = 60
 
 

--- a/tests/test_fable_advisor_mcp.py
+++ b/tests/test_fable_advisor_mcp.py
@@ -674,6 +674,90 @@ class FableAdvisorMcpTests(unittest.TestCase):
                 )
                 self.assertEqual(result["decision"], "PLAN_APPROVED")
 
+    def test_runtime_model_usage_accepts_claude_identity_metadata(self) -> None:
+        self.write_state(planner=self.route())
+        model_usage = {
+            FABLE.FABLE_MODEL: {
+                "inputTokens": 367,
+                "outputTokens": 1039,
+                "cacheReadInputTokens": 0,
+                "cacheCreationInputTokens": 0,
+                "webSearchRequests": 0,
+                "costUSD": 0.05562,
+                "contextWindow": 1_000_000,
+                "maxOutputTokens": 64_000,
+                "canonicalModel": FABLE.FABLE_MODEL,
+                "provider": "firstParty",
+            }
+        }
+        result, _ = self.invoke_with_results(
+            FABLE.create_plan,
+            "packet",
+            model_response="PLAN_DRAFT\nDraft",
+            model_usage=model_usage,
+        )
+        self.assertEqual(result["used_models"], [FABLE.FABLE_MODEL])
+
+    def test_runtime_model_usage_accepts_reviewed_canonical_aliases(self) -> None:
+        alias_pairs = (
+            (FABLE.FABLE_MODEL, FABLE.FABLE_RESOLVED_PRIMARY_MODEL),
+            (FABLE.FABLE_RESOLVED_PRIMARY_MODEL, FABLE.FABLE_MODEL),
+        )
+        for reported_model, canonical_model in alias_pairs:
+            with self.subTest(
+                reported_model=reported_model, canonical_model=canonical_model
+            ):
+                self.assertEqual(
+                    FABLE._validate_runtime_models(
+                        {
+                            reported_model: {
+                                "canonicalModel": canonical_model,
+                                "provider": "firstParty",
+                                "outputTokens": 1,
+                            }
+                        }
+                    ),
+                    [reported_model],
+                )
+
+    def test_runtime_model_usage_identity_metadata_requires_numeric_usage(self) -> None:
+        with self.assertRaisesRegex(FABLE.AdvisorError, "[Rr]untime metadata"):
+            FABLE._validate_runtime_models(
+                {
+                    FABLE.FABLE_MODEL: {
+                        "canonicalModel": FABLE.FABLE_MODEL,
+                        "provider": "firstParty",
+                    }
+                }
+            )
+
+    def test_runtime_model_usage_identity_metadata_fails_closed(self) -> None:
+        malformed_metadata = (
+            (
+                FABLE.FABLE_MODEL,
+                {"canonicalModel": FABLE.OPUS_MODEL, "outputTokens": 1},
+            ),
+            (
+                FABLE.FABLE_MODEL,
+                {"canonicalModel": FABLE.FABLE_HELPER_MODEL, "outputTokens": 1},
+            ),
+            (
+                FABLE.FABLE_HELPER_MODEL,
+                {"canonicalModel": FABLE.FABLE_MODEL, "outputTokens": 1},
+            ),
+            (FABLE.FABLE_MODEL, {"provider": "bedrock", "outputTokens": 1}),
+            (
+                FABLE.FABLE_MODEL,
+                {"unexpectedIdentity": "firstParty", "outputTokens": 1},
+            ),
+        )
+        for reported_model, metadata in malformed_metadata:
+            with self.subTest(reported_model=reported_model, metadata=metadata):
+                with self.assertRaisesRegex(
+                    FABLE.AdvisorError, "[Rr]untime metadata"
+                ):
+                    FABLE._validate_runtime_models({reported_model: metadata})
+
     def test_each_operation_pins_its_authorized_seat_effort(self) -> None:
         self.write_state(planner=self.route("low"))
         created, create_calls = self.invoke_with_results(
@@ -750,7 +834,13 @@ class FableAdvisorMcpTests(unittest.TestCase):
             FABLE.review_plan,
             "packet",
             model_response="PLAN_APPROVED\nNo material gap.",
-            model_usage={FABLE.OPUS_MODEL: {"outputTokens": 12}},
+            model_usage={
+                FABLE.OPUS_MODEL: {
+                    "canonicalModel": FABLE.OPUS_MODEL,
+                    "provider": "firstParty",
+                    "outputTokens": 12,
+                }
+            },
         )
         self.assertEqual(result["model"], FABLE.OPUS_MODEL)
         self.assertEqual(result["effort"], "xhigh")
@@ -782,6 +872,18 @@ class FableAdvisorMcpTests(unittest.TestCase):
                 "packet",
                 model_response="PLAN_APPROVED\nNo material gap.",
                 model_usage={FABLE.FABLE_HELPER_MODEL: {"outputTokens": 1}},
+            )
+        with self.assertRaisesRegex(FABLE.AdvisorError, "[Rr]untime metadata"):
+            self.invoke_with_results(
+                FABLE.review_plan,
+                "packet",
+                model_response="PLAN_APPROVED\nNo material gap.",
+                model_usage={
+                    FABLE.OPUS_MODEL: {
+                        "canonicalModel": FABLE.FABLE_MODEL,
+                        "outputTokens": 12,
+                    }
+                },
             )
 
     def test_opus_planner_create_and_revise_pin_exact_route_and_primary_usage(

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -255,7 +255,7 @@ class PackagingTests(unittest.TestCase):
 
         self.assertEqual(manifest["name"], "codex-orchestration")
         self.assertEqual(manifest["skills"], "./skills/")
-        self.assertEqual(manifest["version"], "0.9.3")
+        self.assertEqual(manifest["version"], "0.9.4")
         self.assertEqual(manifest["mcpServers"], "./.mcp.json")
         self.assertRegex(
             manifest["version"],
@@ -278,7 +278,7 @@ class PackagingTests(unittest.TestCase):
         self.assertFalse((SKILL_ROOT / "scripts" / "update_plugin.py").exists())
         self.assertIn("config/batchWrite", native.read_text(encoding="utf-8"))
         self.assertIn('"--repair"', native.read_text(encoding="utf-8"))
-        self.assertIn('"version": "0.9.3"', native.read_text(encoding="utf-8"))
+        self.assertIn('"version": "0.9.4"', native.read_text(encoding="utf-8"))
         self.assertIn("validate_routing_state", routing_state.read_text(encoding="utf-8"))
         self.assertIn("Standalone custom agent", custom.read_text(encoding="utf-8"))
 
@@ -453,7 +453,7 @@ class PackagingTests(unittest.TestCase):
         self.assertIn("@openai/codex@0.144.1", workflow)
         smoke_text = smoke.read_text(encoding="utf-8")
         self.assertIn('OLD_VERSION = "0.5.0"', smoke_text)
-        self.assertIn('NEW_VERSION = "0.9.3"', smoke_text)
+        self.assertIn('NEW_VERSION = "0.9.4"', smoke_text)
         self.assertIn("old Advisor-only cache unexpectedly supports Planner", smoke_text)
         self.assertIn("Upgraded installed skill is missing Planner contract", smoke_text)
         self.assertIn("reused the Advisor-only 0.5.0 cache directory", smoke_text)

--- a/tests/test_release_check.py
+++ b/tests/test_release_check.py
@@ -69,7 +69,7 @@ class TempRepository:
 
 class ReleaseCheckTests(unittest.TestCase):
     def test_checkout_release_metadata_is_consistent(self) -> None:
-        self.assertEqual(RELEASE.run_check(REPO_ROOT, require_tag=False), "0.9.3")
+        self.assertEqual(RELEASE.run_check(REPO_ROOT, require_tag=False), "0.9.4")
 
     def test_unreleased_checkout_is_not_tag_ready(self) -> None:
         with self.assertRaisesRegex(RELEASE.ReleaseCheckError, "not tagged"):


### PR DESCRIPTION
## Change summary

Claude Code 2.1.220 adds optional string-valued `canonicalModel` and `provider`
fields to each `modelUsage` entry. The bridge treated every inner value as a
numeric usage counter, so otherwise valid Fable Planner and Advisor calls failed
with `Runtime metadata has a malformed modelUsage value.`

This change:

- accepts reviewed Fable primary alias/canonical pairs and exact helper/Opus
  canonical identities;
- requires `provider` to be exactly `firstParty`;
- preserves the outer model allowlist and reviewed-primary requirement;
- still requires at least one nonnegative finite numeric usage field;
- rejects unknown strings, primary/helper cross-mappings, non-first-party
  providers, malformed values, and unknown models;
- bumps the plugin identity to `0.9.4`.

## Validation

- TDD regression reproduced the original `malformed modelUsage value` failure
  before the implementation.
- `python3 scripts/preflight.py full`: all available local gates passed,
  including Ruff, focused tests, release identity, full tests, and lifecycle.
  Hosted Python 3.11/3.13, Windows portability, and CodeQL remain authoritative.
- Live patched-bridge smoke on Claude Code 2.1.220 returned `PLAN_DRAFT` for
  `claude-fable-5` at `xhigh` and confirmed `used_models=["claude-fable-5"]`.
- Fresh independent review approved exact head
  `8b4ccae38e13cb843c2bd7eb8c0916f628fda173`; the reviewer also ran the focused
  suite (66/66) and full local preflight.

## Review attestation

<!-- codex-review-attestation:start -->
{
  "schema": 1,
  "risk_tier": "security-state",
  "repository": "Cjbuilds/Codex-Orchestration",
  "base_branch": "main",
  "reviewed_head_sha": "8b4ccae38e13cb843c2bd7eb8c0916f628fda173",
  "reviewer_identity": "GPT-5.6 Sol high via Codex code reviewer",
  "reviewer_route": "agents.spawn_agent model=gpt-5.6-sol reasoning_effort=high fork_turns=none",
  "threat_model": {
    "assets": [
      "Authentic runtime model identity at the Fable and Opus bridge boundary",
      "Confidentiality of model-authored output rejected before authorization"
    ],
    "threats": [
      "New valid identity metadata could make every bundled Claude call unavailable",
      "Unreviewed canonical identities or providers could bypass runtime model authorization",
      "Identity-only entries could bypass the numeric usage-shape requirement"
    ],
    "mitigations": [
      "Constrain canonical identities to reviewed primary aliases or the exact helper and Opus identities",
      "Require provider=firstParty while preserving the outer allowlist and reviewed-primary check",
      "Require numeric usage and reject malformed or unknown metadata with content-free errors"
    ]
  },
  "negative_test_evidence": [
    {
      "category": "regression",
      "evidence": "A Claude Code 2.1.220-shaped modelUsage payload now passes the real bridge validation path."
    },
    {
      "category": "negative",
      "evidence": "Tests reject non-first-party providers, unknown string fields, and primary/helper or Opus identity mismatches."
    },
    {
      "category": "malformed",
      "evidence": "Tests reject identity-only entries and retain rejection of negative, non-finite, boolean, empty, and nonnumeric usage values."
    }
  ],
  "findings_disposition": "REVIEW_APPROVED on exact head 8b4ccae38e13cb843c2bd7eb8c0916f628fda173 after F-001 and F-002 were incorporated and re-tested."
}
<!-- codex-review-attestation:end -->
