### PR TITLE
fix: let Opus Advisor use the full bridge timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## 0.9.3 — Unreleased
+## 0.9.4 — Unreleased
+
+- Give every bundled Claude MCP launcher a 660-second Codex tool timeout so
+  Opus 5 XHigh reviews can use the bridge's full 600-second subprocess budget
+  and still return a schema-validated decision or fail-closed timeout result.
+
+## 0.9.3 — 2026-07-26
 
 - Raise the bounded Advisor approval loop from five to eight reviews while
   preserving immediate approval exit and fail-closed plan, ledger, and

--- a/plugins/codex-orchestration/.codex-plugin/plugin.json
+++ b/plugins/codex-orchestration/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-orchestration",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Give Codex and audited external models safe, provider-pinned roles.",
   "author": {
     "name": "CJ Zafir",

--- a/plugins/codex-orchestration/.mcp.json
+++ b/plugins/codex-orchestration/.mcp.json
@@ -6,6 +6,7 @@
         "skills/codex-orchestration/scripts/fable_advisor_mcp.py"
       ],
       "cwd": ".",
+      "tool_timeout_sec": 660,
       "enabled": false
     },
     "fable-advisor-python": {
@@ -14,6 +15,7 @@
         "skills/codex-orchestration/scripts/fable_advisor_mcp.py"
       ],
       "cwd": ".",
+      "tool_timeout_sec": 660,
       "enabled": false
     },
     "fable-advisor-py": {
@@ -23,6 +25,7 @@
         "skills/codex-orchestration/scripts/fable_advisor_mcp.py"
       ],
       "cwd": ".",
+      "tool_timeout_sec": 660,
       "enabled": false
     }
   }

--- a/plugins/codex-orchestration/skills/codex-orchestration/SKILL.md
+++ b/plugins/codex-orchestration/skills/codex-orchestration/SKILL.md
@@ -476,6 +476,12 @@ Prerequisites:
 
 The plugin packages three disabled MCP launcher variants for macOS, Linux, and Windows. Setup enables exactly one compatible variant through the plugin's namespaced config when either bundled Claude model is selected. At planning or review time the MCP server gives authentication and model subprocesses only a minimal platform environment. It preserves `HOME` plus canonical operating-system `USER` and `LOGNAME` on POSIX, or `USERPROFILE` on Windows, for first-party login discovery. It does not trust ambient POSIX identity values and does not inherit credential, config-redirection, provider/model/effort, endpoint/gateway, proxy/CA/mTLS, or telemetry override families. It invokes `claude --print --model <sealed-model-id>` with `--safe-mode`, no tools, no session persistence, prompt suggestions disabled, and JSON output. Advisor review additionally requires Claude Code's `--json-schema` capability. Each saved seat pins its model and effort; the root cannot replace them through tool arguments.
 
+Each bundled launcher gives Codex a 660-second MCP tool timeout, slightly longer
+than the bridge's 600-second Claude subprocess timeout. Keep the outer timeout
+strictly greater than the inner timeout so an XHigh call can return either its
+schema-validated result or the bridge's fail-closed timeout error instead of being
+cancelled first by Codex's shorter default.
+
 Fable effort is configurable per setup. The default is `high`; supported Claude Code values are `low`, `medium`, `high`, `xhigh`, and `max`. Accept `ultra` as an alias for `max`, save the effective Claude Code value, and disclose the alias mapping in setup output. Existing saved `max` routes remain valid.
 
 Opus effort is also configurable and defaults to `high`. Its sealed set is

--- a/plugins/codex-orchestration/skills/codex-orchestration/scripts/configure_native_routing.py
+++ b/plugins/codex-orchestration/skills/codex-orchestration/scripts/configure_native_routing.py
@@ -457,7 +457,7 @@ class AppServer:
                     "clientInfo": {
                         "name": "codex_orchestration_installer",
                         "title": "Codex Orchestration Installer",
-                        "version": "0.9.3",
+                        "version": "0.9.4",
                     },
                     "capabilities": {"experimentalApi": True},
                 },

--- a/tests/plugin_lifecycle_smoke.py
+++ b/tests/plugin_lifecycle_smoke.py
@@ -32,7 +32,7 @@ PLUGIN_ID = "codex-orchestration@codex-orchestration"
 MARKETPLACE_NAME = "codex-orchestration"
 OLD_RELEASE = "a1d9c546665c3253cdcaa8fe5c0c060199a6126c"
 OLD_VERSION = "0.5.0"
-NEW_VERSION = "0.9.3"
+NEW_VERSION = "0.9.4"
 COMMAND_TIMEOUT_SECONDS = 60
 
 

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -255,7 +255,7 @@ class PackagingTests(unittest.TestCase):
 
         self.assertEqual(manifest["name"], "codex-orchestration")
         self.assertEqual(manifest["skills"], "./skills/")
-        self.assertEqual(manifest["version"], "0.9.3")
+        self.assertEqual(manifest["version"], "0.9.4")
         self.assertEqual(manifest["mcpServers"], "./.mcp.json")
         self.assertRegex(
             manifest["version"],
@@ -278,7 +278,7 @@ class PackagingTests(unittest.TestCase):
         self.assertFalse((SKILL_ROOT / "scripts" / "update_plugin.py").exists())
         self.assertIn("config/batchWrite", native.read_text(encoding="utf-8"))
         self.assertIn('"--repair"', native.read_text(encoding="utf-8"))
-        self.assertIn('"version": "0.9.3"', native.read_text(encoding="utf-8"))
+        self.assertIn('"version": "0.9.4"', native.read_text(encoding="utf-8"))
         self.assertIn("validate_routing_state", routing_state.read_text(encoding="utf-8"))
         self.assertIn("Standalone custom agent", custom.read_text(encoding="utf-8"))
 
@@ -332,7 +332,24 @@ class PackagingTests(unittest.TestCase):
         for server in servers.values():
             self.assertFalse(server["enabled"])
             self.assertEqual(server["cwd"], ".")
+            self.assertEqual(server["tool_timeout_sec"], 660)
             self.assertIn("fable_advisor_mcp.py", server["args"][-1])
+        bridge = (
+            SKILL_ROOT / "scripts" / "fable_advisor_mcp.py"
+        ).read_text(encoding="utf-8")
+        timeout_match = re.search(
+            r"(?m)^CLAUDE_TIMEOUT_SECONDS\s*=\s*(\d+)$",
+            bridge,
+        )
+        self.assertIsNotNone(timeout_match)
+        assert timeout_match is not None
+        bridge_timeout = int(timeout_match.group(1))
+        self.assertTrue(
+            all(
+                server["tool_timeout_sec"] > bridge_timeout
+                for server in servers.values()
+            )
+        )
         self.assertTrue((SKILL_ROOT / "scripts" / "fable_advisor_mcp.py").is_file())
 
     def test_explicit_and_natural_language_invocation_metadata_is_consistent(self) -> None:
@@ -453,7 +470,7 @@ class PackagingTests(unittest.TestCase):
         self.assertIn("@openai/codex@0.144.1", workflow)
         smoke_text = smoke.read_text(encoding="utf-8")
         self.assertIn('OLD_VERSION = "0.5.0"', smoke_text)
-        self.assertIn('NEW_VERSION = "0.9.3"', smoke_text)
+        self.assertIn('NEW_VERSION = "0.9.4"', smoke_text)
         self.assertIn("old Advisor-only cache unexpectedly supports Planner", smoke_text)
         self.assertIn("Upgraded installed skill is missing Planner contract", smoke_text)
         self.assertIn("reused the Advisor-only 0.5.0 cache directory", smoke_text)

--- a/tests/test_release_check.py
+++ b/tests/test_release_check.py
@@ -69,7 +69,7 @@ class TempRepository:
 
 class ReleaseCheckTests(unittest.TestCase):
     def test_checkout_release_metadata_is_consistent(self) -> None:
-        self.assertEqual(RELEASE.run_check(REPO_ROOT, require_tag=False), "0.9.3")
+        self.assertEqual(RELEASE.run_check(REPO_ROOT, require_tag=False), "0.9.4")
 
     def test_unreleased_checkout_is_not_tag_ready(self) -> None:
         with self.assertRaisesRegex(RELEASE.ReleaseCheckError, "not tagged"):


### PR DESCRIPTION
## What changed

- set `tool_timeout_sec` to 660 seconds on all three bundled Claude MCP launchers
- keep the bridge subprocess timeout at 600 seconds
- bump the plugin payload version to 0.9.4
- document the outer-timeout requirement
- add packaging regression coverage that requires every launcher timeout to exceed the bridge timeout

## Why

Claude Opus 5 XHigh reviews can take longer than Codex's default 300-second MCP tool timeout. The bridge itself already allows 600 seconds, so Codex could cancel a healthy review before the bridge returned either its schema-validated result or its own fail-closed timeout error.

The new contract is `660s Codex tool timeout > 600s Claude subprocess timeout`. This preserves the selected XHigh effort and all existing authentication, model-identity, structured-output, and fail-closed validation.

## Impact

Long-running bundled Claude Planner or Advisor calls can now use the bridge's complete bounded runtime. Fast calls are unaffected. Calls that exceed 600 seconds still fail closed inside the bridge.

## Validation

- `python3 -m unittest -v tests.test_packaging tests.test_release_check` — 38 passed
- `python3 scripts/preflight.py quick` — available local gates passed
- `python3 scripts/preflight.py full` — full tests and disposable plugin install/upgrade lifecycle passed
- JSON manifests validated with `python3 -m json.tool`
- exact-head final-tree review — approved with no actionable findings
- hosted CI — Python 3.11/3.13, lifecycle, legacy-client guard, macOS/Windows portability, and CodeQL passed

Ruff was not installed locally. The hosted Ruff check passed.

## Review attestation

<!-- codex-review-attestation:start -->
{
  "schema": 1,
  "risk_tier": "security-state",
  "repository": "Cjbuilds/Codex-Orchestration",
  "base_branch": "main",
  "reviewed_head_sha": "33fa720392abf01d7ba455449b93f68194f0626f",
  "reviewer_identity": "Codex Executor final-tree reviewer at the exact head commit",
  "reviewer_route": "gpt-5.6-sol xhigh read-only Executor route",
  "threat_model": {
    "assets": [
      "Schema-validated Advisor decisions and selected model identity",
      "Prompt and provider-output confidentiality during timeout failure",
      "Bounded availability of the bundled Claude MCP launchers",
      "Consistent plugin release identity across packaged surfaces"
    ],
    "threats": [
      "Codex cancels a healthy review before the bridge returns",
      "A Claude subprocess hangs beyond the intended bounded runtime",
      "Malformed or unconfirmed model output is treated as approval",
      "Only one bundled Python launcher receives the timeout setting",
      "Payload changes ship without a consistent semantic version bump"
    ],
    "mitigations": [
      "Set every bundled launcher to a 660-second outer tool timeout",
      "Keep the Claude subprocess bounded at 600 seconds and authentication at 20 seconds",
      "Retain fail-closed schema and runtime-model validation with output withholding",
      "Keep all bundled launchers disabled until the user selects the route",
      "Assert timeout ordering and release identity through packaging and lifecycle tests"
    ]
  },
  "negative_test_evidence": [
    {
      "category": "regression",
      "evidence": "Exact-head packaging tests require all three launchers to use 660 seconds and exceed the bounded 600-second bridge timeout."
    },
    {
      "category": "negative",
      "evidence": "Exact-head timeout and unexpected-argument tests passed, confirming failures remain bounded, fail closed, and do not leak prompt or provider output."
    },
    {
      "category": "malformed",
      "evidence": "Exact-head tests passed for malformed JSON, unconfirmed model identity, malformed semantic versions, and invalid review output."
    }
  ],
  "findings_disposition": "No actionable findings; the exact final tree was approved after security, compatibility, packaging, timeout, and fail-closed review."
}
<!-- codex-review-attestation:end -->
